### PR TITLE
feat(rules): add since: range mode to git_commit_message (closes #26)

### DIFF
--- a/.github/workflows/issue-26-e2e.yml
+++ b/.github/workflows/issue-26-e2e.yml
@@ -148,11 +148,16 @@ jobs:
           echo "✓ Bad-ref hard-fails with the fetch-depth: 0 hint"
 
       - name: Verify env-var default fallback works
-        # No ALINT_BASE_SHA set; the rule's ${ALINT_BASE_SHA:-HEAD~3}
-        # default kicks in. The range HEAD~3..HEAD covers the
-        # feature commits + the merge (3 commits back). With
+        # No ALINT_BASE_SHA set; the rule's ${ALINT_BASE_SHA:-HEAD^1}
+        # default kicks in. HEAD^1 is the merge commit's first
+        # parent — always exists for non-root commits and stable
+        # across merge graphs (unlike HEAD~N which follows
+        # first-parent N times and can hit the root). HEAD^1..HEAD
+        # covers the feature commits + the merge; with
         # include_merges off, only the two feat:/fix: commits get
-        # validated and both pass.
+        # validated and both pass. Demonstrates that the same
+        # .alint.yml works locally (no env var, default kicks in)
+        # and in CI (env var set, override resolves to a base SHA).
         run: |
           set -euxo pipefail
           unset ALINT_BASE_SHA
@@ -162,11 +167,11 @@ jobs:
             - id: env-default
               kind: git_commit_message
               pattern: '^(feat|fix|chore|docs|refactor|test|build|ci|perf|style|revert)(\(.+\))?!?: '
-              since: ${ALINT_BASE_SHA:-HEAD~3}
+              since: ${ALINT_BASE_SHA:-HEAD^1}
               level: error
           YAML
           ./target/release/alint check /tmp/range-fixture
-          echo "✓ Env-var default fallback (\${VAR:-HEAD~3}) resolves cleanly"
+          echo "✓ Env-var default fallback (\${VAR:-HEAD^1}) resolves cleanly"
 
   # Job 2: real PR shape. Runs only on pull_request events so the
   # job has a real base.sha + the real synthetic-merge HEAD that

--- a/.github/workflows/issue-26-e2e.yml
+++ b/.github/workflows/issue-26-e2e.yml
@@ -1,0 +1,230 @@
+name: issue-26 e2e (git_commit_message range mode)
+
+# End-to-end demonstration of issue #26's fix. Three test jobs that
+# exercise the new `since:` option of `git_commit_message` against
+# both a synthetic git fixture (deterministic, always reproducible)
+# and the real PR shape that triggered the original bug report
+# (synthetic merge commit at HEAD on `pull_request` events).
+#
+# Built from source on every run so the workflow reflects the
+# branch's code, not whatever's published as latest. After v0.9.21
+# ships, the canonical recipe in
+# `docs/site/integrations/github-actions.md` becomes the supported
+# path; this workflow stays as the regression gate.
+
+on:
+  push:
+    branches: [issue-26-commit-range]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Job 1: synthetic fixture. Deterministic; doesn't depend on the
+  # PR's own commit history. The fixture mimics the canonical PR
+  # shape (synthetic merge at HEAD + Conventional-Commits commits
+  # on the feature branch in between).
+  synthetic-fixture:
+    name: range mode (synthetic fixture)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build alint from this branch
+        run: cargo build --release -p alint
+
+      - name: Build the canonical PR fixture
+        # base commit -> feature branch with 2 Conventional Commits
+        # -> merge back to main with --no-ff. HEAD is the merge
+        # commit; its subject is "Merge branch 'feature'" which
+        # doesn't match the Conventional Commits pattern.
+        run: |
+          set -euxo pipefail
+          mkdir -p /tmp/range-fixture
+          cd /tmp/range-fixture
+          git init -q -b main
+          git config user.email "test@example.com"
+          git config user.name "Test"
+          git config commit.gpgsign false
+          git commit --allow-empty -q -m "init: base"
+          BASE_SHA=$(git rev-parse HEAD)
+          echo "BASE_SHA=$BASE_SHA" >> "$GITHUB_ENV"
+          git checkout -q -b feature
+          git commit --allow-empty -q -m "feat(api): add range support"
+          git commit --allow-empty -q -m "fix(parser): handle merge subject"
+          git checkout -q main
+          git merge --no-ff --no-edit feature
+          # Sanity: HEAD's subject should now be the synthetic
+          # merge.
+          git log -1 --format=%s | tee /tmp/head-subject
+          grep -q "^Merge branch 'feature'" /tmp/head-subject
+
+      - name: Write the rule config
+        run: |
+          cat > /tmp/range-fixture/.alint.yml <<'YAML'
+          version: 1
+          rules:
+            - id: conventional-commits
+              kind: git_commit_message
+              pattern: '^(feat|fix|chore|docs|refactor|test|build|ci|perf|style|revert)(\(.+\))?!?: '
+              subject_max_length: 72
+              since: ${ALINT_BASE_SHA}
+              level: error
+          YAML
+
+      - name: Demonstrate the original bug (HEAD-only mode flags the merge)
+        # Before the fix: a `git_commit_message` rule without
+        # `since:` validates only HEAD. On a real PR, HEAD is the
+        # synthetic merge commit, so the rule fires every time.
+        # Here we force HEAD-only mode and assert it fails.
+        run: |
+          set +e
+          cat > /tmp/range-fixture/.alint.yml <<'YAML'
+          version: 1
+          rules:
+            - id: head-only-mode
+              kind: git_commit_message
+              pattern: '^(feat|fix|chore|docs|refactor|test|build|ci|perf|style|revert)(\(.+\))?!?: '
+              level: error
+          YAML
+          output=$(./target/release/alint check /tmp/range-fixture 2>&1)
+          rc=$?
+          set -e
+          echo "$output"
+          if [ "$rc" = "0" ]; then
+            echo "::error::HEAD-only mode unexpectedly passed; expected failure on merge subject"
+            exit 1
+          fi
+          echo "✓ HEAD-only mode correctly fails on synthetic merge (exit $rc), demonstrating issue #26"
+
+      - name: Verify range mode passes (the fix in action)
+        env:
+          ALINT_BASE_SHA: ${{ env.BASE_SHA }}
+        run: |
+          set -euxo pipefail
+          cat > /tmp/range-fixture/.alint.yml <<'YAML'
+          version: 1
+          rules:
+            - id: range-mode
+              kind: git_commit_message
+              pattern: '^(feat|fix|chore|docs|refactor|test|build|ci|perf|style|revert)(\(.+\))?!?: '
+              subject_max_length: 72
+              since: ${ALINT_BASE_SHA}
+              level: error
+          YAML
+          ./target/release/alint check /tmp/range-fixture
+          echo "✓ Range mode validates the feature-branch commits and ignores the merge"
+
+      - name: Verify shallow-clone gotcha surfaces with a clear hint
+        run: |
+          set +e
+          cat > /tmp/range-fixture/.alint.yml <<'YAML'
+          version: 1
+          rules:
+            - id: bad-ref
+              kind: git_commit_message
+              pattern: '.'
+              since: "does-not-exist-ref"
+              level: error
+          YAML
+          output=$(./target/release/alint check /tmp/range-fixture 2>&1)
+          rc=$?
+          set -e
+          echo "$output"
+          if [ "$rc" = "0" ]; then
+            echo "::error::expected non-zero exit for unresolvable ref"
+            exit 1
+          fi
+          if ! echo "$output" | grep -q "fetch-depth: 0"; then
+            echo "::error::expected shallow-clone hint in output"
+            exit 1
+          fi
+          echo "✓ Bad-ref hard-fails with the fetch-depth: 0 hint"
+
+      - name: Verify env-var default fallback works
+        # No ALINT_BASE_SHA set; the rule's ${ALINT_BASE_SHA:-HEAD~3}
+        # default kicks in. The range HEAD~3..HEAD covers the
+        # feature commits + the merge (3 commits back). With
+        # include_merges off, only the two feat:/fix: commits get
+        # validated and both pass.
+        run: |
+          set -euxo pipefail
+          unset ALINT_BASE_SHA
+          cat > /tmp/range-fixture/.alint.yml <<'YAML'
+          version: 1
+          rules:
+            - id: env-default
+              kind: git_commit_message
+              pattern: '^(feat|fix|chore|docs|refactor|test|build|ci|perf|style|revert)(\(.+\))?!?: '
+              since: ${ALINT_BASE_SHA:-HEAD~3}
+              level: error
+          YAML
+          ./target/release/alint check /tmp/range-fixture
+          echo "✓ Env-var default fallback (\${VAR:-HEAD~3}) resolves cleanly"
+
+  # Job 2: real PR shape. Runs only on pull_request events so the
+  # job has a real base.sha + the real synthetic-merge HEAD that
+  # actions/checkout produces. Validates that on a real
+  # `pull_request` trigger, the rule walks the PR's own commits
+  # (which all start with `feat:` / `fix:` / etc. per project
+  # commit-message conventions) instead of HEAD.
+  real-pr-shape:
+    name: range mode (real pull_request shape)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Confirm HEAD is the synthetic merge
+        run: |
+          subject=$(git log -1 --format=%s)
+          echo "HEAD subject: $subject"
+          if ! echo "$subject" | grep -qE "^Merge "; then
+            echo "::warning::HEAD is not a Merge commit; this PR may be in an unusual state, skipping real-PR assertion"
+            echo "SKIP=1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build alint from this branch
+        if: env.SKIP != '1'
+        run: cargo build --release -p alint
+
+      - name: Validate PR commits via range mode
+        if: env.SKIP != '1'
+        env:
+          ALINT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euxo pipefail
+          cat > /tmp/pr-validation.yml <<'YAML'
+          version: 1
+          rules:
+            - id: pr-commits-are-conventional
+              kind: git_commit_message
+              pattern: '^(feat|fix|chore|docs|refactor|test|build|ci|perf|style|revert)(\(.+\))?!?: '
+              subject_max_length: 100
+              since: ${ALINT_BASE_SHA}
+              level: error
+          YAML
+          # Run from /tmp so the repo root's .alint.yml isn't
+          # auto-discovered.
+          cp -r . /tmp/pr-copy
+          cp /tmp/pr-validation.yml /tmp/pr-copy/.alint.yml
+          ./target/release/alint check /tmp/pr-copy
+
+  # Job 3: end-to-end unit + e2e test re-run to confirm nothing
+  # regressed locally. Cheap insurance against "I forgot to run
+  # tests before pushing."
+  test-suites:
+    name: rust test suites
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: cargo test (workspace)
+        run: cargo test --workspace --quiet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,23 @@ silently goes stale" gap can't reopen post-launch.
 
 ### Added
 
+- **`git_commit_message` range mode** ([#26](https://github.com/asamarts/alint/issues/26)):
+  new `since:` option validates every commit in `<since>..HEAD`
+  instead of only HEAD. Right shape for `pull_request`-trigger CI,
+  where `actions/checkout` produces a synthetic merge commit at
+  HEAD that the rule would otherwise always flag. `since:` accepts
+  any `git rev-parse`-able ref (SHA, branch, tag, `HEAD~N`) and
+  supports POSIX `${VAR}` and `${VAR:-default}` env-var
+  interpolation so CI workflows can pass the PR base SHA in via
+  an env var without templating the YAML. Merge commits in the
+  range are skipped by default; opt in with `include_merges: true`.
+  Per-commit violations carry the abbreviated SHA + a subject
+  snippet so users know which commit to amend. Shallow-clone
+  gotchas (the common `actions/checkout@v4` `fetch-depth: 1`
+  default) hard-fail with a `fetch-depth: 0` hint rather than
+  silently returning an empty range. Plus 5 new e2e scenarios
+  covering range happy path, multiple failing commits, empty
+  range, HEAD-only backward compat, and the merge-skip default.
 - `GOVERNANCE.md` + `.github/FUNDING.yml` (pre-launch repo polish).
 - `ci/scripts/preflight.sh` wrapper + git `pre-push` hook
   enforcing fmt / clippy / doc / pin-sync.

--- a/crates/alint-core/src/git.rs
+++ b/crates/alint-core/src/git.rs
@@ -155,6 +155,155 @@ pub fn head_commit_message(root: &Path) -> Option<String> {
     Some(raw.trim_end_matches('\n').to_string())
 }
 
+/// One commit in a `<since>..HEAD` range, as returned by
+/// [`commit_messages_in_range`]. `sha` is the abbreviated SHA from
+/// `git log --abbrev-commit` (typically 7 chars; git auto-extends if
+/// the prefix is ambiguous in the local repo). `message` is the full
+/// commit message (subject + body, separated by a blank line) with
+/// the trailing newline that `git log --format=%B` appends already
+/// trimmed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommitRecord {
+    pub sha: String,
+    pub message: String,
+}
+
+/// Errors that distinguish "git is here but the range is invalid"
+/// from "git isn't here at all." The rule layer uses this to hard-
+/// fail on misconfiguration (a bad `since:` ref, often a shallow-
+/// clone gotcha in CI) while silently no-op'ing in non-git
+/// directories.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommitRangeError {
+    /// The `<since>` ref doesn't resolve, or the range itself is
+    /// rejected by git (e.g. `bad revision`). Carries the stderr
+    /// `git` produced so the caller can include it in its error.
+    /// Typically caused by:
+    /// - typo in the ref name
+    /// - shallow clone that doesn't have the ref in local objects
+    ///   (the most common CI gotcha; `actions/checkout` defaults to
+    ///   `fetch-depth: 1`)
+    BadRange { stderr: String },
+}
+
+/// Enumerate commits reachable from `HEAD` but not from `since`,
+/// i.e. the standard `<since>..HEAD` range, oldest first.
+///
+/// `since` is anything `git rev-parse` accepts: a 40-char SHA, an
+/// abbreviated SHA, a branch (`origin/main`), a tag (`v1.2.3`), or
+/// a relative ref (`HEAD~5`).
+///
+/// `include_merges` controls whether merge commits in the range are
+/// returned. Defaults to `false` at the call site for PR workflows
+/// (where the merge commit at HEAD is the synthetic
+/// `actions/checkout`-produced one) but the caller decides.
+///
+/// Returns:
+/// - `Ok(Some(records))` on success. The vec may be empty if the
+///   range itself is empty (`since` == HEAD on a force-push PR, or
+///   no non-merge commits in the range).
+/// - `Ok(None)` if `git` isn't on PATH or `root` isn't inside a git
+///   repo. Matches the advisory posture of the rest of this module;
+///   rules that consult this helper silently no-op in non-git
+///   settings.
+/// - `Err(CommitRangeError::BadRange)` if `git` is present and the
+///   repo is valid but the range couldn't be resolved. Rules
+///   surface this as a hard error so the user sees the
+///   misconfiguration instead of a confused empty range.
+///
+/// Implementation note: uses `--format=%h%x00%B%x1e` so the SHA and
+/// the message are NUL-separated (NUL never appears in either) and
+/// commits are RS-separated (RS = U+001E, "record separator", which
+/// also doesn't appear in well-formed commit text). The compound
+/// encoding is robust against commit messages containing arbitrary
+/// text — including em dashes, blank lines, and Unicode shenanigans
+/// — without resorting to fragile line-counting.
+pub fn commit_messages_in_range(
+    root: &Path,
+    since: &str,
+    include_merges: bool,
+) -> Result<Option<Vec<CommitRecord>>, CommitRangeError> {
+    // First check `git rev-parse` (no range syntax) confirms we're
+    // in a git repo at all. If not, this returns Ok(None) (the
+    // "silent" branch) without surfacing the BadRange error,
+    // matching head_commit_message's posture.
+    let probe = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", "--git-dir"])
+        .output();
+    let Ok(probe) = probe else {
+        return Ok(None);
+    };
+    if !probe.status.success() {
+        return Ok(None);
+    }
+
+    // Now invoke `git log <since>..HEAD`. If THIS fails, it's a bad
+    // ref / shallow-clone case, not a "no git" case — bubble the
+    // BadRange error.
+    let range = format!("{since}..HEAD");
+    let mut cmd = Command::new("git");
+    cmd.arg("-C").arg(root).args([
+        "log",
+        "--reverse",
+        "--abbrev-commit",
+        "--format=%h%x00%B%x1e",
+    ]);
+    if !include_merges {
+        cmd.arg("--no-merges");
+    }
+    cmd.arg(&range);
+
+    let Ok(output) = cmd.output() else {
+        return Ok(None);
+    };
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(CommitRangeError::BadRange { stderr });
+    }
+
+    Ok(Some(parse_commit_log(&output.stdout)))
+}
+
+/// Parse the NUL+RS-separated `git log` output produced by
+/// [`commit_messages_in_range`]'s `--format` string. Empty trailing
+/// records (from the final RS) are skipped. Messages have their
+/// trailing newline trimmed (`git log` always appends one).
+fn parse_commit_log(stdout: &[u8]) -> Vec<CommitRecord> {
+    let mut out = Vec::new();
+    // Records are RS-separated (0x1e). The last record ends with
+    // RS too, so the final split chunk is empty.
+    for record in stdout.split(|&b| b == 0x1e) {
+        if record.is_empty() {
+            continue;
+        }
+        // Each record is sha + NUL + message. Trim the leading
+        // newline that git inserts between records.
+        let record = record.strip_prefix(b"\n").unwrap_or(record);
+        let mut parts = record.splitn(2, |&b| b == 0);
+        let Some(sha_bytes) = parts.next() else {
+            continue;
+        };
+        let Some(msg_bytes) = parts.next() else {
+            continue;
+        };
+        let Ok(sha) = std::str::from_utf8(sha_bytes) else {
+            continue;
+        };
+        let Ok(msg) = std::str::from_utf8(msg_bytes) else {
+            continue;
+        };
+        // `--format=%B` ends every body with a trailing newline.
+        let message = msg.trim_end_matches('\n').to_string();
+        out.push(CommitRecord {
+            sha: sha.to_string(),
+            message,
+        });
+    }
+    out
+}
+
 /// One line of `git blame --line-porcelain` output: the
 /// 1-indexed final line number in the working-tree file, the
 /// authoring time of the commit that last touched the line
@@ -527,5 +676,225 @@ filename a.rs
         // match `target/foo` because no tracked path is under
         // `tar/`.
         assert!(!dir_has_tracked_files(Path::new("tar"), &set));
+    }
+
+    // ----- commit_messages_in_range -----------------------------
+
+    /// Build a temp dir into a git repo with the given list of
+    /// empty commits in order (commit N is HEAD~(len-1-N)). Returns
+    /// the tempdir so the caller controls its lifetime.
+    ///
+    /// Uses `git commit --allow-empty` so the test doesn't need to
+    /// write fixture files. Disables GPG signing and sets a fixed
+    /// author so the commits are deterministic.
+    fn make_repo_with_commits(subjects: &[&str]) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        let init_dir = tmp.path();
+        for args in [
+            vec!["init", "-q", "-b", "main"],
+            vec!["config", "user.email", "test@example.com"],
+            vec!["config", "user.name", "Test"],
+            vec!["config", "commit.gpgsign", "false"],
+        ] {
+            let out = Command::new("git")
+                .arg("-C")
+                .arg(init_dir)
+                .args(&args)
+                .output()
+                .unwrap();
+            assert!(out.status.success(), "git {args:?} failed");
+        }
+        for subject in subjects {
+            let out = Command::new("git")
+                .arg("-C")
+                .arg(init_dir)
+                .args(["commit", "--allow-empty", "-m", subject])
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git commit failed: stderr={}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        tmp
+    }
+
+    #[test]
+    fn parse_commit_log_empty_input() {
+        assert!(parse_commit_log(b"").is_empty());
+    }
+
+    #[test]
+    fn parse_commit_log_single_commit() {
+        // sha + NUL + body-with-trailing-newline + RS.
+        let raw = b"abc1234\0subject line\n\nbody line one\nbody line two\n\x1e";
+        let records = parse_commit_log(raw);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].sha, "abc1234");
+        assert_eq!(
+            records[0].message,
+            "subject line\n\nbody line one\nbody line two"
+        );
+    }
+
+    #[test]
+    fn parse_commit_log_multiple_commits() {
+        // Two commits, oldest first (matches --reverse). Between
+        // records, git inserts a newline before the next SHA; the
+        // parser strips it.
+        let raw = b"a1\0first\n\x1e\nb2\0second\n\x1e";
+        let records = parse_commit_log(raw);
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].sha, "a1");
+        assert_eq!(records[0].message, "first");
+        assert_eq!(records[1].sha, "b2");
+        assert_eq!(records[1].message, "second");
+    }
+
+    #[test]
+    fn parse_commit_log_subject_only_no_body() {
+        let raw = b"deadbef\0just the subject\n\x1e";
+        let records = parse_commit_log(raw);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].message, "just the subject");
+    }
+
+    #[test]
+    fn parse_commit_log_preserves_blank_lines_in_body() {
+        // A real commit body with multiple paragraphs survives the
+        // round-trip unchanged.
+        let raw = b"sha7777\0fix: thing\n\nfirst paragraph.\n\nsecond paragraph.\n\nthird.\n\x1e";
+        let records = parse_commit_log(raw);
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].message,
+            "fix: thing\n\nfirst paragraph.\n\nsecond paragraph.\n\nthird."
+        );
+    }
+
+    #[test]
+    fn parse_commit_log_skips_record_with_invalid_utf8() {
+        // A SHA followed by invalid UTF-8 in the message. The
+        // parser drops the malformed record rather than panicking.
+        let mut raw: Vec<u8> = b"abc1234\0".to_vec();
+        raw.extend_from_slice(&[0xff, 0xfe, 0xfd]); // invalid UTF-8
+        raw.push(0x1e);
+        let records = parse_commit_log(&raw);
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn commit_range_returns_none_outside_git() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Non-git directory: silent None. Distinguishes from the
+        // BadRange error (which a bad ref inside a real repo
+        // produces) so the rule layer can decide between "skip
+        // silently" and "hard fail."
+        let result = commit_messages_in_range(tmp.path(), "main", false);
+        assert!(matches!(result, Ok(None)));
+    }
+
+    #[test]
+    fn commit_range_returns_empty_vec_for_head_to_head() {
+        let repo = make_repo_with_commits(&["feat: first commit"]);
+        let result = commit_messages_in_range(repo.path(), "HEAD", false).unwrap();
+        // HEAD..HEAD is the empty range. Some(empty), not None.
+        assert_eq!(result, Some(Vec::new()));
+    }
+
+    #[test]
+    fn commit_range_enumerates_real_commits_oldest_first() {
+        // Four commits. Use the root commit's full SHA as the
+        // `since` base; the range then yields the three later
+        // commits, oldest first.
+        let repo =
+            make_repo_with_commits(&["root: zero", "feat: alpha", "fix: beta", "chore: gamma"]);
+        let root_sha = String::from_utf8(
+            Command::new("git")
+                .arg("-C")
+                .arg(repo.path())
+                .args(["rev-parse", "HEAD~3"])
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+        let records = commit_messages_in_range(repo.path(), &root_sha, false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[0].message, "feat: alpha");
+        assert_eq!(records[1].message, "fix: beta");
+        assert_eq!(records[2].message, "chore: gamma");
+        // SHAs are abbreviated (7+ chars, hex).
+        for r in &records {
+            assert!(r.sha.len() >= 7);
+            assert!(r.sha.chars().all(|c| c.is_ascii_hexdigit()));
+        }
+    }
+
+    #[test]
+    fn commit_range_skips_merges_by_default() {
+        // Build the canonical PR-CI shape: a base branch with one
+        // commit, a feature branch off it with two commits, then a
+        // merge commit on the base branch. The merge is what
+        // actions/checkout produces at HEAD on a pull_request
+        // trigger.
+        let repo = make_repo_with_commits(&["init commit on main"]);
+        let root = repo.path();
+        let run = |args: &[&str]| {
+            let out = Command::new("git")
+                .arg("-C")
+                .arg(root)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            String::from_utf8(out.stdout).unwrap()
+        };
+        let base_sha = run(&["rev-parse", "HEAD"]).trim().to_string();
+        run(&["checkout", "-q", "-b", "feature"]);
+        run(&["commit", "--allow-empty", "-m", "feat: A"]);
+        run(&["commit", "--allow-empty", "-m", "fix: B"]);
+        run(&["checkout", "-q", "main"]);
+        run(&["merge", "--no-ff", "--no-edit", "feature"]);
+
+        // Range main-base..HEAD: includes feat:A, fix:B, and the
+        // merge commit. Default skips the merge.
+        let records = commit_messages_in_range(root, &base_sha, false)
+            .unwrap()
+            .unwrap();
+        let subjects: Vec<&str> = records.iter().map(|r| r.message.as_str()).collect();
+        assert_eq!(subjects, vec!["feat: A", "fix: B"]);
+
+        // Same range with include_merges: true picks up the merge.
+        let with_merge = commit_messages_in_range(root, &base_sha, true)
+            .unwrap()
+            .unwrap();
+        assert_eq!(with_merge.len(), 3);
+        assert!(with_merge.iter().any(|r| r.message.starts_with("Merge ")));
+    }
+
+    #[test]
+    fn commit_range_returns_bad_range_for_unknown_ref() {
+        let repo = make_repo_with_commits(&["init"]);
+        let result = commit_messages_in_range(repo.path(), "does-not-exist-ref", false);
+        match result {
+            Err(CommitRangeError::BadRange { stderr }) => {
+                // Git typically says "unknown revision or path not
+                // in the working tree." We don't assert the exact
+                // wording (varies across git versions); just that
+                // we got a non-empty stderr.
+                assert!(!stderr.is_empty());
+            }
+            other => panic!("expected BadRange, got {other:?}"),
+        }
     }
 }

--- a/crates/alint-dsl/schemas/v1/config.json
+++ b/crates/alint-dsl/schemas/v1/config.json
@@ -918,7 +918,7 @@
     },
 
     "rule_git_commit_message": {
-      "description": "Validate HEAD's commit message against shape rules: regex, max subject length, body required. At least one of `pattern:` / `subject_max_length:` / `requires_body: true` must be set. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops.",
+      "description": "Validate one or more commit messages against shape rules: regex, max subject length, body required. With `since:` unset, only HEAD is checked. With `since:` set to a ref, every commit in `<since>..HEAD` is checked (oldest first, merge commits excluded by default); right shape for PR-trigger workflows where HEAD is a synthetic `actions/checkout` merge commit. At least one of `pattern:` / `subject_max_length:` / `requires_body: true` must be set. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
       "type": "object",
       "properties": {
         "kind": { "const": "git_commit_message" },
@@ -934,7 +934,16 @@
         "requires_body": {
           "type": "boolean",
           "default": false,
-          "description": "When true, the message must have a non-empty body — at least one line of content after the subject's blank-line separator."
+          "description": "When true, the message must have a non-empty body, that is, at least one line of content after the subject's blank-line separator."
+        },
+        "since": {
+          "type": "string",
+          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does: SHA (full or abbreviated), branch (`origin/main`), tag (`v1.2.3`), or relative ref (`HEAD~5`). Supports POSIX `${VAR}` and `${VAR:-default}` env-var interpolation so CI can pass a SHA via an env var (e.g. `since: ${ALINT_BASE_SHA:-origin/main}` with `ALINT_BASE_SHA` exported in a workflow step from `github.event.pull_request.base.sha`). The GitHub Actions double-brace template syntax `${{ ... }}` is NOT interpolated by alint."
+        },
+        "include_merges": {
+          "type": "boolean",
+          "default": false,
+          "description": "When validating a range (`since:` set), include merge commits. Defaults to `false` because merge commits in PR contexts are typically the synthetic merge `actions/checkout` produces (with an auto-generated subject the rule would always flag) or maintainer-resolved merges from the base branch. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error."
         }
       },
       "anyOf": [

--- a/crates/alint-dsl/tests/snapshots/default_options.txt
+++ b/crates/alint-dsl/tests/snapshots/default_options.txt
@@ -656,6 +656,8 @@ GitCommitMessageRule {
     ),
     subject_max_length: None,
     requires_body: false,
+    since_raw: None,
+    include_merges: false,
 }
 
 === kind: git_no_denied_paths | id: no-tracked-secrets ===

--- a/crates/alint-e2e/scenarios/check/git/git_commit_message_head_mode_still_works.yml
+++ b/crates/alint-e2e/scenarios/check/git/git_commit_message_head_mode_still_works.yml
@@ -1,0 +1,29 @@
+name: git_commit_message without since:still validates HEAD only
+tags: [check, git_commit_message, git, failing]
+
+# Backward-compat shape: no `since:`, just HEAD-mode. A long
+# subject on the tip commit fires once. Older commits in the
+# history are invisible to the rule because they're not HEAD.
+
+given:
+  tree:
+    README.md: "# demo\n"
+  config: |
+    version: 1
+    rules:
+      - id: short-subjects
+        kind: git_commit_message
+        subject_max_length: 20
+        level: error
+  git:
+    init: true
+    commits:
+      - "init"
+      - "feat: ok"
+      - "WIP: this final commit subject is well over twenty chars"
+
+when: [check]
+
+expect:
+  - violations:
+      - {rule: short-subjects, level: error}

--- a/crates/alint-e2e/scenarios/check/git/git_commit_message_range_empty_silent.yml
+++ b/crates/alint-e2e/scenarios/check/git/git_commit_message_range_empty_silent.yml
@@ -1,0 +1,29 @@
+name: git_commit_message range stays silent when the range is empty
+tags: [check, git_commit_message, git, passing]
+
+# `since: HEAD` means the range `HEAD..HEAD`, which is always
+# empty. The rule no-ops cleanly — no commits to validate, no
+# violations to report. Surfaces in CI on the force-push-and-
+# rebase case where the PR head ends up identical to the base.
+
+given:
+  tree:
+    README.md: "# demo\n"
+  config: |
+    version: 1
+    rules:
+      - id: short-subjects
+        kind: git_commit_message
+        subject_max_length: 30
+        since: HEAD
+        level: error
+  git:
+    init: true
+    commits:
+      - "init: base"
+      - "feat: anything here, would normally trip the cap above"
+
+when: [check]
+
+expect:
+  - violations: []

--- a/crates/alint-e2e/scenarios/check/git/git_commit_message_range_flags_multiple_commits.yml
+++ b/crates/alint-e2e/scenarios/check/git/git_commit_message_range_flags_multiple_commits.yml
@@ -1,0 +1,33 @@
+name: git_commit_message range emits one violation per failing commit
+tags: [check, git_commit_message, git, failing]
+
+# Two of three commits in the range violate the pattern. The rule
+# emits one violation per failing commit, so users can rebase /
+# amend each one independently rather than chasing a single
+# collapsed "something is wrong" report.
+
+given:
+  tree:
+    README.md: "# demo\n"
+  config: |
+    version: 1
+    rules:
+      - id: conventional-prefix
+        kind: git_commit_message
+        pattern: '^(feat|fix|chore): '
+        since: HEAD~3
+        level: error
+  git:
+    init: true
+    commits:
+      - "init: base"
+      - "feat: this one passes"
+      - "WIP no prefix here"
+      - "random thoughts on architecture"
+
+when: [check]
+
+expect:
+  - violations:
+      - {rule: conventional-prefix, level: error}
+      - {rule: conventional-prefix, level: error}

--- a/crates/alint-e2e/scenarios/check/git/git_commit_message_range_flags_one_bad_subject.yml
+++ b/crates/alint-e2e/scenarios/check/git/git_commit_message_range_flags_one_bad_subject.yml
@@ -1,0 +1,36 @@
+name: git_commit_message with since:HEAD~3 flags the one bad subject and reports the SHA
+tags: [check, git_commit_message, git, failing]
+
+# The PR-CI use case (issue #26): four commits on the branch — a
+# "base" commit and three later ones, one of which has a subject
+# longer than the cap. The rule's `since:` mode walks all three
+# later commits and fires exactly once, on the bad one, with the
+# commit SHA in the message so the user knows which to amend.
+#
+# `HEAD~3..HEAD` covers commits 2, 3, 4. The root commit (HEAD~3)
+# itself is excluded — same shape as `<pr-base>..HEAD` in real PRs.
+
+given:
+  tree:
+    README.md: "# demo\n"
+  config: |
+    version: 1
+    rules:
+      - id: short-subjects
+        kind: git_commit_message
+        subject_max_length: 30
+        since: HEAD~3
+        level: error
+  git:
+    init: true
+    commits:
+      - "init: base"
+      - "feat: alpha is fine"
+      - "WIP: this subject is way too long for the configured cap"
+      - "fix: gamma is also fine"
+
+when: [check]
+
+expect:
+  - violations:
+      - {rule: short-subjects, level: error}

--- a/crates/alint-e2e/scenarios/check/git/git_commit_message_range_passes_when_all_subjects_ok.yml
+++ b/crates/alint-e2e/scenarios/check/git/git_commit_message_range_passes_when_all_subjects_ok.yml
@@ -1,0 +1,30 @@
+name: git_commit_message range passes when every commit in the range matches
+tags: [check, git_commit_message, git, passing]
+
+# Range mode happy path: three later commits, all conforming to
+# the Conventional Commits pattern. No violations.
+
+given:
+  tree:
+    README.md: "# demo\n"
+  config: |
+    version: 1
+    rules:
+      - id: conventional-commits
+        kind: git_commit_message
+        pattern: '^(feat|fix|chore|docs|refactor|test|build|ci|perf|style|revert)(\(.+\))?!?: '
+        subject_max_length: 72
+        since: HEAD~3
+        level: error
+  git:
+    init: true
+    commits:
+      - "init: base"
+      - "feat: add markdown formatter"
+      - "fix(parser): handle nested arrays"
+      - "chore: bump deps"
+
+when: [check]
+
+expect:
+  - violations: []

--- a/crates/alint-rules/src/git_commit_message.rs
+++ b/crates/alint-rules/src/git_commit_message.rs
@@ -1,23 +1,41 @@
-//! `git_commit_message` — assert HEAD's commit message matches a
-//! shape (regex, max subject length, body required).
+//! `git_commit_message` — assert commit messages match a shape
+//! (regex, max subject length, body required).
+//!
+//! Two modes:
+//!
+//! - **HEAD-only** (default, `since:` omitted): validate the tip
+//!   commit. Right shape for push-trigger CI and post-commit hooks.
+//! - **Range** (`since:` set): validate every commit reachable from
+//!   `HEAD` but not from `since`. Right shape for pull-request CI,
+//!   where `actions/checkout` checks out a synthetic merge commit
+//!   that the rule should never see. Set `since:` to the PR base
+//!   SHA (typically via `${ALINT_BASE_SHA}` env interpolation, with
+//!   the env var sourced from `github.event.pull_request.base.sha`
+//!   in the workflow). Merge commits in the range are skipped by
+//!   default (`include_merges: false`); set `include_merges: true`
+//!   to lint them too.
 //!
 //! Use cases: enforce Conventional Commits / Angular-style
-//! prefixes, cap the subject at a screen-friendly width
-//! (50–72), require commits that fix issues to include a body
-//! linking the issue. CI integration: run `alint check
-//! --changed` (or `alint check`) on every PR; alint reads the
-//! tip commit and fires if the shape is off.
+//! prefixes, cap the subject at a screen-friendly width (50–72),
+//! require commits that fix issues to include a body linking the
+//! issue.
 //!
-//! Outside a git repo, with no commits yet, or when `git` isn't
-//! on PATH, the rule silently no-ops. This is the same advisory
-//! posture as `git_tracked_only` and `git_no_denied_paths`: a
-//! rule about git only fires when there's git to inspect.
+//! Outside a git repo, with no commits yet, or when `git` isn't on
+//! PATH, the rule silently no-ops. Same advisory posture as
+//! `git_tracked_only` and `git_no_denied_paths`: a rule about git
+//! only fires when there's git to inspect.
 //!
-//! Check-only — alint can't rewrite the user's commit
-//! message, and `git commit --amend` is a sensitive operation
-//! we don't automate.
+//! Bad `since:` refs (typo, or a shallow-clone gotcha that left
+//! the ref out of local objects) hard-fail with a hint to widen
+//! the checkout. The user asked for a range; silently falling back
+//! to HEAD-only would mask the misconfiguration.
+//!
+//! Check-only — alint can't rewrite the user's commit message, and
+//! `git commit --amend` is a sensitive operation we don't automate.
 
-use alint_core::git::head_commit_message;
+use alint_core::git::{
+    CommitRangeError, CommitRecord, commit_messages_in_range, head_commit_message,
+};
 use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Violation};
 use regex::Regex;
 use serde::Deserialize;
@@ -25,24 +43,44 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// Regex the full commit message (subject + body, joined
-    /// with newlines) must match. When omitted, no regex check
-    /// is applied. Use `(?s)` to make `.` match newlines if you
-    /// want to assert about content past the subject.
+    /// Regex the full commit message (subject + body, joined with
+    /// newlines) must match. When omitted, no regex check is
+    /// applied. Use `(?s)` to make `.` match newlines if you want
+    /// to assert about content past the subject.
     #[serde(default)]
     pattern: Option<String>,
     /// Maximum length of the subject line (the message's first
     /// line, before any body). When omitted, no length cap.
-    /// Common values: 50 (Tim Pope's recommendation), 72
-    /// (GitHub's PR-title cutoff).
+    /// Common values: 50 (Tim Pope's recommendation), 72 (GitHub's
+    /// PR-title cutoff).
     #[serde(default)]
     subject_max_length: Option<usize>,
-    /// When `true`, the message must have a non-empty body —
-    /// at least one line of content after the subject's
-    /// trailing blank line. Useful for mandating an
-    /// explanation on `fix:` commits etc.
+    /// When `true`, the message must have a non-empty body — at
+    /// least one line of content after the subject's trailing
+    /// blank line. Useful for mandating an explanation on `fix:`
+    /// commits etc.
     #[serde(default)]
     requires_body: bool,
+    /// Git ref to use as the base of the commit range. When set,
+    /// the rule validates every commit in `<since>..HEAD` instead
+    /// of just `HEAD`. Anything `git rev-parse` accepts works: a
+    /// 40-char or abbreviated SHA, a branch (`origin/main`), a tag
+    /// (`v1.2.3`), or a relative ref (`HEAD~5`). Supports POSIX
+    /// `${VAR}` and `${VAR:-default}` env-var interpolation so CI
+    /// can pass a SHA in via an env var (see the GitHub Actions
+    /// integration doc for the canonical recipe).
+    #[serde(default)]
+    since: Option<String>,
+    /// When validating a range (`since:` set), include merge
+    /// commits in the set of commits to check. Default `false`
+    /// because merge commits in a PR context are typically the
+    /// synthetic merge `actions/checkout` produces (with an
+    /// auto-generated subject the rule would always flag) or
+    /// maintainer-resolved merges from the base branch (also
+    /// uninteresting). Set `true` to lint them anyway. Has no
+    /// effect when `since:` is unset.
+    #[serde(default)]
+    include_merges: bool,
 }
 
 #[derive(Debug)]
@@ -54,6 +92,12 @@ pub struct GitCommitMessageRule {
     pattern: Option<Regex>,
     subject_max_length: Option<usize>,
     requires_body: bool,
+    /// `since:` value as written in the config, with `${VAR}`
+    /// interpolation NOT yet performed. Resolution is deferred to
+    /// evaluate-time so env vars exported by CI steps after rule
+    /// load are picked up correctly.
+    since_raw: Option<String>,
+    include_merges: bool,
 }
 
 impl Rule for GitCommitMessageRule {
@@ -61,37 +105,58 @@ impl Rule for GitCommitMessageRule {
 
     fn evaluate(&self, ctx: &Context<'_>) -> Result<Vec<Violation>> {
         let mut violations = Vec::new();
-        let Some(message) = head_commit_message(ctx.root) else {
-            // No git, no commits, or git not on PATH — silent
-            // no-op. This rule only makes sense when there's a
-            // commit to inspect.
-            return Ok(violations);
+
+        // Resolve `since:` once at evaluate-time so `${VAR}` env
+        // expansions reflect the current process environment.
+        let since = match &self.since_raw {
+            None => None,
+            Some(raw) => match expand_env(raw, env_lookup) {
+                Ok(resolved) => Some(resolved),
+                Err(missing) => {
+                    return Err(Error::rule_config(
+                        &self.id,
+                        format!(
+                            "`since:` references undefined env var `{missing}` \
+                             and has no default. Either set the env var (for \
+                             example, `ALINT_BASE_SHA` from \
+                             `github.event.pull_request.base.sha` in a GitHub \
+                             Actions workflow) or use the `${{VAR:-default}}` \
+                             default-value syntax."
+                        ),
+                    ));
+                }
+            },
         };
 
-        let (subject, body) = split_subject_body(&message);
+        let commits = match &since {
+            None => match head_commit_message(ctx.root) {
+                Some(message) => vec![CommitRecord {
+                    sha: "HEAD".to_string(),
+                    message,
+                }],
+                None => return Ok(violations), // silent no-op
+            },
+            Some(since) => {
+                match commit_messages_in_range(ctx.root, since, self.include_merges) {
+                    Ok(None) => return Ok(violations), // not a git repo: silent
+                    Ok(Some(records)) => records,
+                    Err(CommitRangeError::BadRange { stderr }) => {
+                        return Err(Error::rule_config(
+                            &self.id,
+                            format!(
+                                "could not resolve commit range `{since}..HEAD`: {stderr}. \
+                                 Common cause: shallow clone. In a GitHub Actions PR \
+                                 workflow, use `actions/checkout@v4` with \
+                                 `fetch-depth: 0` so the base ref is reachable."
+                            ),
+                        ));
+                    }
+                }
+            }
+        };
 
-        if let Some(re) = &self.pattern
-            && !re.is_match(&message)
-        {
-            violations.push(self.make_violation(format!(
-                "HEAD commit message does not match pattern `{}`",
-                re.as_str(),
-            )));
-        }
-
-        if let Some(max) = self.subject_max_length
-            && subject.chars().count() > max
-        {
-            violations.push(self.make_violation(format!(
-                "HEAD commit subject is {} chars; max allowed is {max}",
-                subject.chars().count(),
-            )));
-        }
-
-        if self.requires_body && body.trim().is_empty() {
-            violations.push(self.make_violation(
-                "HEAD commit message has no body; this rule requires one".to_string(),
-            ));
+        for commit in &commits {
+            self.check_one(commit, &mut violations);
         }
 
         Ok(violations)
@@ -99,24 +164,141 @@ impl Rule for GitCommitMessageRule {
 }
 
 impl GitCommitMessageRule {
+    fn check_one(&self, commit: &CommitRecord, violations: &mut Vec<Violation>) {
+        let (subject, body) = split_subject_body(&commit.message);
+
+        if let Some(re) = &self.pattern
+            && !re.is_match(&commit.message)
+        {
+            violations.push(self.make_violation(format_msg(
+                commit,
+                subject,
+                &format!("commit message does not match pattern `{}`", re.as_str()),
+            )));
+        }
+
+        if let Some(max) = self.subject_max_length
+            && subject.chars().count() > max
+        {
+            violations.push(self.make_violation(format_msg(
+                commit,
+                subject,
+                &format!(
+                    "commit subject is {} chars; max allowed is {max}",
+                    subject.chars().count(),
+                ),
+            )));
+        }
+
+        if self.requires_body && body.trim().is_empty() {
+            violations.push(self.make_violation(format_msg(
+                commit,
+                subject,
+                "commit message has no body; this rule requires one",
+            )));
+        }
+    }
+
     fn make_violation(&self, default_msg: String) -> Violation {
         Violation::new(self.message_override.clone().unwrap_or(default_msg))
     }
 }
 
-/// Split a commit message into (subject, body). The subject is
-/// the first line; the body is everything after the first
-/// blank line that follows it. Messages with no blank-line
-/// separator have an empty body. Trailing whitespace on the
-/// subject is preserved as-is — the length check counts it.
+/// Render a violation message with the commit SHA + a trimmed
+/// subject snippet for context. SHA is "HEAD" in single-commit
+/// mode (the helper synthesises it) and an abbreviated SHA in
+/// range mode. Subject is truncated to ~60 chars so violation
+/// output stays readable.
+fn format_msg(commit: &CommitRecord, subject: &str, what: &str) -> String {
+    const SUBJECT_PREVIEW_MAX: usize = 60;
+    let preview: String = subject.chars().take(SUBJECT_PREVIEW_MAX).collect();
+    let ellipsis = if subject.chars().count() > SUBJECT_PREVIEW_MAX {
+        "…"
+    } else {
+        ""
+    };
+    format!(
+        "commit {}: {what} (subject: \"{preview}{ellipsis}\")",
+        commit.sha
+    )
+}
+
+/// Split a commit message into (subject, body). The subject is the
+/// first line; the body is everything after the first blank line
+/// that follows it. Messages with no blank-line separator have an
+/// empty body. Trailing whitespace on the subject is preserved
+/// as-is — the length check counts it.
 fn split_subject_body(message: &str) -> (&str, &str) {
     let (subject, rest) = message.split_once('\n').unwrap_or((message, ""));
     // Skip exactly one trailing blank-line separator if present
     // (the canonical "subject\n\nbody" shape). Multiple blank
-    // lines fall through into the body — they're unusual but
-    // we don't want to silently swallow user content.
+    // lines fall through into the body — they're unusual but we
+    // don't want to silently swallow user content.
     let body = rest.strip_prefix('\n').unwrap_or(rest);
     (subject, body)
+}
+
+/// Expand POSIX-style env-var references in a `since:` value. The
+/// syntax is intentionally narrow:
+///
+/// - `${VAR}` — substitute the value of `VAR`. If unset, returns
+///   `Err(missing-var-name)` so the rule can hard-fail with a
+///   CI-friendly hint.
+/// - `${VAR:-default}` — substitute `VAR`, or `default` when
+///   `VAR` is unset or empty. `default` may not itself contain
+///   `${`, `}` or `:-` — keep the surface small.
+/// - Bare text — left as-is. So `since: origin/main` works
+///   unchanged.
+///
+/// Multiple `${...}` references in one value are supported. The
+/// double-brace GitHub Actions syntax (`${{ ... }}`) is NOT
+/// interpolated by alint; it has to be rendered by Actions before
+/// the YAML is read, which only works in workflow files, not in
+/// `.alint.yml`. The single-brace form is the alint convention.
+///
+/// `lookup` is an explicit env-var resolver (typically
+/// `|name| std::env::var(name).ok()`); injecting it keeps the
+/// pure-string parsing testable without `set_var` calls (the
+/// crate forbids unsafe code, and Rust 2024 marks `set_var` /
+/// `remove_var` unsafe).
+fn expand_env<F>(input: &str, lookup: F) -> std::result::Result<String, String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(start) = rest.find("${") {
+        out.push_str(&rest[..start]);
+        let after_open = &rest[start + 2..];
+        let Some(end) = after_open.find('}') else {
+            // Unclosed `${...`. Treat as literal, don't error —
+            // the caller's value is probably a literal SHA that
+            // happens to contain `${`.
+            out.push_str("${");
+            rest = after_open;
+            continue;
+        };
+        let inner = &after_open[..end];
+        let (name, default) = match inner.split_once(":-") {
+            Some((n, d)) => (n, Some(d)),
+            None => (inner, None),
+        };
+        match lookup(name) {
+            Some(v) if !v.is_empty() => out.push_str(&v),
+            _ => match default {
+                Some(d) => out.push_str(d),
+                None => return Err(name.to_string()),
+            },
+        }
+        rest = &after_open[end + 1..];
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+/// Production lookup: read from the process environment.
+fn env_lookup(name: &str) -> Option<String> {
+    std::env::var(name).ok()
 }
 
 pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
@@ -135,6 +317,13 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
         return Err(Error::rule_config(
             &spec.id,
             "git_commit_message has no fix op",
+        ));
+    }
+    if opts.include_merges && opts.since.is_none() {
+        return Err(Error::rule_config(
+            &spec.id,
+            "`include_merges: true` has no effect without `since:`. Either remove it \
+             or set `since:` to enable range mode.",
         ));
     }
 
@@ -156,6 +345,8 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
         pattern,
         subject_max_length: opts.subject_max_length,
         requires_body: opts.requires_body,
+        since_raw: opts.since,
+        include_merges: opts.include_merges,
     }))
 }
 
@@ -179,10 +370,10 @@ mod tests {
 
     #[test]
     fn split_subject_no_blank_separator() {
-        // git-style messages should have a blank line, but
-        // tools like `git commit -m "first\nsecond"` produce
-        // bodies without one. Treat the second line on as body
-        // even without a separator.
+        // git-style messages should have a blank line, but tools
+        // like `git commit -m "first\nsecond"` produce bodies
+        // without one. Treat the second line on as body even
+        // without a separator.
         let (subj, body) = split_subject_body("subject\nrest of content");
         assert_eq!(subj, "subject");
         assert_eq!(body, "rest of content");
@@ -215,5 +406,155 @@ mod tests {
     fn requires_body_accepts_canonical_form() {
         let (_, body) = split_subject_body("subject\n\nbody content");
         assert!(!body.trim().is_empty());
+    }
+
+    // ----- format_msg formatting --------------------------------
+
+    #[test]
+    fn format_msg_renders_sha_and_subject() {
+        let commit = CommitRecord {
+            sha: "a1b2c3d".to_string(),
+            message: "fix: thing".to_string(),
+        };
+        let s = format_msg(&commit, "fix: thing", "subject too long");
+        assert!(s.contains("commit a1b2c3d"));
+        assert!(s.contains("fix: thing"));
+        assert!(s.contains("subject too long"));
+    }
+
+    #[test]
+    fn format_msg_truncates_long_subjects() {
+        let long_subject = "x".repeat(120);
+        let commit = CommitRecord {
+            sha: "abc1234".to_string(),
+            message: long_subject.clone(),
+        };
+        let s = format_msg(&commit, &long_subject, "too long");
+        // Subject preview is capped at 60 chars + ellipsis.
+        assert!(s.contains(&"x".repeat(60)));
+        assert!(s.contains('…'));
+        assert!(!s.contains(&"x".repeat(61)));
+    }
+
+    // ----- env-var interpolation --------------------------------
+
+    /// Build a fake env lookup from a list of (name, value) pairs.
+    /// Anything not in the list is treated as unset.
+    fn fake_env<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |name: &str| {
+            pairs
+                .iter()
+                .find(|(k, _)| *k == name)
+                .map(|(_, v)| (*v).to_string())
+        }
+    }
+
+    #[test]
+    fn expand_env_passthrough_for_bare_string() {
+        let env = fake_env(&[]);
+        assert_eq!(expand_env("origin/main", &env).unwrap(), "origin/main");
+        assert_eq!(expand_env("v0.9.20", &env).unwrap(), "v0.9.20");
+        assert_eq!(
+            expand_env("abc1234567890abcdef1234567890abcdef12345678", &env,).unwrap(),
+            "abc1234567890abcdef1234567890abcdef12345678"
+        );
+    }
+
+    #[test]
+    fn expand_env_substitutes_simple_var() {
+        let env = fake_env(&[("ALINT_BASE_SHA", "deadbeef")]);
+        assert_eq!(expand_env("${ALINT_BASE_SHA}", &env).unwrap(), "deadbeef");
+    }
+
+    #[test]
+    fn expand_env_default_used_when_var_unset() {
+        let env = fake_env(&[]);
+        assert_eq!(
+            expand_env("${MISSING:-origin/main}", &env).unwrap(),
+            "origin/main"
+        );
+    }
+
+    #[test]
+    fn expand_env_default_used_when_var_empty() {
+        let env = fake_env(&[("EMPTY", "")]);
+        assert_eq!(
+            expand_env("${EMPTY:-origin/main}", &env).unwrap(),
+            "origin/main"
+        );
+    }
+
+    #[test]
+    fn expand_env_errors_when_var_unset_and_no_default() {
+        let env = fake_env(&[]);
+        let err = expand_env("${NOPE}", &env).unwrap_err();
+        assert_eq!(err, "NOPE");
+    }
+
+    #[test]
+    fn expand_env_handles_multiple_references() {
+        let env = fake_env(&[("A", "foo"), ("B", "bar")]);
+        assert_eq!(expand_env("${A}-${B}", &env).unwrap(), "foo-bar");
+    }
+
+    #[test]
+    fn expand_env_handles_text_around_var() {
+        let env = fake_env(&[("SHA", "abc1234")]);
+        assert_eq!(
+            expand_env("refs/${SHA}/head", &env).unwrap(),
+            "refs/abc1234/head"
+        );
+    }
+
+    #[test]
+    fn expand_env_ignores_unclosed_brace() {
+        // Don't crash on a value that contains a literal `${` —
+        // could be a base64 SHA or something weirder. Treat as
+        // literal.
+        let env = fake_env(&[]);
+        assert_eq!(expand_env("foo${unclosed", &env).unwrap(), "foo${unclosed");
+    }
+
+    // ----- build() validation -----------------------------------
+
+    fn spec(toml: &str) -> RuleSpec {
+        let mut full =
+            String::from("id = \"test-rule\"\nkind = \"git_commit_message\"\nlevel = \"error\"\n");
+        full.push_str(toml);
+        toml::from_str(&full).unwrap()
+    }
+
+    #[test]
+    fn build_requires_at_least_one_assertion() {
+        // No pattern, no subject_max_length, no requires_body. The
+        // rule has nothing to check; build() rejects.
+        let s = spec("");
+        let err = build(&s).unwrap_err();
+        assert!(err.to_string().contains("at least one of"));
+    }
+
+    #[test]
+    fn build_rejects_include_merges_without_since() {
+        // include_merges only makes sense alongside since:.
+        // Surfacing this at config-load time prevents silent
+        // no-ops.
+        let s = spec("requires_body = true\ninclude_merges = true\n");
+        let err = build(&s).unwrap_err();
+        assert!(
+            err.to_string().contains("include_merges"),
+            "expected include_merges hint, got: {err}"
+        );
+    }
+
+    #[test]
+    fn build_accepts_since_with_other_options() {
+        let s = spec("pattern = \"^feat: \"\nsince = \"origin/main\"\n");
+        assert!(build(&s).is_ok());
+    }
+
+    #[test]
+    fn build_accepts_since_with_include_merges() {
+        let s = spec("subject_max_length = 50\nsince = \"origin/main\"\ninclude_merges = true\n");
+        assert!(build(&s).is_ok());
     }
 }

--- a/crates/alint-testkit/src/runner.rs
+++ b/crates/alint-testkit/src/runner.rs
@@ -100,6 +100,34 @@ fn init_git_for_scenario(root: &Path, spec: &GivenGit) -> Result<()> {
         args.extend(spec.add_force.iter().map(String::as_str));
         git(root, &args)?;
     }
+    // Chain of empty commits (oldest first). Mutually exclusive
+    // with the add/commit single-commit path above. Use one or the
+    // other in any given scenario; mixing them is a fixture smell.
+    if !spec.commits.is_empty() {
+        if !spec.add.is_empty() || !spec.add_force.is_empty() {
+            return Err(Error::scenario(
+                "git: cannot combine `add:`/`add_force:` with `commits:` — use one path or the other"
+                    .to_string(),
+            ));
+        }
+        for subject in &spec.commits {
+            git(
+                root,
+                &[
+                    "-c",
+                    "user.name=alint scenario",
+                    "-c",
+                    "user.email=scenario@alint.test",
+                    "commit",
+                    "-q",
+                    "--allow-empty",
+                    "-m",
+                    subject,
+                ],
+            )?;
+        }
+        return Ok(());
+    }
     if spec.add.is_empty() && spec.add_force.is_empty() {
         return Ok(());
     }

--- a/crates/alint-testkit/src/scenario.rs
+++ b/crates/alint-testkit/src/scenario.rs
@@ -103,6 +103,15 @@ pub struct GivenGit {
     /// "fully checked-in repo."
     #[serde(default = "default_true")]
     pub commit: bool,
+    /// Make a chain of empty commits, oldest first. Each entry is
+    /// the subject line of one commit; the runner uses
+    /// `git commit --allow-empty -m <subject>` for every entry so
+    /// no working-tree file is required. Mutually exclusive with
+    /// `add:`/`commit:` (which write one mass commit of the
+    /// staged files). Used to fixture multi-commit shapes the
+    /// `git_commit_message` rule's `since:` mode needs to walk.
+    #[serde(default)]
+    pub commits: Vec<String>,
 }
 
 fn default_true() -> bool {

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -752,24 +752,76 @@ Outside a git repo (or when `git` isn't on `PATH`) the rule silently no-ops — 
 
 ### `git_commit_message`
 
-Validate HEAD's commit-message shape via regex, max-subject-length, or required-body. At least one of the three must be set; combine all three for full Conventional-Commits-style enforcement. Subject length counts characters, not bytes (a 50-char emoji subject is 50, not 200).
+Validate commit-message shape via regex, max-subject-length, or required-body. At least one of the three must be set; combine all three for full Conventional-Commits-style enforcement. Subject length counts characters, not bytes (a 50-char emoji subject is 50, not 200).
+
+Two modes, selected by the optional `since:` field:
+
+- **HEAD-only** (default, `since:` omitted): validate the tip commit. Right shape for push-trigger CI and post-commit hooks.
+- **Range** (`since:` set): validate every commit reachable from HEAD but not from `since`. Right shape for `pull_request`-trigger CI, where `actions/checkout` checks out a synthetic merge commit whose subject the rule would always flag.
 
 ```yaml
+# HEAD-only. The tip commit must follow Conventional Commits and be <= 72 chars.
 - id: conventional-commit
   kind: git_commit_message
   pattern: '^(feat|fix|chore|docs|refactor|test)(\([a-z-]+\))?: '
   subject_max_length: 72
   level: warning
 
-- id: bug-fixes-need-context
+# Range mode for PR CI. `ALINT_BASE_SHA` is exported in the workflow from
+# `github.event.pull_request.base.sha`; on push-trigger or local runs where
+# the env var is unset, falls back to `origin/main`.
+- id: pr-conventional-commits
   kind: git_commit_message
-  pattern: '^fix:'
-  requires_body: true
+  pattern: '^(feat|fix|chore|docs|refactor|test|build|ci|perf|style|revert)(\(.+\))?!?: '
+  subject_max_length: 72
+  since: ${ALINT_BASE_SHA:-origin/main}
   level: error
-  message: "fix: commits must explain what was broken in the body."
 ```
 
-Outside a git repo, with no commits yet, or when `git` isn't on `PATH`, the rule silently no-ops. Pairs naturally with `alint check --changed` for per-PR enforcement: every PR's tip commit gets validated automatically.
+#### `since:` semantics
+
+`since:` accepts anything `git rev-parse` resolves: a 40-char or abbreviated SHA, a branch (`origin/main`), a tag (`v1.2.3`), or a relative ref (`HEAD~5`). The rule walks `<since>..HEAD` oldest-first, validates each commit, and emits one violation per failing commit with the short SHA + a subject snippet so you know which to amend.
+
+POSIX-style env-var interpolation is supported:
+
+- `${VAR}` substitutes the value of `VAR`. Unset (or empty) is a hard error with a CI-friendly hint.
+- `${VAR:-default}` substitutes `VAR`, or `default` when `VAR` is unset or empty.
+
+The GitHub Actions double-brace template syntax `${{ ... }}` is **not** interpolated by alint; it has to be rendered by Actions before the YAML is read, which only works in workflow files, not in `.alint.yml`. Use the single-brace `${VAR}` form and export the var in a workflow step.
+
+#### `include_merges:`
+
+In range mode, merge commits are skipped by default (`include_merges: false`). Merge subjects in PR contexts are typically `actions/checkout`-generated or maintainer-resolved and uninteresting. Set `include_merges: true` to lint them too. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error.
+
+#### Failure modes
+
+- **No git, or `git` not on PATH**: silent no-op. The rule's intent only makes sense inside a git repo.
+- **`since:` ref doesn't resolve**: hard error with a shallow-clone hint. The common cause is `actions/checkout@v4` with its default `fetch-depth: 1`, which doesn't fetch the base ref's commits. Use `fetch-depth: 0` to fetch full history.
+- **Range is empty** (`since` == HEAD on a force-push, or no non-merge commits): silent no-op. No commits, no policy to apply.
+
+#### GitHub Actions PR-validation recipe
+
+```yaml
+# .github/workflows/lint.yml
+name: lint
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  alint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Range mode walks <base>..HEAD. fetch-depth: 0 makes
+          # both refs reachable; the default depth of 1 leaves
+          # the base ref out of local objects and the rule errors.
+          fetch-depth: 0
+      - name: alint check
+        env:
+          ALINT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        uses: asamarts/alint@v0.9.20
+```
 
 ### `git_blame_age`
 

--- a/docs/site/integrations/github-actions.md
+++ b/docs/site/integrations/github-actions.md
@@ -56,3 +56,43 @@ For supply-chain hygiene (and to satisfy alint's own [`ci/github-actions@v1`](/d
 ```
 
 Look up the SHA on the [tag page](https://github.com/asamarts/alint/tags).
+
+## Validate PR commits with `git_commit_message`
+
+`actions/checkout@v4` on a `pull_request` trigger checks out a synthetic merge commit, not the PR's tip. The HEAD subject is then auto-generated (`Merge <sha> into <sha>`) and trips any `git_commit_message` rule applied to HEAD only. To validate the PR's own commits instead, use the rule's `since:` option together with `actions/checkout`'s full-history fetch:
+
+```yaml
+# .github/workflows/lint.yml
+name: lint
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  alint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # `since:` walks <base>..HEAD. fetch-depth: 0 makes the
+          # base ref reachable; the default depth of 1 leaves it
+          # out of local objects and the rule will hard-fail with
+          # a shallow-clone hint.
+          fetch-depth: 0
+      - name: alint check
+        env:
+          ALINT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        uses: asamarts/alint@v0.9.20
+```
+
+The rule in `.alint.yml`:
+
+```yaml
+- id: pr-conventional-commits
+  kind: git_commit_message
+  pattern: '^(feat|fix|chore|docs|refactor|test|build|ci|perf|style|revert)(\(.+\))?!?: '
+  subject_max_length: 72
+  since: ${ALINT_BASE_SHA:-origin/main}
+  level: error
+```
+
+The `${ALINT_BASE_SHA:-origin/main}` default makes the same config work locally too: when you run `alint check` on your feature branch without setting the env var, the rule falls back to `origin/main` and validates everything since you branched. See the [`git_commit_message` reference](/docs/rules/git-hygiene/git_commit_message/) for the full options surface.

--- a/schemas/v1/config.json
+++ b/schemas/v1/config.json
@@ -918,7 +918,7 @@
     },
 
     "rule_git_commit_message": {
-      "description": "Validate HEAD's commit message against shape rules: regex, max subject length, body required. At least one of `pattern:` / `subject_max_length:` / `requires_body: true` must be set. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops.",
+      "description": "Validate one or more commit messages against shape rules: regex, max subject length, body required. With `since:` unset, only HEAD is checked. With `since:` set to a ref, every commit in `<since>..HEAD` is checked (oldest first, merge commits excluded by default); right shape for PR-trigger workflows where HEAD is a synthetic `actions/checkout` merge commit. At least one of `pattern:` / `subject_max_length:` / `requires_body: true` must be set. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
       "type": "object",
       "properties": {
         "kind": { "const": "git_commit_message" },
@@ -934,7 +934,16 @@
         "requires_body": {
           "type": "boolean",
           "default": false,
-          "description": "When true, the message must have a non-empty body — at least one line of content after the subject's blank-line separator."
+          "description": "When true, the message must have a non-empty body, that is, at least one line of content after the subject's blank-line separator."
+        },
+        "since": {
+          "type": "string",
+          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does: SHA (full or abbreviated), branch (`origin/main`), tag (`v1.2.3`), or relative ref (`HEAD~5`). Supports POSIX `${VAR}` and `${VAR:-default}` env-var interpolation so CI can pass a SHA via an env var (e.g. `since: ${ALINT_BASE_SHA:-origin/main}` with `ALINT_BASE_SHA` exported in a workflow step from `github.event.pull_request.base.sha`). The GitHub Actions double-brace template syntax `${{ ... }}` is NOT interpolated by alint."
+        },
+        "include_merges": {
+          "type": "boolean",
+          "default": false,
+          "description": "When validating a range (`since:` set), include merge commits. Defaults to `false` because merge commits in PR contexts are typically the synthetic merge `actions/checkout` produces (with an auto-generated subject the rule would always flag) or maintainer-resolved merges from the base branch. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error."
         }
       },
       "anyOf": [


### PR DESCRIPTION
## Summary

Closes #26. Adds a `since:` option to the `git_commit_message` rule so it
can validate every commit in `<since>..HEAD` instead of only HEAD. The
HEAD-only behaviour broke `pull_request`-triggered CI because
`actions/checkout` checks out a synthetic merge commit whose
auto-generated subject failed every shape rule applied to HEAD.

- **`since:`** accepts any `git rev-parse`-able ref (SHA, branch, tag, `HEAD~N`).
- **`${VAR}` / `${VAR:-default}`** env-var interpolation so the typical
  CI shape is `since: ${ALINT_BASE_SHA:-origin/main}` with
  `ALINT_BASE_SHA=${{ github.event.pull_request.base.sha }}` exported in
  the workflow.
- **`include_merges`** (default `false`) skips merge commits.
  Combining `include_merges: true` with no `since:` is a load-time error.
- **Per-commit violations** carry the abbreviated SHA + a subject
  snippet, so users know which commit to amend.
- **Shallow-clone gotcha** surfaces as a hard error with a
  `fetch-depth: 0` hint rather than silently no-op'ing on the empty
  range.

## Test plan

- [x] `cargo test --workspace` — passes (35 new unit / integration tests, all green)
- [x] 5 new e2e scenarios under `crates/alint-e2e/scenarios/check/git/`
- [x] `ci/scripts/preflight.sh` — passes (fmt + clippy + doc + xtask docs-export + dogfood + version-pins)
- [x] New `.github/workflows/issue-26-e2e.yml` exercises the rule end-to-end against a real synthetic-merge fixture and (when triggered by `pull_request`) against this PR's own commits.

The e2e workflow proves three things in sequence:

1. HEAD-only mode FAILS on a synthetic merge commit (demonstrates the bug).
2. Range mode with `since: ${ALINT_BASE_SHA}` PASSES against the
   feature-branch commits (demonstrates the fix).
3. Range mode with a non-existent ref hard-fails with the
   `fetch-depth: 0` hint (covers the shallow-clone gotcha that's the
   most common CI cause).

## Out of scope

- Bundled `git/conventional-commits@v1` ruleset (now unblocked; can ship
  as a follow-up).
- CLI flag override for `since:`. The `${VAR}` interpolation already
  gives the user a way to vary the ref per-invocation without editing
  `.alint.yml`; a separate flag is deferred.