### PR TITLE
Release v0.9.23 — GitHub Action pinning + release-pipeline hardening (review before tag)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.23] — 2026-05-17 (GitHub Action pinning + release-pipeline hardening)
+
+Distribution + release-reliability release. The headline is the
+GitHub Action change: a pinned action ref now pins the installed
+binary, so `uses: asamarts/alint@vX.Y.Z` is reproducible with zero
+release-time maintenance. Bundled in: the `bump-version.sh`
+`Cargo.lock` refresh that recovers the v0.9.22 release-day failure
+mode, a cargo-deny supply-chain gate, the generated `/docs/rules/`
+index corrected to the canonical 70-rule-kinds figure, and a
+GitHub Action provenance hardening. No `.alint.yml` schema,
+output-format, or rule-engine changes; safe upgrade for every
+consumer except the single Action-pinning edge case called out
+under **Changed** below.
+
+### Added
+
+- **cargo-deny license / supply-chain gate (`deny.toml`).** A
+  tailored `deny.toml` plus `ci/scripts/deny.sh` enforce the
+  dependency graph's license, ban, and source policy. `licenses.allow`
+  is the exact permissive set present in the graph (not a blanket
+  allow): an LGPL-2.1 dependency that is OR-satisfied by MIT/Apache
+  is not separately allowed, and MPL-2.0 is a scoped single-crate
+  exception so a future MPL dependency fails the check. Wildcard
+  version requirements are banned and duplicate versions warn;
+  sources are restricted to crates.io; advisories stay advisory-only
+  (mirroring `audit.sh`). Wired as a `deny` job in `ci.yml` and into
+  the `release.yml` preflight, so a license or supply-chain
+  violation blocks a release. Build-time control only; no effect on
+  the published binary or library.
+
 ### Changed
 
 - **GitHub Action: a pinned action ref now pins the binary.** When
@@ -39,6 +69,33 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `Cargo.lock` refresh; step 4 stage list now includes
   `Cargo.lock` explicitly; new "Why `Cargo.lock` is in the stage
   list" note under step 4 captures the recurrence rationale.
+
+### Fixed
+
+- **Generated `/docs/rules/` index now reports the canonical "70
+  rule kinds".** The rules master-index headline counted only the
+  60 distinct documented behaviours and excluded the 10 short-name
+  aliases, contradicting `/docs/about/`, the README (corrected in
+  v0.9.22), the JSON schema, and the alint.org marketing surfaces,
+  all of which say 70. The generator (`xtask/src/docs_export.rs`)
+  now derives the count as behaviours + aliases, so the page reads
+  "70 rule kinds across 13 families (60 distinct rule behaviours
+  plus 10 short-name aliases)". Documentation output only; no
+  engine or schema change.
+
+### Security
+
+- **GitHub Action: an empty `action_ref` no longer silently falls
+  back to `main`.** Previously, if `github.action_ref` resolved
+  empty the Action fetched `install.sh` from `main`, silently
+  defeating the supply-chain-pin guarantee for a consumer who
+  pinned the Action. The fallback to `main` is now restricted to
+  the `asamarts/alint` local-checkout self-test path; for any
+  external consumer an empty ref is a hard error rather than an
+  implicit `main` fetch. Restores the provenance guarantee that
+  pinning `uses: asamarts/alint@<ref>` fetches the install script
+  from that exact ref. Pairs with the binary-pin change under
+  **Changed**.
 
 ## [0.9.22] — 2026-05-14 (doc-drift cleanup + prevention automation)
 
@@ -4738,7 +4795,8 @@ Initial release. MVP.
   verification.
 - Dogfood `.alint.yml` exercising the tool against its own repo.
 
-[Unreleased]: https://github.com/asamarts/alint/compare/v0.9.22...HEAD
+[Unreleased]: https://github.com/asamarts/alint/compare/v0.9.23...HEAD
+[0.9.23]: https://github.com/asamarts/alint/compare/v0.9.22...v0.9.23
 [0.9.22]: https://github.com/asamarts/alint/compare/v0.9.21...v0.9.22
 [0.9.21]: https://github.com/asamarts/alint/compare/v0.9.20...v0.9.21
 [0.9.20]: https://github.com/asamarts/alint/compare/v0.9.19...v0.9.20

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "alint"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "alint-core",
  "alint-dsl",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "alint-bench"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "alint-core",
  "alint-dsl",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "alint-core"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "globset",
  "ignore",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "alint-dsl"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "alint-core",
  "alint-rules",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "alint-e2e"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "alint-core",
  "alint-dsl",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "alint-output"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "alint-core",
  "anstream",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "alint-rules"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "alint-core",
  "content_inspector",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "alint-testkit"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "alint-core",
  "alint-dsl",
@@ -3013,7 +3013,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "alint-bench",
  "alint-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 default-members = ["crates/alint"]
 
 [workspace.package]
-version = "0.9.22"
+version = "0.9.23"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Bundled rulesets are gated by ecosystem facts (`has_rust`, `has_node`, `has_pyth
 - **8 output formats**: `human`, `json` (stable schema), `sarif` (GitHub Code Scanning), `github` (inline PR annotations), `markdown` (PR comments), `junit` (CI test reports), `gitlab` (Code Quality), `agent` (LLM-shaped JSON with `agent_instruction` per violation).
 - **JSON Schemas**: config at [`schemas/v1/config.json`](schemas/v1/config.json) for editor autocomplete; report shapes at [`schemas/v1/check-report.json`](schemas/v1/check-report.json) and [`schemas/v1/fix-report.json`](schemas/v1/fix-report.json) for downstream tooling.
 - **Telemetry-free.** No network access at runtime, except the user-explicit `extends: https://...` URLs (SRI-pinned). Reproducible builds (`Cargo.lock` committed, pinned toolchain). See [SECURITY.md](SECURITY.md) for the threat model.
-- **Official GitHub Action**: [`asamarts/alint@v0.9.22`](https://github.com/asamarts/alint).
+- **Official GitHub Action**: [`asamarts/alint@v0.9.23`](https://github.com/asamarts/alint).
 
 ## Where alint shines
 
@@ -134,7 +134,7 @@ A distroless multi-arch image (`linux/amd64`, `linux/arm64`) is published to ghc
 docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:latest
 
 # Pin to an exact version:
-docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.9.22 check
+docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.9.23 check
 ```
 
 The image runs as the distroless `nonroot` user (UID 65532); host files must be world-readable. To apply fixes and preserve host ownership, pass `-u`:
@@ -143,7 +143,7 @@ The image runs as the distroless `nonroot` user (UID 65532); host files must be 
 docker run --rm -u $(id -u):$(id -g) -v "$PWD:/repo" ghcr.io/asamarts/alint:latest fix
 ```
 
-Also published: `:<major>.<minor>` (e.g. `:0.9`) and the raw git tag (`:v0.9.22`).
+Also published: `:<major>.<minor>` (e.g. `:0.9`) and the raw git tag (`:v0.9.23`).
 
 ## Quick start
 
@@ -258,15 +258,15 @@ All rulesets ship with non-blocking defaults (`info` / `warning` for recommendat
 Inline PR annotations (default):
 
 ```yaml
-- uses: asamarts/alint@v0.9.22
+- uses: asamarts/alint@v0.9.23
 ```
 
 All inputs (all optional):
 
 ```yaml
-- uses: asamarts/alint@v0.9.22
+- uses: asamarts/alint@v0.9.23
   with:
-    version: v0.9.22        # alint release tag (default: latest)
+    version: v0.9.23        # alint release tag (default: latest)
     path: .                # directory to lint (default: .)
     format: github         # human | json | sarif | github | markdown | junit | gitlab (default: github)
     config: |              # extra config path(s), one per line
@@ -278,7 +278,7 @@ All inputs (all optional):
 Upload findings to GitHub Code Scanning:
 
 ```yaml
-- uses: asamarts/alint@v0.9.22
+- uses: asamarts/alint@v0.9.23
   id: alint
   with:
     format: sarif
@@ -296,7 +296,7 @@ Add to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/asamarts/alint
-    rev: v0.9.22
+    rev: v0.9.23
     hooks:
       - id: alint
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -188,3 +188,22 @@ Major (`<x+1>.0.0`):
   relevant once external plugin authors exist; today the trait is
   effectively crate-private).
 - `Engine` API breaking changes for `alint-core` consumers.
+
+Scope:
+- The contract covers the **observable product surface** only: the
+  `.alint.yml` schema, the CLI (flags, subcommands, exit codes),
+  and the machine-readable output formats. The `alint-core` public
+  API joins at v1.0 (pre-1.0 the engine API + `Rule` trait are
+  effectively crate-private; see the `publish = false` members).
+- The GitHub Action wrapper (`action.yml`, incl. its input
+  defaults and ref/binary-pin behaviour), `install.sh`, the
+  npm / Homebrew / Docker shims, benchmark numbers, and the docs
+  site are **integration surface, not the contract**: changes
+  there are **patch** even when they warrant an "Action required
+  only if ..." edge-case caveat (e.g. the v0.9.23 `version:`-default
+  shift: a patch with a caveat, not a minor).
+- Tie-breaker when unsure: does an unchanged `.alint.yml`, run
+  with the same CLI invocation, still produce the same findings
+  and the same machine-readable output? Only a "no" forces
+  minor/major; an integration-default shift with an upgrade note
+  stays patch.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,7 +62,7 @@ Out of scope (report directly to upstream):
 Published advisories live at
 https://github.com/asamarts/alint/security/advisories.
 
-No advisories published as of the v0.9.22 release.
+No advisories published as of the v0.9.23 release.
 
 ## Threat model
 

--- a/docs/site/getting-started/installation.md
+++ b/docs/site/getting-started/installation.md
@@ -33,7 +33,7 @@ A distroless multi-arch image (`linux/amd64`, `linux/arm64`) is published to ghc
 docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:latest
 
 # Pin to an exact version:
-docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.9.22 check
+docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.9.23 check
 ```
 
 The image runs as the distroless `nonroot` user (UID 65532); host files must be world-readable. To apply fixes and preserve host ownership, pass `-u`:
@@ -42,7 +42,7 @@ The image runs as the distroless `nonroot` user (UID 65532); host files must be 
 docker run --rm -u $(id -u):$(id -g) -v "$PWD:/repo" ghcr.io/asamarts/alint:latest fix
 ```
 
-Also published: `:<major>.<minor>` (e.g. `:0.9`) and the raw git tag (`:v0.9.22`).
+Also published: `:<major>.<minor>` (e.g. `:0.9`) and the raw git tag (`:v0.9.23`).
 
 ## crates.io
 

--- a/docs/site/integrations/docker.md
+++ b/docs/site/integrations/docker.md
@@ -18,10 +18,10 @@ The image's `WORKDIR` is `/repo`, so the bind-mount lets alint see your repo as 
 ## Pin to a version
 
 ```bash
-docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.9.22 check
+docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.9.23 check
 ```
 
-Tags published per release: the exact git tag (`:v0.9.22`), the bare semver (`:0.9.22`), the `<major>.<minor>` channel (`:0.9`), and `:latest`.
+Tags published per release: the exact git tag (`:v0.9.23`), the bare semver (`:0.9.23`), the `<major>.<minor>` channel (`:0.9`), and `:latest`.
 
 ## Apply auto-fixes
 
@@ -46,7 +46,7 @@ For one-shot lint runs in CI systems that prefer containers over running custom 
 ```yaml
 # Generic CI (GitLab, Drone, BuildKite, …)
 script:
-  - docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.9.22 check --format json
+  - docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.9.23 check --format json
 ```
 
 For GitHub Actions specifically, the [official Action](/docs/integrations/github-actions/) is more ergonomic.

--- a/docs/site/integrations/github-actions.md
+++ b/docs/site/integrations/github-actions.md
@@ -10,7 +10,7 @@ The official Action wraps the `install.sh` flow plus alint invocation into one s
 ## Inline PR annotations (default)
 
 ```yaml
-- uses: asamarts/alint@v0.9.22
+- uses: asamarts/alint@v0.9.23
 ```
 
 This runs `alint check --format github` against `.` and emits findings as `::error::` / `::warning::` workflow commands, which GitHub renders inline on the PR.
@@ -18,9 +18,9 @@ This runs `alint check --format github` against `.` and emits findings as `::err
 ## Inputs (all optional)
 
 ```yaml
-- uses: asamarts/alint@v0.9.22
+- uses: asamarts/alint@v0.9.23
   with:
-    version: v0.9.22        # alint release tag (default: latest)
+    version: v0.9.23        # release tag; omit to follow the pinned action ref
     path: .                # directory to lint (default: .)
     format: github         # human | json | sarif | github (default)
     config: |              # extra config path(s), one per line
@@ -34,7 +34,7 @@ This runs `alint check --format github` against `.` and emits findings as `::err
 Use `format: sarif` and pipe to the standard upload action:
 
 ```yaml
-- uses: asamarts/alint@v0.9.22
+- uses: asamarts/alint@v0.9.23
   id: alint
   with:
     format: sarif
@@ -52,7 +52,7 @@ Use `format: sarif` and pipe to the standard upload action:
 For supply-chain hygiene (and to satisfy alint's own [`ci/github-actions@v1`](/docs/bundled-rulesets/) bundled ruleset), pin the action to a commit SHA:
 
 ```yaml
-- uses: asamarts/alint@<40-char-sha>  # v0.9.22
+- uses: asamarts/alint@<40-char-sha>  # v0.9.23
 ```
 
 Look up the SHA on the [tag page](https://github.com/asamarts/alint/tags).
@@ -81,7 +81,7 @@ jobs:
       - name: alint check
         env:
           ALINT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        uses: asamarts/alint@v0.9.22
+        uses: asamarts/alint@v0.9.23
 ```
 
 The rule in `.alint.yml`:

--- a/docs/site/integrations/pre-commit.md
+++ b/docs/site/integrations/pre-commit.md
@@ -10,7 +10,7 @@ alint ships a [pre-commit](https://pre-commit.com/) hook definition. Add it to y
 ```yaml
 repos:
   - repo: https://github.com/asamarts/alint
-    rev: v0.9.22
+    rev: v0.9.23
     hooks:
       - id: alint
 ```
@@ -32,7 +32,7 @@ Pin to a tagged release. Updating the `rev:` is how you upgrade alint:
 ```yaml
 repos:
   - repo: https://github.com/asamarts/alint
-    rev: v0.9.22
+    rev: v0.9.23
     hooks:
       - id: alint
         # Pass extra args here if you need to:

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asamarts/alint",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "description": "Language-agnostic linter for repository structure, file existence, filename conventions, and file content rules. This package downloads and wraps the platform-matched native alint binary.",
   "keywords": ["lint", "linter", "repository", "filename", "policy", "compliance"],
   "homepage": "https://github.com/asamarts/alint",


### PR DESCRIPTION
## Release v0.9.23 — review before tagging

Cuts **v0.9.23** (a patch per `RELEASING.md` Release version policy:
distribution / release-tooling / supply-chain hardening; no
`.alint.yml` schema, CLI, or output-format change). Prepared and
**held for review** — no tag has been placed.

### Commits (2 — do **not** squash)

| Commit | Purpose | In v0.9.23 changelog? |
|---|---|---|
| `42be8a7a` `chore(release): bump workspace to 0.9.23` | The release itself | ✅ yes — this is the release commit |
| `609185b9` `docs(releasing): scope the SemVer contract explicitly` | Codifies the patch-vs-minor ruling this release required, so it can't recur | ❌ no — contributor-doc, below the adopter waterline (deliberate) |

Kept as two commits on purpose. Please merge with a **merge
commit** (or rebase-merge), **not squash**, so `42be8a7a`
survives as a taggable point whose tree == what was reviewed and
preflighted.

### What's in v0.9.23

- **`bump-version.sh 0.9.23`**: `Cargo.toml`, `Cargo.lock`
  (auto-refreshed — first live exercise of the v0.9.22 incident
  fix `3fba1039`), `npm/package.json`, 6 install snippets.
  Dep-floor pins correctly untouched.
- **CHANGELOG** composed per `RELEASING.md` step 2: `## [0.9.23] —
  2026-05-17` with headline summary; **Added** (cargo-deny gate),
  **Changed** (the 3 `[Unreleased]` entries verbatim), **Fixed**
  (generated `/docs/rules/` "70 rule kinds"), **Security**
  (`action.yml` empty-ref no longer falls back to `main`). Empty
  `## [Unreleased]` re-seeded. Scope (3 existing + 3 user-visible)
  was an explicit decision; the two pure CI-plumbing commits
  (`52027805`, `c0f173c9`) intentionally left below the waterline.
- **Doc-consistency fix**: `docs/site/integrations/github-actions.md`
  said `(default: latest)`, which would have shipped contradicting
  this release's own binary-pin Changed entry. Corrected to "omit
  to follow the pinned action ref".

### Verification

- `cargo clean` then `ci/scripts/preflight.sh` (clean cache, the
  tag-push case where warm-cache masks CI failures): **all 7 gates
  green** — fmt, clippy (pedantic), test, doc (`-D warnings`),
  version-pins, dep-floors, dogfood. Exit 0.
- `609185b9` separately re-ran `dogfood.sh` (21/21); alint's own
  `top-level-docs-no-em-dash` rule caught em-dashes in the first
  RELEASING.md draft — fixed to pure ASCII.
- The push of this branch re-ran the full pre-push preflight on a
  clean working tree and passed.

### After merge — cutting the release

`RELEASING.md` step 4's bare `git tag v0.9.23` tags `HEAD`. With a
merge commit, **tag the release commit explicitly** so the v0.9.23
artifacts == the reviewed tree and match the changelog exactly:

```
git checkout main && git pull
git tag v0.9.23 <SHA of 42be8a7a on main after merge>
git push origin v0.9.23
```

The tag push fires `release.yml`: cross-platform build matrix (the
exact step that failed on v0.9.22 — this release is the first live
test of its fix), crates.io (`alint` + `alint-core`, yank-only),
Docker/GHCR, npm, Homebrew, docs-bundle → alint.org, and
`bench-record` (~3.5 hr, opens a separate PR). `cargo audit` is
not in preflight — `bash ci/scripts/audit.sh` is the optional
belt-and-suspenders before tagging.

### Deferred (tracked, not in this PR)

- `docs/design/ROADMAP.md` "Latest release" prose (hand-written;
  `bump-version.sh` followup + `RELEASING.md` stage list both
  exclude it from the release commit) — do after the tag is pushed.

### Review checklist

- [ ] `42be8a7a` diff: version bump + changelog composition + the
      github-actions.md doc fix
- [ ] CHANGELOG `[0.9.23]` reads correctly; scope (3 + 3) is what
      you want
- [ ] `609185b9` RELEASING.md "Scope:" block states the contract
      boundary the way you want it codified
- [ ] Merge **without squash**; then tag `42be8a7a`'s post-merge
      SHA, not `HEAD`
