### PR TITLE
feat: spec-driven development foundations (Phase 0 ADRs + Phase 1 schema-from-types)

### DIFF
--- a/.alint.yml
+++ b/.alint.yml
@@ -3,6 +3,13 @@
 
 version: 1
 
+extends:
+  # Dogfood alint's own ADR ruleset on alint's own decision records under
+  # docs/adr/. Every docs/adr/*.md is a numbered, MADR-shaped file (the
+  # template lives at 0000-template.md and is itself a valid ADR shape), so
+  # this stays green. See ADR-0001 and docs/design/spec-driven-development.md.
+  - url: "alint://bundled/docs/adr@v1"
+
 ignore:
   - "target/**"
   # Test fixtures deliberately contain shapes that violate our own

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,6 @@ jobs:
     if: >-
       !cancelled() && !failure()
       && needs.changes.outputs.rust == 'true'
-      && github.event_name == 'push'
     runs-on: [self-hosted, linux, alint]
     steps:
       - uses: actions/checkout@v6
@@ -148,6 +147,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: ci-docs
+      # Runs on pull_request too (not just push): docs.sh carries the
+      # `gen-schema --check`, `docs-export --check`, and rustdoc gates, which
+      # are load-bearing for schema/parser correctness and must catch drift on a
+      # PR, not only post-merge.
       - run: ci/scripts/docs.sh
 
   dogfood:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "jsonschema",
  "regex",
  "roxmltree",
+ "schemars",
  "serde",
  "serde_json",
  "serde_json_path",
@@ -758,6 +759,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -2215,6 +2222,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,6 +2282,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3401,6 +3444,7 @@ dependencies = [
  "alint-rules",
  "anyhow",
  "clap",
+ "jsonschema",
  "serde",
  "serde_json",
  "serde_yaml_ng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 content_inspector = "0.2"
 anyhow = "1"
 jsonschema = { version = "0.46", default-features = false }
+schemars = "1"
 criterion = "0.8"
 rand = "0.10"
 rand_chacha = "0.10"

--- a/ci/scripts/docs.sh
+++ b/ci/scripts/docs.sh
@@ -14,3 +14,12 @@ RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
 # refuses --help fails CI rather than the alint.org build.
 echo "==> Running xtask docs-export --check"
 cargo run -q -p xtask -- docs-export --check
+
+# `xtask gen-schema --check` regenerates schemas/v1/config.json (+ the in-crate
+# copy) from the Rust option structs (schemars) for the migrated rule kinds and
+# fails if the committed schema drifted from the types that parse configs. The
+# regenerate-and-diff gate for the schema-from-types keystone (ADR-0001 /
+# docs/design/spec-driven-development.md). Run `cargo run -p xtask -- gen-schema`
+# to refresh after changing a migrated kind's Options struct.
+echo "==> Running xtask gen-schema --check"
+cargo run -q -p xtask -- gen-schema --check

--- a/crates/alint-dsl/schemas/v1/config.json
+++ b/crates/alint-dsl/schemas/v1/config.json
@@ -1,5 +1,94 @@
 {
   "$defs": {
+    "Algorithm": {
+      "enum": [
+        "sha256",
+        "sha512"
+      ],
+      "type": "string"
+    },
+    "Comparator": {
+      "oneOf": [
+        {
+          "const": "lexical",
+          "description": "Rust `str` `Ord` — byte-wise over the UTF-8.",
+          "type": "string"
+        },
+        {
+          "const": "lexical-ci",
+          "description": "ASCII-case-insensitive lexical.",
+          "type": "string"
+        },
+        {
+          "const": "numeric",
+          "description": "Leading-integer order; entries without a leading integer\nfall back to `lexical` so a mixed block degrades\npredictably rather than panicking.",
+          "type": "string"
+        }
+      ]
+    },
+    "FilesFrom": {
+      "oneOf": [
+        {
+          "const": "none",
+          "description": "One violation for the whole invocation (default).",
+          "type": "string"
+        },
+        {
+          "const": "stdout",
+          "description": "Parse the checker's stdout for the offender list.",
+          "type": "string"
+        },
+        {
+          "const": "stderr",
+          "description": "Parse the checker's stderr for the offender list.",
+          "type": "string"
+        }
+      ]
+    },
+    "Format": {
+      "oneOf": [
+        {
+          "const": "contains",
+          "description": "The digest must appear as a substring anywhere in `target`.",
+          "type": "string"
+        },
+        {
+          "const": "sums-line",
+          "description": "`target` must carry a `sha256sum`-style `<hex> [*]<path>`\nline whose path token is the source's path.",
+          "type": "string"
+        }
+      ]
+    },
+    "Language": {
+      "enum": [
+        "auto",
+        "rust",
+        "typescript",
+        "javascript",
+        "python",
+        "go",
+        "java",
+        "c",
+        "cpp",
+        "ruby",
+        "shell"
+      ],
+      "type": "string"
+    },
+    "StyleName": {
+      "enum": [
+        "tabs",
+        "spaces"
+      ],
+      "type": "string"
+    },
+    "TargetName": {
+      "enum": [
+        "lf",
+        "crlf"
+      ],
+      "type": "string"
+    },
     "case_convention": {
       "description": "Case convention. Aliases like PascalCase / pascal / pascal-case / UpperCamelCase all resolve to the same canonical form.",
       "enum": [
@@ -597,7 +686,7 @@
       "description": "Shell out to an external CLI per matched file. argv[0] is the program; remaining tokens support path-template substitution (`{path}`, `{dir}`, `{stem}`, `{ext}`, `{basename}`, `{parent_name}`). Working dir = repo root; stdin = /dev/null. Env: ALINT_PATH, ALINT_ROOT, ALINT_RULE_ID, ALINT_LEVEL, plus ALINT_VAR_<NAME> per `vars:` and ALINT_FACT_<NAME> per resolved fact. Verdict: exit 0 = pass; non-zero = one violation whose message is the (truncated) stdout+stderr. Trust-gated: only allowed in the user's top-level config (rejected at load-time when introduced via `extends:` or a bundled ruleset).",
       "properties": {
         "command": {
-          "description": "Argv tokens. The first token is the program (looked up via PATH if it's a bare name); remaining tokens accept `{path}` and friends.",
+          "description": "Argv tokens. The first token is the program (looked up via PATH if it's\na bare name); remaining tokens accept `{path}` and friends.",
           "items": {
             "type": "string"
           },
@@ -611,9 +700,14 @@
           "$ref": "#/$defs/paths_spec"
         },
         "timeout": {
-          "description": "Per-file timeout in seconds. Default 30. Past this, the child is killed and a violation reports the timeout.",
+          "default": null,
+          "description": "Per-file timeout in seconds. Default 30. Past this, the child is killed\nand a violation reports the timeout.",
+          "format": "uint64",
           "minimum": 1,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
       "required": [
@@ -626,7 +720,7 @@
       "description": "Run a user-declared formatter/checker in its --check (idempotence) mode once: exit 0 = the tree is formatter-clean (silent), non-zero = violation(s). alint never runs a mutating formatter and never writes the tree (the sibling of generated_file_fresh; same trust tier as the command rule — trust-gated to the user's own top-level config). With `files_from` (+ optional `files_pattern`) the tool's offender list is parsed into one violation per file. Single-shot, opt-in.",
       "properties": {
         "command": {
-          "description": "Checker argv (no shell), run in its --check / idempotence mode; exit 0 = clean.",
+          "description": "Checker argv (no shell), run in its --check / idempotence mode; exit\n0 = clean.",
           "items": {
             "type": "string"
           },
@@ -634,28 +728,37 @@
           "type": "array"
         },
         "files_from": {
-          "description": "On failure, parse this stream into per-file violations (default: none = one violation for the whole invocation).",
-          "enum": [
-            "none",
-            "stdout",
-            "stderr"
-          ]
+          "$ref": "#/$defs/FilesFrom",
+          "description": "On failure, parse this stream into per-file violations (default: none =\none violation for the whole invocation)."
         },
         "files_pattern": {
-          "description": "Regex whose capture group 1 is a file path, applied per output line (requires `files_from`; omit for bare-path listers).",
-          "type": "string"
+          "default": null,
+          "description": "Regex whose capture group 1 is a file path, applied per output line\n(requires `files_from`; omit for bare-path listers).",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "kind": {
           "const": "command_idempotent"
         },
         "timeout": {
-          "description": "Checker timeout in seconds (default 120). On timeout the child is killed and one violation is emitted.",
+          "default": null,
+          "description": "Checker timeout in seconds (default 120). On timeout the child is killed\nand one violation is emitted.",
+          "format": "uint64",
           "minimum": 1,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "workdir": {
+          "default": null,
           "description": "Checker cwd, relative to the lint root (default: lint root).",
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -670,26 +773,13 @@
           "const": "commented_out_code"
         },
         "language": {
-          "default": "auto",
-          "description": "Comment-marker set to use. `auto` (default) infers from each file's extension. Files with extensions the resolver doesn't recognise are silently skipped.",
-          "enum": [
-            "auto",
-            "rust",
-            "typescript",
-            "javascript",
-            "python",
-            "go",
-            "java",
-            "c",
-            "cpp",
-            "ruby",
-            "shell"
-          ],
-          "type": "string"
+          "$ref": "#/$defs/Language",
+          "description": "`auto` (default) infers the comment-marker set from\neach file's extension. Explicit override useful for\nembedded DSLs or cases where the extension lies."
         },
         "min_lines": {
           "default": 3,
-          "description": "Minimum consecutive comment-line count for a block to be considered. Default 3 — 1-2 line comments are almost always prose.",
+          "description": "Minimum consecutive comment-line count for a block to\nbe considered. 1-2 line comments are almost always\nprose; 3+ starts looking like dead code. Default 3.",
+          "format": "uint",
           "minimum": 2,
           "type": "integer"
         },
@@ -698,13 +788,15 @@
         },
         "skip_leading_lines": {
           "default": 30,
-          "description": "Skip blocks whose first line is at or before this line number. Default 30 — covers typical license headers without false-positive flagging them as commented-out code.",
+          "description": "Skip the first N lines of any file. Defaults to 30 to\npass over license headers without false-positive\nflagging them as commented-out code.",
+          "format": "uint",
           "minimum": 0,
           "type": "integer"
         },
         "threshold": {
           "default": 0.5,
-          "description": "Density floor for code-shapedness. Higher = stricter. Default 0.5 sits at the midpoint between obvious-prose (0.0) and obvious-code (1.0); lower it to widen the catch (more FPs), raise it to narrow.",
+          "description": "Token-density floor (0.0-1.0). Higher = stricter (only\nthe most code-shaped blocks fire). Default 0.5.",
+          "format": "double",
           "maximum": 1.0,
           "minimum": 0.0,
           "type": "number"
@@ -1360,6 +1452,7 @@
           "$ref": "#/$defs/paths_spec"
         },
         "sha256": {
+          "description": "Expected SHA-256 in lowercase hex (64 chars). Accepting\nuppercase and the `sha256:` prefix keeps the field forgiving.",
           "pattern": "^(sha256:)?[0-9a-fA-F]{64}$",
           "type": "string"
         }
@@ -1403,7 +1496,8 @@
       "description": "Every byte in every file in scope must be < 0x80 (pure ASCII), except codepoints listed in `allow:`. Stricter than file_is_text; check-only — auto-replacement for non-ASCII bytes would silently lose meaning. With `allow:` the file is decoded as UTF-8 and checked per character; without it, the strict byte-level fast path is used.",
       "properties": {
         "allow": {
-          "description": "Permitted non-ASCII codepoints — each entry a single character (e.g. \"ö\"), a `U+XXXX` codepoint, or a `U+XXXX-U+YYYY` inclusive range.",
+          "default": [],
+          "description": "Permitted non-ASCII codepoints - each a single character\n(e.g. \"o-umlaut\"), a `U+XXXX` codepoint, or a `U+XXXX-U+YYYY`\ninclusive range.",
           "items": {
             "type": "string"
           },
@@ -2163,16 +2257,18 @@
           "$ref": "#/$defs/paths_spec"
         },
         "style": {
-          "enum": [
-            "tabs",
-            "spaces"
-          ],
-          "type": "string"
+          "$ref": "#/$defs/StyleName",
+          "description": "Required indentation style: `tabs` rejects any leading space; `spaces`\nrejects any leading tab."
         },
         "width": {
-          "description": "When `style: spaces`, the leading-space count on every non-blank line must be a multiple of this. Ignored for `style: tabs`.",
+          "default": null,
+          "description": "When `style: spaces`, the leading-space count on every non-blank line\nmust be a multiple of this. Ignored for `style: tabs`.",
+          "format": "uint32",
           "minimum": 1,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
       "required": [
@@ -2514,11 +2610,8 @@
           "$ref": "#/$defs/paths_spec"
         },
         "target": {
-          "enum": [
-            "lf",
-            "crlf"
-          ],
-          "type": "string"
+          "$ref": "#/$defs/TargetName",
+          "description": "Required line ending style: `lf` or `crlf`. Mixed endings within a\nfile also fail."
         }
       },
       "required": [
@@ -2800,15 +2893,16 @@
       "description": "The lines between a `start` / `end` marker pair must stay sorted (and, with `unique`, free of duplicates) under `comparator`. Both markers are optional: omit `end` to sort from `start` to EOF, omit both to sort the whole file (the markerless 'this file is one sorted list' form). The generic form of per-project keep-sorted scripts. Per-file: markers match the trimmed line; blank lines inside a block are ignored.",
       "properties": {
         "comparator": {
-          "enum": [
-            "lexical",
-            "lexical-ci",
-            "numeric"
-          ]
+          "$ref": "#/$defs/Comparator",
+          "description": "Comparator used to order entries: lexical (default), lexical-ci, or\nnumeric."
         },
         "end": {
-          "description": "Marker line closing a block. Optional — omit to run the block to EOF.",
-          "type": "string"
+          "default": null,
+          "description": "Marker line closing a block. Optional - omit to run the block to EOF.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "kind": {
           "const": "ordered_block"
@@ -2817,14 +2911,24 @@
           "$ref": "#/$defs/paths_spec"
         },
         "select": {
-          "description": "Regex; when set, only lines inside a block matching it are sortable entries (others — comments, group headers — pass through). The sectioned / keep-sorted-subset shape.",
-          "type": "string"
+          "default": null,
+          "description": "Regex; when set, only lines inside a block matching it are sortable\nentries (others, such as comments or group headers, pass through).",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "start": {
-          "description": "Marker line opening a block (matched on the trimmed line). Optional — omit to anchor the block at the start of the file.",
-          "type": "string"
+          "default": null,
+          "description": "Marker line opening a block (matched on the trimmed line). Optional -\nomit to anchor the block at the start of the file.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "unique": {
+          "default": false,
+          "description": "When true, also forbid duplicate (equal) entries within a block.",
           "type": "boolean"
         }
       },
@@ -2881,28 +2985,22 @@
       "description": "Cross-file: the `algorithm` digest of every file matching `source` must appear in the single `target` file — either as an embedded hex substring (`format: contains`, the default) or a coreutils / go-`.sum`-style `<hex>  <path>` manifest line (`format: sums-line`). Detection-only (alint never rewrites the manifest). A missing `target` is one violation; one violation per source whose digest is absent or mismatched. golang/go FIPS `fips140.sum` is the canonical use.",
       "properties": {
         "algorithm": {
-          "description": "Digest algorithm (default: sha256).",
-          "enum": [
-            "sha256",
-            "sha512"
-          ]
+          "$ref": "#/$defs/Algorithm",
+          "description": "Digest algorithm (default: sha256)."
         },
         "format": {
-          "description": "How the digest must appear in `target`: `contains` = hex substring anywhere (default); `sums-line` = a `<hex> [*]<path>` line whose path token is the source's path.",
-          "enum": [
-            "contains",
-            "sums-line"
-          ]
+          "$ref": "#/$defs/Format",
+          "description": "How the digest must appear in `target`: `contains` = hex\nsubstring anywhere (default); `sums-line` = a `<hex> [*]<path>`\nline whose path token is the source's path."
         },
         "kind": {
           "const": "pair_hash"
         },
         "source": {
-          "description": "Literal path or glob selecting the file(s) whose content is hashed (one check per match).",
+          "description": "Literal path or glob selecting the file(s) whose content is\nhashed (one check per match).",
           "type": "string"
         },
         "target": {
-          "description": "The single file that must carry the digest (a `.sum` / `SHA256SUMS` / file with an embedded hash).",
+          "description": "The single file that must carry the digest (a `.sum` /\n`SHA256SUMS` / a file with an embedded hash).",
           "type": "string"
         }
       },

--- a/crates/alint-dsl/schemas/v1/config.json
+++ b/crates/alint-dsl/schemas/v1/config.json
@@ -21,7 +21,7 @@
         },
         {
           "const": "numeric",
-          "description": "Leading-integer order; entries without a leading integer\nfall back to `lexical` so a mixed block degrades\npredictably rather than panicking.",
+          "description": "Leading-integer order; entries without a leading integer fall back to `lexical` so a mixed block degrades predictably rather than panicking.",
           "type": "string"
         }
       ]
@@ -54,7 +54,7 @@
         },
         {
           "const": "sums-line",
-          "description": "`target` must carry a `sha256sum`-style `<hex> [*]<path>`\nline whose path token is the source's path.",
+          "description": "`target` must carry a `sha256sum`-style `<hex> [*]<path>` line whose path token is the source's path.",
           "type": "string"
         }
       ]
@@ -664,12 +664,12 @@
           "const": "changeset_requires_path"
         },
         "since": {
-          "description": "Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}`\ninterpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
+          "description": "Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}` interpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
           "type": "string"
         },
         "when_changed": {
           "default": null,
-          "description": "Optional gate: only require the add when some path matching this glob\nchanged (any status). Omit to require it on any non-empty changeset.",
+          "description": "Optional gate: only require the add when some path matching this glob changed (any status). Omit to require it on any non-empty changeset.",
           "type": [
             "string",
             "null"
@@ -686,7 +686,7 @@
       "description": "Shell out to an external CLI per matched file. argv[0] is the program; remaining tokens support path-template substitution (`{path}`, `{dir}`, `{stem}`, `{ext}`, `{basename}`, `{parent_name}`). Working dir = repo root; stdin = /dev/null. Env: ALINT_PATH, ALINT_ROOT, ALINT_RULE_ID, ALINT_LEVEL, plus ALINT_VAR_<NAME> per `vars:` and ALINT_FACT_<NAME> per resolved fact. Verdict: exit 0 = pass; non-zero = one violation whose message is the (truncated) stdout+stderr. Trust-gated: only allowed in the user's top-level config (rejected at load-time when introduced via `extends:` or a bundled ruleset).",
       "properties": {
         "command": {
-          "description": "Argv tokens. The first token is the program (looked up via PATH if it's\na bare name); remaining tokens accept `{path}` and friends.",
+          "description": "Argv tokens. The first token is the program (looked up via PATH if it's a bare name); remaining tokens accept `{path}` and friends.",
           "items": {
             "type": "string"
           },
@@ -701,7 +701,7 @@
         },
         "timeout": {
           "default": null,
-          "description": "Per-file timeout in seconds. Default 30. Past this, the child is killed\nand a violation reports the timeout.",
+          "description": "Per-file timeout in seconds. Default 30. Past this, the child is killed and a violation reports the timeout.",
           "format": "uint64",
           "minimum": 1,
           "type": [
@@ -720,7 +720,7 @@
       "description": "Run a user-declared formatter/checker in its --check (idempotence) mode once: exit 0 = the tree is formatter-clean (silent), non-zero = violation(s). alint never runs a mutating formatter and never writes the tree (the sibling of generated_file_fresh; same trust tier as the command rule — trust-gated to the user's own top-level config). With `files_from` (+ optional `files_pattern`) the tool's offender list is parsed into one violation per file. Single-shot, opt-in.",
       "properties": {
         "command": {
-          "description": "Checker argv (no shell), run in its --check / idempotence mode; exit\n0 = clean.",
+          "description": "Checker argv (no shell), run in its --check / idempotence mode; exit 0 = clean.",
           "items": {
             "type": "string"
           },
@@ -729,11 +729,11 @@
         },
         "files_from": {
           "$ref": "#/$defs/FilesFrom",
-          "description": "On failure, parse this stream into per-file violations (default: none =\none violation for the whole invocation)."
+          "description": "On failure, parse this stream into per-file violations (default: none = one violation for the whole invocation)."
         },
         "files_pattern": {
           "default": null,
-          "description": "Regex whose capture group 1 is a file path, applied per output line\n(requires `files_from`; omit for bare-path listers).",
+          "description": "Regex whose capture group 1 is a file path, applied per output line (requires `files_from`; omit for bare-path listers).",
           "type": [
             "string",
             "null"
@@ -744,7 +744,7 @@
         },
         "timeout": {
           "default": null,
-          "description": "Checker timeout in seconds (default 120). On timeout the child is killed\nand one violation is emitted.",
+          "description": "Checker timeout in seconds (default 120). On timeout the child is killed and one violation is emitted.",
           "format": "uint64",
           "minimum": 1,
           "type": [
@@ -774,11 +774,12 @@
         },
         "language": {
           "$ref": "#/$defs/Language",
-          "description": "`auto` (default) infers the comment-marker set from\neach file's extension. Explicit override useful for\nembedded DSLs or cases where the extension lies."
+          "default": "auto",
+          "description": "`auto` (default) infers the comment-marker set from each file's extension. Explicit override useful for embedded DSLs or cases where the extension lies."
         },
         "min_lines": {
           "default": 3,
-          "description": "Minimum consecutive comment-line count for a block to\nbe considered. 1-2 line comments are almost always\nprose; 3+ starts looking like dead code. Default 3.",
+          "description": "Minimum consecutive comment-line count for a block to be considered. 1-2 line comments are almost always prose; 3+ starts looking like dead code. Default 3.",
           "format": "uint",
           "minimum": 2,
           "type": "integer"
@@ -788,14 +789,14 @@
         },
         "skip_leading_lines": {
           "default": 30,
-          "description": "Skip the first N lines of any file. Defaults to 30 to\npass over license headers without false-positive\nflagging them as commented-out code.",
+          "description": "Skip blocks whose first line is at or before this line number. Default 30 - covers typical license headers without false-positive flagging them as commented-out code.",
           "format": "uint",
           "minimum": 0,
           "type": "integer"
         },
         "threshold": {
           "default": 0.5,
-          "description": "Token-density floor (0.0-1.0). Higher = stricter (only\nthe most code-shaped blocks fire). Default 0.5.",
+          "description": "Density floor for code-shapedness. Higher = stricter. Default 0.5 sits at the midpoint between obvious-prose (0.0) and obvious-code (1.0); lower it to widen the catch (more FPs), raise it to narrow.",
           "format": "double",
           "maximum": 1.0,
           "minimum": 0.0,
@@ -1452,7 +1453,7 @@
           "$ref": "#/$defs/paths_spec"
         },
         "sha256": {
-          "description": "Expected SHA-256 in lowercase hex (64 chars). Accepting\nuppercase and the `sha256:` prefix keeps the field forgiving.",
+          "description": "Expected SHA-256 in lowercase hex (64 chars). Accepting uppercase and the `sha256:` prefix keeps the field forgiving.",
           "pattern": "^(sha256:)?[0-9a-fA-F]{64}$",
           "type": "string"
         }
@@ -1497,7 +1498,7 @@
       "properties": {
         "allow": {
           "default": [],
-          "description": "Permitted non-ASCII codepoints - each a single character\n(e.g. \"o-umlaut\"), a `U+XXXX` codepoint, or a `U+XXXX-U+YYYY`\ninclusive range.",
+          "description": "Permitted non-ASCII codepoints - each a single character (e.g. \"o-umlaut\"), a `U+XXXX` codepoint, or a `U+XXXX-U+YYYY` inclusive range.",
           "items": {
             "type": "string"
           },
@@ -1645,7 +1646,7 @@
         },
         "shebang": {
           "default": "^#!",
-          "description": "Rust regex; the first line of every matched file must match. Default\n`^#!` only enforces shebang presence.",
+          "description": "Rust regex; the first line of every matched file must match. Default `^#!` only enforces shebang presence.",
           "type": "string"
         }
       },
@@ -1936,7 +1937,7 @@
           "const": "git_blame_age"
         },
         "max_age_days": {
-          "description": "Minimum line age (in days) for a matching line to fire as a violation.\nLines younger than this pass silently.",
+          "description": "Minimum line age (in days) for a matching line to fire as a violation. Lines younger than this pass silently. Common values: 90 (one quarter), 180 (half a year), 365 (a full year of debt).",
           "format": "uint64",
           "minimum": 1,
           "type": "integer"
@@ -1945,7 +1946,7 @@
           "$ref": "#/$defs/paths_spec"
         },
         "pattern": {
-          "description": "Rust-regex pattern applied to each blame line's content. Capture group 1\n(when present) is exposed as `{{ctx.match}}` in the message template;\nwithout a capture group, `{{ctx.match}}` substitutes the full match.",
+          "description": "Rust-regex pattern applied to each blame line's content. Capture group 1 (when present) is exposed as `{{ctx.match}}` in the message template; without a capture group, `{{ctx.match}}` substitutes the full match.",
           "type": "string"
         }
       },
@@ -1973,7 +1974,7 @@
       "properties": {
         "email_pattern": {
           "default": null,
-          "description": "Rust-regex the author email (`git log %ae`) must match, e.g.\n`^.+@example\\.com$`.",
+          "description": "Rust-regex the author email (`git log %ae`) must match, e.g. `^.+@example\\.com$`.",
           "type": [
             "string",
             "null"
@@ -1981,7 +1982,7 @@
         },
         "include_merges": {
           "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error.",
           "type": "boolean"
         },
         "kind": {
@@ -1997,7 +1998,7 @@
         },
         "since": {
           "default": null,
-          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does.",
+          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
           "type": [
             "string",
             "null"
@@ -2011,7 +2012,7 @@
       "properties": {
         "include_merges": {
           "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error.",
           "type": "boolean"
         },
         "kind": {
@@ -2019,7 +2020,7 @@
         },
         "since": {
           "default": null,
-          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does.",
+          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
           "type": [
             "string",
             "null"
@@ -2050,7 +2051,7 @@
       "properties": {
         "include_merges": {
           "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset; combining `include_merges: true` with no\n`since:` is a load-time error.",
+          "description": "When validating a range (`since:` set), include merge commits. Defaults to `false` because merge commits in PR contexts are typically the synthetic merge `actions/checkout` produces (with an auto-generated subject the rule would always flag) or maintainer-resolved merges from the base branch. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error.",
           "type": "boolean"
         },
         "kind": {
@@ -2058,7 +2059,7 @@
         },
         "pattern": {
           "default": null,
-          "description": "Rust-regex pattern the full message (subject + body, joined with\nnewlines) must match. Use `(?s)` to make `.` match newlines.",
+          "description": "Rust-regex pattern the full message (subject + body, joined with newlines) must match. Use `(?s)` to make `.` match newlines.",
           "type": [
             "string",
             "null"
@@ -2066,12 +2067,12 @@
         },
         "requires_body": {
           "default": false,
-          "description": "When true, the message must have a non-empty body, that is, at least\none line of content after the subject's blank-line separator.",
+          "description": "When true, the message must have a non-empty body, that is, at least one line of content after the subject's blank-line separator.",
           "type": "boolean"
         },
         "since": {
           "default": null,
-          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does: SHA (full or abbreviated), branch (`origin/main`),\ntag (`v1.2.3`), or relative ref (`HEAD~5`).",
+          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does: SHA (full or abbreviated), branch (`origin/main`), tag (`v1.2.3`), or relative ref (`HEAD~5`). Supports POSIX `${VAR}` and `${VAR:-default}` env-var interpolation so CI can pass a SHA via an env var (e.g. `since: ${ALINT_BASE_SHA:-origin/main}` with `ALINT_BASE_SHA` exported in a workflow step from `github.event.pull_request.base.sha`). The GitHub Actions double-brace template syntax `${{ ... }}` is NOT interpolated by alint.",
           "type": [
             "string",
             "null"
@@ -2079,7 +2080,7 @@
         },
         "subject_max_length": {
           "default": null,
-          "description": "Maximum number of characters allowed in the subject line. Common\nvalues: 50 (Tim Pope's recommendation), 72 (GitHub PR-title cutoff).",
+          "description": "Maximum number of characters allowed in the subject line. Common values: 50 (Tim Pope's recommendation), 72 (GitHub PR-title cutoff).",
           "format": "uint",
           "minimum": 1,
           "type": [
@@ -2095,7 +2096,7 @@
       "properties": {
         "include_merges": {
           "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error.",
           "type": "boolean"
         },
         "kind": {
@@ -2103,7 +2104,7 @@
         },
         "since": {
           "default": null,
-          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does.",
+          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
           "type": [
             "string",
             "null"
@@ -2117,7 +2118,7 @@
       "properties": {
         "include_merges": {
           "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error.",
           "type": "boolean"
         },
         "kind": {
@@ -2125,7 +2126,7 @@
         },
         "pattern": {
           "default": null,
-          "description": "Trailer pattern each commit message must contain. Defaults to the\ncanonical DCO sign-off shape. Override to enforce a stricter form\n(e.g. a corporate-domain email).",
+          "description": "Trailer pattern each commit message must contain. Defaults to the canonical DCO sign-off shape `(?m)^Signed-off-by: .+ <.+@.+>$`. Override to enforce a stricter form (e.g. a corporate-domain email).",
           "type": [
             "string",
             "null"
@@ -2133,7 +2134,7 @@
         },
         "since": {
           "default": null,
-          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does.",
+          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
           "type": [
             "string",
             "null"
@@ -2147,7 +2148,7 @@
       "properties": {
         "include_merges": {
           "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error.",
           "type": "boolean"
         },
         "kind": {
@@ -2159,7 +2160,7 @@
         },
         "since": {
           "default": null,
-          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD.",
+          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
           "type": [
             "string",
             "null"
@@ -2175,7 +2176,7 @@
       "description": "Fire when any tracked path matches a configured glob denylist. Companion of `git_tracked_only` for the absence axis: catches secrets, large binaries, or accidentally-tracked artifacts that would otherwise need a `file_absent` per pattern. With `since:` set, only paths changed in the `<since>...HEAD` diff are flagged (PR-scoped). Outside a git repo, silently no-ops; a `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
       "properties": {
         "denied": {
-          "description": "Globset patterns no tracked path may match. Both whole-path patterns\n(`secrets/**`) and basename-only patterns (`*.env`) work.",
+          "description": "Globset patterns no tracked path may match. Both whole-path patterns (`secrets/**`) and basename-only patterns (`*.env`) work.",
           "items": {
             "type": "string"
           },
@@ -2187,7 +2188,7 @@
         },
         "since": {
           "default": null,
-          "description": "Optional git ref. When set, only denied paths that changed in the\n`<since>...HEAD` diff are flagged, catches a secret added in a PR even if\nHEAD's tree still tracks an older one. Accepts the `{{env.X}}`\ninterpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
+          "description": "Optional git ref. When set, only denied paths that changed in the `<since>...HEAD` diff are flagged, catches a secret added in a PR even if HEAD's tree still tracks an older one. Accepts the `{{env.X}}` interpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
           "type": [
             "string",
             "null"
@@ -2258,11 +2259,11 @@
         },
         "style": {
           "$ref": "#/$defs/StyleName",
-          "description": "Required indentation style: `tabs` rejects any leading space; `spaces`\nrejects any leading tab."
+          "description": "Required indentation style: `tabs` rejects any leading space; `spaces` rejects any leading tab."
         },
         "width": {
           "default": null,
-          "description": "When `style: spaces`, the leading-space count on every non-blank line\nmust be a multiple of this. Ignored for `style: tabs`.",
+          "description": "When `style: spaces`, the leading-space count on every non-blank line must be a multiple of this. Ignored for `style: tabs`.",
           "format": "uint32",
           "minimum": 1,
           "type": [
@@ -2611,7 +2612,7 @@
         },
         "target": {
           "$ref": "#/$defs/TargetName",
-          "description": "Required line ending style: `lf` or `crlf`. Mixed endings within a\nfile also fail."
+          "description": "Required line ending style: `lf` or `crlf`. Mixed endings within a file also fail."
         }
       },
       "required": [
@@ -2647,7 +2648,7 @@
       "properties": {
         "ignore_template_vars": {
           "default": true,
-          "description": "Skip backticked tokens containing template-variable\nmarkers (`{{ }}`, `${ }`, `<…>`). Default true.",
+          "description": "When true (default), skip backticked tokens containing `{{ ... }}`, `${ ... }`, or `<...>` template-variable markers. These are placeholders, not real paths.",
           "type": "boolean"
         },
         "kind": {
@@ -2657,7 +2658,7 @@
           "$ref": "#/$defs/paths_spec"
         },
         "prefixes": {
-          "description": "Whitelist of path-shape prefixes to validate. A backticked\ntoken must start with one of these to be considered a path\ncandidate. No defaults — every project's layout differs and\nthe user must declare which prefixes mark a path.",
+          "description": "Whitelist of path-shape prefixes to validate. A backticked token must start with one of these to be considered a path candidate. No defaults — every project's layout differs and the user must declare which prefixes mark a path.",
           "items": {
             "type": "string"
           },
@@ -2678,7 +2679,7 @@
           "const": "max_consecutive_blank_lines"
         },
         "max": {
-          "description": "Maximum number of blank lines allowed in a row. `0` means\nno blank lines at all.",
+          "description": "Maximum number of blank lines allowed in a row. `0` means no blank lines at all.",
           "format": "uint32",
           "minimum": 0,
           "type": "integer"
@@ -2722,7 +2723,7 @@
           "const": "max_files_per_directory"
         },
         "max_files": {
-          "description": "Maximum number of in-scope files allowed as immediate children\nof any one directory (non-recursive).",
+          "description": "Maximum number of in-scope files allowed as immediate children of any one directory (non-recursive).",
           "format": "uint",
           "minimum": 1,
           "type": "integer"
@@ -2894,7 +2895,7 @@
       "properties": {
         "comparator": {
           "$ref": "#/$defs/Comparator",
-          "description": "Comparator used to order entries: lexical (default), lexical-ci, or\nnumeric."
+          "description": "Comparator used to order entries: lexical (default), lexical-ci, or numeric."
         },
         "end": {
           "default": null,
@@ -2912,7 +2913,7 @@
         },
         "select": {
           "default": null,
-          "description": "Regex; when set, only lines inside a block matching it are sortable\nentries (others, such as comments or group headers, pass through).",
+          "description": "Regex; when set, only lines inside a block matching it are sortable entries (others, such as comments or group headers, pass through). The sectioned / keep-sorted-subset shape.",
           "type": [
             "string",
             "null"
@@ -2920,7 +2921,7 @@
         },
         "start": {
           "default": null,
-          "description": "Marker line opening a block (matched on the trimmed line). Optional -\nomit to anchor the block at the start of the file.",
+          "description": "Marker line opening a block (matched on the trimmed line). Optional - omit to anchor the block at the start of the file.",
           "type": [
             "string",
             "null"
@@ -2959,18 +2960,18 @@
       "description": "If the `<since>...HEAD` diff changes any path matching `if_changed:`, at least one path matching `then_changed:` must change in the same range — the co-change gate (a FORMAT_VERSION must bump when the format struct changes; version.txt and the lockfile change together). Both globs and `since:` (the base ref) are required. Directional: a `then_changed`-only change never triggers it (add a second rule with the globs swapped for a bidirectional pact). Diff-scoped: silent no-op outside a git repo / when `if_changed` didn't change; a `since:` that fails to resolve hard-fails with a shallow-clone hint. Check-only.",
       "properties": {
         "if_changed": {
-          "description": "Glob; the trigger. When the diff changes a path matching this, a\n`then_changed` co-change is required.",
+          "description": "Glob; the trigger. When the diff changes a path matching this, a `then_changed` co-change is required.",
           "type": "string"
         },
         "kind": {
           "const": "pair_changed_together"
         },
         "since": {
-          "description": "Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}`\ninterpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
+          "description": "Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}` interpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
           "type": "string"
         },
         "then_changed": {
-          "description": "Glob; the obligation. At least one changed path must match it whenever\n`if_changed` fired.",
+          "description": "Glob; the obligation. At least one changed path must match it whenever `if_changed` fired.",
           "type": "string"
         }
       },
@@ -2982,7 +2983,7 @@
       "type": "object"
     },
     "rule_pair_hash": {
-      "description": "Cross-file: the `algorithm` digest of every file matching `source` must appear in the single `target` file — either as an embedded hex substring (`format: contains`, the default) or a coreutils / go-`.sum`-style `<hex>  <path>` manifest line (`format: sums-line`). Detection-only (alint never rewrites the manifest). A missing `target` is one violation; one violation per source whose digest is absent or mismatched. golang/go FIPS `fips140.sum` is the canonical use.",
+      "description": "Cross-file: the `algorithm` digest of every file matching `source` must appear in the single `target` file — either as an embedded hex substring (`format: contains`, the default) or a coreutils / go-`.sum`-style `<hex> <path>` manifest line (`format: sums-line`). Detection-only (alint never rewrites the manifest). A missing `target` is one violation; one violation per source whose digest is absent or mismatched. golang/go FIPS `fips140.sum` is the canonical use.",
       "properties": {
         "algorithm": {
           "$ref": "#/$defs/Algorithm",
@@ -2990,17 +2991,17 @@
         },
         "format": {
           "$ref": "#/$defs/Format",
-          "description": "How the digest must appear in `target`: `contains` = hex\nsubstring anywhere (default); `sums-line` = a `<hex> [*]<path>`\nline whose path token is the source's path."
+          "description": "How the digest must appear in `target`: `contains` = hex substring anywhere (default); `sums-line` = a `<hex> [*]<path>` line whose path token is the source's path."
         },
         "kind": {
           "const": "pair_hash"
         },
         "source": {
-          "description": "Literal path or glob selecting the file(s) whose content is\nhashed (one check per match).",
+          "description": "Literal path or glob selecting the file(s) whose content is hashed (one check per match).",
           "type": "string"
         },
         "target": {
-          "description": "The single file that must carry the digest (a `.sum` /\n`SHA256SUMS` / a file with an embedded hash).",
+          "description": "The single file that must carry the digest (a `.sum` / `SHA256SUMS` / a file with an embedded hash).",
           "type": "string"
         }
       },
@@ -3207,7 +3208,7 @@
       "properties": {
         "case_insensitive": {
           "default": false,
-          "description": "Fold the key to lowercase before grouping, so keys that\ncollide only under case-folding count as duplicates — the\ncase-insensitive-filesystem hazard (Windows / macOS).",
+          "description": "Fold the key to lowercase before grouping, so keys that collide only under case-folding count as duplicates — the case-insensitive-filesystem hazard (Windows / macOS).",
           "type": "boolean"
         },
         "key": {
@@ -3430,7 +3431,7 @@
       ]
     },
     "extends": {
-      "description": "Configs to inherit from. Each entry is either a bare string (local path, `https://` URL with SRI, or `alint://bundled/<name>@<rev>`) or a mapping `{url, only?, except?}` that filters the inherited rule set before merging.\n\nEntries resolved left-to-right; later entries override earlier ones, and the current file's own definitions override everything it extends.\n\n**Rule merging is field-level by `id`.** A child can override just the fields it wants to change — `rules: [{id: inherited, level: warning}]` keeps the parent's `kind`/`paths`/etc. and only downgrades severity. `{id: inherited, level: off}` disables a rule without redeclaring it.\n\n**Selective adoption** via `only:` (keep these ids, drop everything else) or `except:` (drop these ids). The two are mutually exclusive on a single entry. Unknown ids are a load-time error so typos surface immediately.\n\nRemote and bundled configs cannot themselves declare `extends:` (no principled base for relative resolution in a fetched body); nest extends locally instead.",
+      "description": "Configs to inherit from. Each entry is either a bare string (local path, `https://` URL with SRI, or `alint://bundled/<name>@<rev>`) or a mapping `{url, only?, except?}` that filters the inherited rule set before merging. Entries resolved left-to-right; later entries override earlier ones, and the current file's own definitions override everything it extends. **Rule merging is field-level by `id`.** A child can override just the fields it wants to change — `rules: [{id: inherited, level: warning}]` keeps the parent's `kind`/`paths`/etc. and only downgrades severity. `{id: inherited, level: off}` disables a rule without redeclaring it. **Selective adoption** via `only:` (keep these ids, drop everything else) or `except:` (drop these ids). The two are mutually exclusive on a single entry. Unknown ids are a load-time error so typos surface immediately. Remote and bundled configs cannot themselves declare `extends:` (no principled base for relative resolution in a fetched body); nest extends locally instead.",
       "items": {
         "$ref": "#/$defs/extends_entry"
       },

--- a/crates/alint-dsl/schemas/v1/config.json
+++ b/crates/alint-dsl/schemas/v1/config.json
@@ -1,922 +1,677 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/asamarts/alint/main/schemas/v1/config.json",
-  "title": "alint configuration (v1)",
-  "description": "Schema for .alint.yml configuration files. Authoritative reference: docs/design/ARCHITECTURE.md in the alint repository.",
-  "type": "object",
-  "required": ["version"],
-  "additionalProperties": false,
-  "properties": {
-    "version": {
-      "const": 1,
-      "description": "Config schema version. Always 1 for this schema."
-    },
-    "extends": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/extends_entry" },
-      "description": "Configs to inherit from. Each entry is either a bare string (local path, `https://` URL with SRI, or `alint://bundled/<name>@<rev>`) or a mapping `{url, only?, except?}` that filters the inherited rule set before merging.\n\nEntries resolved left-to-right; later entries override earlier ones, and the current file's own definitions override everything it extends.\n\n**Rule merging is field-level by `id`.** A child can override just the fields it wants to change — `rules: [{id: inherited, level: warning}]` keeps the parent's `kind`/`paths`/etc. and only downgrades severity. `{id: inherited, level: off}` disables a rule without redeclaring it.\n\n**Selective adoption** via `only:` (keep these ids, drop everything else) or `except:` (drop these ids). The two are mutually exclusive on a single entry. Unknown ids are a load-time error so typos surface immediately.\n\nRemote and bundled configs cannot themselves declare `extends:` (no principled base for relative resolution in a fetched body); nest extends locally instead."
-    },
-    "ignore": {
-      "type": "array",
-      "items": { "type": "string" },
-      "description": "Additional glob patterns excluded on top of .gitignore."
-    },
-    "respect_gitignore": {
-      "type": "boolean",
-      "default": true,
-      "description": "Whether to honor .gitignore files during the walk."
-    },
-    "vars": {
-      "type": "object",
-      "additionalProperties": { "type": "string" },
-      "description": "Free-form string variables referenced from rule messages as {{vars.<name>}} and from `when` clauses as vars.<name>."
-    },
-    "facts": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/fact" },
-      "description": "Properties of the repository evaluated once per run; referenced from `when` clauses as facts.<id>."
-    },
-    "rules": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/rule" },
-      "description": "Rules evaluated against the repository tree."
-    },
-    "templates": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/template" },
-      "description": "Reusable rule shapes referenced by `extends_template:` in `rules:` entries. Each template carries an `id:` and any other rule-spec fields; `{{vars.<name>}}` placeholders in those fields substitute from each instance's `vars:` map at expansion time. Templates are leaf-only — a template may not itself `extends_template:` another. Templates merge through the `extends:` chain by id, so a downstream config can override an upstream template's body."
-    },
-    "fix_size_limit": {
-      "type": ["integer", "null"],
-      "minimum": 0,
-      "default": 1048576,
-      "description": "Max bytes a content-editing fix will touch. Files over this limit are reported as Skipped with a stderr warning. Default: 1 MiB. Explicit null disables the cap. Path-only fixes (file_create, file_remove, file_rename) ignore this setting."
-    },
-    "nested_configs": {
-      "type": "boolean",
-      "default": false,
-      "description": "Opt in to discovery of nested `.alint.yml` / `.alint.yaml` files in subdirectories. When true, the loader walks the tree from this config's directory (honoring `.gitignore` + `ignore`) and finds any nested config files. Each nested rule's path-like scope fields (`paths`, `select`, `primary`) are automatically prefixed with the nested config's relative directory, so rules declared in `packages/frontend/.alint.yml` apply only under `packages/frontend/**`. Id collisions across configs are rejected with a clear error — per-subtree overrides aren't supported in this release (use `when:` on the root rule for that). Only the root config sets this; nested configs can't spawn further nested discovery."
-    },
-    "allow_out_of_root": {
-      "description": "Top-level-only escape hatch for path confinement: permit rules to read a config-declared path that escapes the repo root. `true` allows every rule; a map `{ kinds: [...], rules: [...] }` allows only the listed rule kinds / ids. Absent or `false` keeps the secure default (every config-derived path read is confined). REJECTED from `extends:`'d rulesets — only the user's own top-level config may set it. Applies to file reads (currently `registry_paths_resolve` source, `json_schema_passes` schema_path, `pair_hash` target); resolve/index checks stay confined. Permitted reads emit an informational note. See docs/design/v0.12/allow_out_of_root.md.",
-      "oneOf": [
-        { "type": "boolean" },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "kinds": {
-              "type": "array",
-              "items": { "type": "string" },
-              "description": "Rule kinds permitted to read out of the repo root."
-            },
-            "rules": {
-              "type": "array",
-              "items": { "type": "string" },
-              "description": "Rule ids permitted to read out of the repo root."
-            }
-          }
-        }
-      ]
-    }
-  },
-
   "$defs": {
-    "level": {
-      "type": "string",
-      "enum": ["error", "warning", "info", "off"],
-      "description": "Severity. `off` disables a rule (useful when overriding inherited rules)."
+    "case_convention": {
+      "description": "Case convention. Aliases like PascalCase / pascal / pascal-case / UpperCamelCase all resolve to the same canonical form.",
+      "enum": [
+        "lower",
+        "lowercase",
+        "upper",
+        "uppercase",
+        "pascal",
+        "pascalcase",
+        "PascalCase",
+        "UpperCamelCase",
+        "upper_camel",
+        "upper_camel_case",
+        "camel",
+        "camelcase",
+        "camelCase",
+        "lowerCamelCase",
+        "lower_camel",
+        "lower_camel_case",
+        "snake",
+        "snakecase",
+        "snake_case",
+        "kebab",
+        "kebabcase",
+        "kebab-case",
+        "dash",
+        "dashcase",
+        "dash-case",
+        "screaming-snake",
+        "screamingsnake",
+        "screamingsnakecase",
+        "SCREAMING_SNAKE_CASE",
+        "upper_snake",
+        "upper_snake_case",
+        "flat",
+        "flatcase"
+      ],
+      "type": "string"
     },
-
-    "rule_id": {
-      "type": "string",
-      "pattern": "^[a-z][a-z0-9_-]*$",
-      "description": "Unique kebab-case identifier for the rule."
-    },
-
-    "string_or_string_array": {
-      "oneOf": [
-        { "type": "string" },
-        { "type": "array", "items": { "type": "string" } }
-      ]
-    },
-
     "extends_entry": {
       "description": "One extends entry. Bare string = classic form (url-only). Mapping form lets you filter with `only:` / `except:` (mutually exclusive).",
       "oneOf": [
-        { "type": "string" },
         {
-          "type": "object",
-          "required": ["url"],
+          "type": "string"
+        },
+        {
           "additionalProperties": false,
           "properties": {
-            "url": {
-              "type": "string",
-              "description": "Local path, `https://...#sha256-<hex>`, or `alint://bundled/<name>@<rev>`."
+            "except": {
+              "description": "Drop these rule ids from the extended config.",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
             },
             "only": {
-              "type": "array",
-              "items": { "type": "string" },
+              "description": "Keep only these rule ids from the extended config; drop everything else.",
+              "items": {
+                "type": "string"
+              },
               "minItems": 1,
-              "description": "Keep only these rule ids from the extended config; drop everything else."
+              "type": "array"
             },
-            "except": {
-              "type": "array",
-              "items": { "type": "string" },
-              "minItems": 1,
-              "description": "Drop these rule ids from the extended config."
+            "url": {
+              "description": "Local path, `https://...#sha256-<hex>`, or `alint://bundled/<name>@<rev>`.",
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "url"
+          ],
+          "type": "object"
         }
       ]
     },
-
-    "paths_spec": {
-      "description": "A single glob, an array of globs (with optional `!negation`), or an explicit include/exclude pair.",
-      "oneOf": [
-        { "type": "string" },
-        {
-          "type": "array",
-          "items": { "type": "string" }
+    "extract_spec": {
+      "additionalProperties": false,
+      "description": "Exactly one of: toml/json/yaml (RFC 9535 JSONPath string), lines (object; optional `comment` prefix, default `#`), regex (string; capture group 1 is the value), whole_file (object `{}`; the entire file content as one value — for byte-level cross_file comparison; the non-literal skip does not apply).",
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "json": {
+          "type": "string"
         },
-        {
-          "type": "object",
+        "lines": {
           "additionalProperties": false,
           "properties": {
-            "include": { "$ref": "#/$defs/string_or_string_array" },
-            "exclude": { "$ref": "#/$defs/string_or_string_array" }
-          }
+            "comment": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "regex": {
+          "type": "string"
+        },
+        "toml": {
+          "type": "string"
+        },
+        "whole_file": {
+          "additionalProperties": false,
+          "type": "object"
+        },
+        "yaml": {
+          "type": "string"
         }
-      ]
+      },
+      "type": "object"
     },
-
-    "case_convention": {
-      "type": "string",
-      "description": "Case convention. Aliases like PascalCase / pascal / pascal-case / UpperCamelCase all resolve to the same canonical form.",
-      "enum": [
-        "lower", "lowercase",
-        "upper", "uppercase",
-        "pascal", "pascalcase", "PascalCase", "UpperCamelCase", "upper_camel", "upper_camel_case",
-        "camel", "camelcase", "camelCase", "lowerCamelCase", "lower_camel", "lower_camel_case",
-        "snake", "snakecase", "snake_case",
-        "kebab", "kebabcase", "kebab-case", "dash", "dashcase", "dash-case",
-        "screaming-snake", "screamingsnake", "screamingsnakecase", "SCREAMING_SNAKE_CASE", "upper_snake", "upper_snake_case",
-        "flat", "flatcase"
-      ]
-    },
-
-    "rule_common": {
-      "type": "object",
-      "required": ["id", "kind", "level"],
-      "properties": {
-        "id": { "$ref": "#/$defs/rule_id" },
-        "kind": {
-          "type": "string",
-          "description": "The primitive rule kind. See docs/design/ARCHITECTURE.md §4.4 for the full catalog."
-        },
-        "level": { "$ref": "#/$defs/level" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "message": {
-          "type": "string",
-          "description": "Override the default failure message. Supports `{{vars.*}}` and `{{ctx.*}}` substitution."
-        },
-        "policy_url": {
-          "type": "string",
-          "format": "uri",
-          "description": "Link to a human-readable policy justification."
-        },
-        "when": {
-          "type": "string",
-          "description": "Gate the rule on a fact-based expression (available from v0.2)."
-        },
-        "scope_filter": { "$ref": "#/$defs/scope_filter" },
-        "fix": { "$ref": "#/$defs/fix" }
-      }
-    },
-
-    "fix": {
-      "description": "Automatic-fix strategy applied by `alint fix`. Each rule kind accepts a specific op — alint errors at load time when the op and kind are incompatible.",
-      "type": "object",
+    "fact": {
+      "description": "A single fact declaration. Each fact has an `id` plus exactly one kind-specific field.",
       "oneOf": [
         {
-          "type": "object",
-          "required": ["file_create"],
+          "properties": {
+            "any_file_exists": {
+              "$ref": "#/$defs/string_or_string_array"
+            }
+          },
+          "required": [
+            "any_file_exists"
+          ]
+        },
+        {
+          "properties": {
+            "all_files_exist": {
+              "$ref": "#/$defs/string_or_string_array"
+            }
+          },
+          "required": [
+            "all_files_exist"
+          ]
+        },
+        {
+          "properties": {
+            "count_files": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "count_files"
+          ]
+        },
+        {
+          "properties": {
+            "file_content_matches": {
+              "additionalProperties": false,
+              "properties": {
+                "paths": {
+                  "$ref": "#/$defs/string_or_string_array"
+                },
+                "pattern": {
+                  "description": "Rust-regex pattern matched against the content of every file in `paths`. The fact is true iff at least one file contains a match. Non-UTF-8 files are skipped.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "paths",
+                "pattern"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "file_content_matches"
+          ]
+        },
+        {
+          "properties": {
+            "git_branch": {
+              "additionalProperties": false,
+              "description": "Read `<repo>/.git/HEAD` and return the current branch name (string). Detached HEAD, no `.git/` directory, or any unrecognized layout resolves to an empty string (falsy under `when:`).",
+              "properties": {},
+              "type": "object"
+            }
+          },
+          "required": [
+            "git_branch"
+          ]
+        },
+        {
+          "properties": {
+            "custom": {
+              "additionalProperties": false,
+              "properties": {
+                "argv": {
+                  "description": "Program + arguments, passed verbatim to the OS (no shell). Fact value is the process's stdout (trimmed). Non-zero exit, spawn failure, or non-UTF-8 output all resolve to an empty string. SECURITY: `custom:` is only valid in the user's top-level config — alint refuses to load an extended config that declares one.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "required": [
+                "argv"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "custom"
+          ]
+        }
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/rule_id"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "fix": {
+      "description": "Automatic-fix strategy applied by `alint fix`. Each rule kind accepts a specific op — alint errors at load time when the op and kind are incompatible.",
+      "oneOf": [
+        {
           "additionalProperties": false,
           "properties": {
             "file_create": {
-              "type": "object",
               "additionalProperties": false,
               "oneOf": [
-                { "required": ["content"] },
-                { "required": ["content_from"] }
+                {
+                  "required": [
+                    "content"
+                  ]
+                },
+                {
+                  "required": [
+                    "content_from"
+                  ]
+                }
               ],
               "properties": {
                 "content": {
-                  "type": "string",
-                  "description": "Literal bytes to write. Mutually exclusive with `content_from`. Pass \"\" for an empty file."
+                  "description": "Literal bytes to write. Mutually exclusive with `content_from`. Pass \"\" for an empty file.",
+                  "type": "string"
                 },
                 "content_from": {
-                  "type": "string",
-                  "description": "Path to a file whose bytes will be the content, relative to the lint root. Mutually exclusive with `content`. Read at fix-apply time; missing source produces a `Skipped` outcome rather than an error. Useful for LICENSE / NOTICE / boilerplate too long to inline."
-                },
-                "path": {
-                  "type": "string",
-                  "description": "Target path, relative to the repo root. When omitted, the first literal entry from the rule's `paths:` list is used."
+                  "description": "Path to a file whose bytes will be the content, relative to the lint root. Mutually exclusive with `content`. Read at fix-apply time; missing source produces a `Skipped` outcome rather than an error. Useful for LICENSE / NOTICE / boilerplate too long to inline.",
+                  "type": "string"
                 },
                 "create_parents": {
-                  "type": "boolean",
                   "default": true,
-                  "description": "Create intermediate directories if missing."
+                  "description": "Create intermediate directories if missing.",
+                  "type": "boolean"
+                },
+                "path": {
+                  "description": "Target path, relative to the repo root. When omitted, the first literal entry from the rule's `paths:` list is used.",
+                  "type": "string"
                 }
-              }
+              },
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_create"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_remove"],
           "additionalProperties": false,
           "properties": {
             "file_remove": {
-              "type": "object",
               "additionalProperties": false,
-              "properties": {}
+              "properties": {},
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_remove"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_prepend"],
           "additionalProperties": false,
           "properties": {
             "file_prepend": {
-              "type": "object",
               "additionalProperties": false,
               "oneOf": [
-                { "required": ["content"] },
-                { "required": ["content_from"] }
+                {
+                  "required": [
+                    "content"
+                  ]
+                },
+                {
+                  "required": [
+                    "content_from"
+                  ]
+                }
               ],
               "properties": {
                 "content": {
-                  "type": "string",
-                  "description": "Bytes to insert at the start of each violating file. Mutually exclusive with `content_from`. A trailing newline is the caller's responsibility."
+                  "description": "Bytes to insert at the start of each violating file. Mutually exclusive with `content_from`. A trailing newline is the caller's responsibility.",
+                  "type": "string"
                 },
                 "content_from": {
-                  "type": "string",
-                  "description": "Path to a file whose bytes will be prepended, relative to the lint root. Mutually exclusive with `content`. Read at fix-apply time."
+                  "description": "Path to a file whose bytes will be prepended, relative to the lint root. Mutually exclusive with `content`. Read at fix-apply time.",
+                  "type": "string"
                 }
-              }
+              },
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_prepend"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_append"],
           "additionalProperties": false,
           "properties": {
             "file_append": {
-              "type": "object",
               "additionalProperties": false,
               "oneOf": [
-                { "required": ["content"] },
-                { "required": ["content_from"] }
+                {
+                  "required": [
+                    "content"
+                  ]
+                },
+                {
+                  "required": [
+                    "content_from"
+                  ]
+                }
               ],
               "properties": {
                 "content": {
-                  "type": "string",
-                  "description": "Bytes to append to each violating file. Mutually exclusive with `content_from`. A leading newline is the caller's responsibility."
+                  "description": "Bytes to append to each violating file. Mutually exclusive with `content_from`. A leading newline is the caller's responsibility.",
+                  "type": "string"
                 },
                 "content_from": {
-                  "type": "string",
-                  "description": "Path to a file whose bytes will be appended, relative to the lint root. Mutually exclusive with `content`. Read at fix-apply time."
+                  "description": "Path to a file whose bytes will be appended, relative to the lint root. Mutually exclusive with `content`. Read at fix-apply time.",
+                  "type": "string"
                 }
-              }
+              },
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_append"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_rename"],
           "additionalProperties": false,
           "properties": {
             "file_rename": {
-              "type": "object",
               "additionalProperties": false,
+              "description": "Rename the violating file's stem to the parent rule's target convention (e.g. filename_case's `case:`). Extension is preserved; the file stays in the same directory. No parameters.",
               "properties": {},
-              "description": "Rename the violating file's stem to the parent rule's target convention (e.g. filename_case's `case:`). Extension is preserved; the file stays in the same directory. No parameters."
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_rename"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_trim_trailing_whitespace"],
           "additionalProperties": false,
           "properties": {
             "file_trim_trailing_whitespace": {
-              "type": "object",
               "additionalProperties": false,
+              "description": "Read the violating file, strip trailing space/tab on every line, write back. Preserves LF or CRLF endings. Skipped on files larger than `fix_size_limit`.",
               "properties": {},
-              "description": "Read the violating file, strip trailing space/tab on every line, write back. Preserves LF or CRLF endings. Skipped on files larger than `fix_size_limit`."
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_trim_trailing_whitespace"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_append_final_newline"],
           "additionalProperties": false,
           "properties": {
             "file_append_final_newline": {
-              "type": "object",
               "additionalProperties": false,
+              "description": "Append a single `\\n` byte when the file has content but doesn't end with one. No-op on empty files.",
               "properties": {},
-              "description": "Append a single `\\n` byte when the file has content but doesn't end with one. No-op on empty files."
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_append_final_newline"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_normalize_line_endings"],
           "additionalProperties": false,
           "properties": {
             "file_normalize_line_endings": {
-              "type": "object",
               "additionalProperties": false,
+              "description": "Rewrite every line ending in the file to the parent rule's `target` (lf or crlf). Skipped on files larger than `fix_size_limit`.",
               "properties": {},
-              "description": "Rewrite every line ending in the file to the parent rule's `target` (lf or crlf). Skipped on files larger than `fix_size_limit`."
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_normalize_line_endings"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_strip_bidi"],
           "additionalProperties": false,
           "properties": {
             "file_strip_bidi": {
-              "type": "object",
               "additionalProperties": false,
+              "description": "Remove every Unicode bidi control character (U+202A–202E, U+2066–2069). Skipped on files larger than `fix_size_limit` or on non-UTF-8 content.",
               "properties": {},
-              "description": "Remove every Unicode bidi control character (U+202A–202E, U+2066–2069). Skipped on files larger than `fix_size_limit` or on non-UTF-8 content."
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_strip_bidi"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_strip_zero_width"],
           "additionalProperties": false,
           "properties": {
             "file_strip_zero_width": {
-              "type": "object",
               "additionalProperties": false,
+              "description": "Remove every zero-width character (U+200B/C/D, body-internal U+FEFF). A leading BOM is preserved — use `no_bom` to strip that.",
               "properties": {},
-              "description": "Remove every zero-width character (U+200B/C/D, body-internal U+FEFF). A leading BOM is preserved — use `no_bom` to strip that."
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_strip_zero_width"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_strip_bom"],
           "additionalProperties": false,
           "properties": {
             "file_strip_bom": {
-              "type": "object",
               "additionalProperties": false,
+              "description": "Remove a leading UTF-8 / UTF-16 / UTF-32 BOM from the file. No-op when no BOM is present.",
               "properties": {},
-              "description": "Remove a leading UTF-8 / UTF-16 / UTF-32 BOM from the file. No-op when no BOM is present."
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_strip_bom"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_collapse_blank_lines"],
           "additionalProperties": false,
           "properties": {
             "file_collapse_blank_lines": {
-              "type": "object",
               "additionalProperties": false,
+              "description": "Collapse runs of blank lines longer than the parent rule's `max` down to exactly `max` blank lines. Preserves the file's line endings (LF vs CRLF). Skipped on files larger than `fix_size_limit` or on non-UTF-8 content.",
               "properties": {},
-              "description": "Collapse runs of blank lines longer than the parent rule's `max` down to exactly `max` blank lines. Preserves the file's line endings (LF vs CRLF). Skipped on files larger than `fix_size_limit` or on non-UTF-8 content."
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_collapse_blank_lines"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "git_tracked_only": {
+      "default": false,
+      "description": "When true, restrict the rule to files / directories tracked in git's index. Outside a git repo the rule becomes a silent no-op for absence-style checks. Currently supported on `file_exists`, `file_absent`, `dir_exists`, `dir_absent`; other rule kinds ignore the field. See https://alint.org/docs/concepts/walker-and-gitignore/ for the full semantics.",
+      "type": "boolean"
+    },
+    "if_present": {
+      "default": false,
+      "description": "When true, a JSONPath query returning zero matches is silently OK — only real matches that fail the op produce violations. Use for predicates conditional on a field's presence (e.g. \"every `uses:` must be SHA-pinned\" where a workflow without `uses:` steps shouldn't be flagged).",
+      "type": "boolean"
+    },
+    "level": {
+      "description": "Severity. `off` disables a rule (useful when overriding inherited rules).",
+      "enum": [
+        "error",
+        "warning",
+        "info",
+        "off"
+      ],
+      "type": "string"
+    },
+    "nested_rule": {
+      "description": "A nested rule inside `require:`. Unlike top-level rules, `id` and `level` are synthesized from the parent; the user supplies only `kind` plus kind-specific options.",
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "policy_url": {
+          "format": "uri",
+          "type": "string"
+        },
+        "when": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    "paths_spec": {
+      "description": "A single glob, an array of globs (with optional `!negation`), or an explicit include/exclude pair.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "exclude": {
+              "$ref": "#/$defs/string_or_string_array"
+            },
+            "include": {
+              "$ref": "#/$defs/string_or_string_array"
+            }
+          },
+          "type": "object"
         }
       ]
     },
-
+    "per_rule_respect_gitignore": {
+      "description": "Per-rule override for the workspace-level `respect_gitignore:` setting. When `false`, this rule treats `.gitignore`-listed files as if they were untracked-but-on-disk: the rule sees them. The canonical use case is the bazel-style \"tracked AND gitignored\" pattern (a file like `.bazelversion` ships a default upstream and contributors override it locally without committing the override) — the workspace walker honours the gitignore, so `file_exists` reports \"no match\" against a file that's both on disk AND in `git ls-files`. This per-rule knob lets that single rule see the file without flipping the workspace-wide setting. Currently honoured by `file_exists` for literal-path patterns; other rule kinds + glob patterns fall through to the workspace setting. Default: inherit the workspace `respect_gitignore`. See `docs/development/CONFIG-AUTHORING.md` pitfall #18.",
+      "type": "boolean"
+    },
     "rule": {
       "description": "A rule entry — either a kind-driven rule (with `kind` and the kind-specific fields) or a template instance (with `extends_template` referencing a template id and optional `vars` overrides).",
       "oneOf": [
         {
           "allOf": [
-            { "$ref": "#/$defs/rule_common" },
-            { "$ref": "#/$defs/rule_kind_dispatch" }
+            {
+              "$ref": "#/$defs/rule_common"
+            },
+            {
+              "$ref": "#/$defs/rule_kind_dispatch"
+            }
           ],
           "unevaluatedProperties": false
         },
-        { "$ref": "#/$defs/rule_template_instance" }
+        {
+          "$ref": "#/$defs/rule_template_instance"
+        }
       ]
     },
-
-    "rule_template_instance": {
-      "description": "A rule entry that expands a `templates:` body. The instance's `id:` is required; `vars:` provides the substitutions for the template's `{{vars.<name>}}` placeholders. Any other field overrides the corresponding field in the expanded template.",
-      "type": "object",
-      "required": ["id", "extends_template"],
+    "rule_changeset_requires_path": {
+      "description": "The `<since>...HEAD` diff must ADD (git status A) at least one path matching `add_glob:` — the 'did you add a changelog entry?' gate (prettier `changelog_unreleased/`, cpython `Misc/NEWS.d/next/`, pnpm `.changeset/*.md`). `since:` (the base ref) is required. Optional `when_changed:` gates the requirement on some other glob having changed (don't demand a changelog for a docs-only PR); with no gate, any non-empty changeset triggers it. Diff-scoped: silent no-op outside a git repo / when nothing relevant changed; a `since:` that fails to resolve hard-fails with a shallow-clone hint. Check-only.",
       "properties": {
-        "id": { "$ref": "#/$defs/rule_id" },
-        "extends_template": {
-          "type": "string",
-          "description": "Id of an entry in the top-level `templates:` block to instantiate."
+        "add_glob": {
+          "description": "Glob; the diff must ADD at least one path matching it.",
+          "type": "string"
         },
-        "vars": {
-          "type": "object",
-          "additionalProperties": { "type": ["string", "number", "boolean"] },
-          "description": "Map of `name → value` to substitute into `{{vars.<name>}}` placeholders in the template body."
+        "kind": {
+          "const": "changeset_requires_path"
         },
-        "level": { "$ref": "#/$defs/level" },
-        "message": { "type": "string" },
-        "policy_url": { "type": "string", "format": "uri" },
-        "when": { "type": "string" }
-      }
-    },
-
-    "template": {
-      "description": "A reusable rule shape. Identical to a regular rule except `level` is optional (instances may add it) and the body is matched after `{{vars.<name>}}` substitution.",
-      "type": "object",
-      "required": ["id"],
-      "properties": {
-        "id": { "$ref": "#/$defs/rule_id" }
+        "since": {
+          "description": "Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}`\ninterpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
+          "type": "string"
+        },
+        "when_changed": {
+          "default": null,
+          "description": "Optional gate: only require the add when some path matching this glob\nchanged (any status). Omit to require it on any non-empty changeset.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
       },
-      "additionalProperties": true
-    },
-
-    "rule_kind_dispatch": {
-      "description": "Dispatch on the `kind` discriminator. Each branch sets the required kind-specific fields.",
-      "oneOf": [
-        { "$ref": "#/$defs/rule_file_exists" },
-        { "$ref": "#/$defs/rule_file_absent" },
-        { "$ref": "#/$defs/rule_dir_exists" },
-        { "$ref": "#/$defs/rule_dir_absent" },
-        { "$ref": "#/$defs/rule_file_content_matches" },
-        { "$ref": "#/$defs/rule_file_content_forbidden" },
-        { "$ref": "#/$defs/rule_file_header" },
-        { "$ref": "#/$defs/rule_file_max_size" },
-        { "$ref": "#/$defs/rule_file_min_size" },
-        { "$ref": "#/$defs/rule_file_min_lines" },
-        { "$ref": "#/$defs/rule_file_max_lines" },
-        { "$ref": "#/$defs/rule_file_footer" },
-        { "$ref": "#/$defs/rule_file_shebang" },
-        { "$ref": "#/$defs/rule_file_is_text" },
-        { "$ref": "#/$defs/rule_json_path_equals" },
-        { "$ref": "#/$defs/rule_json_path_matches" },
-        { "$ref": "#/$defs/rule_yaml_path_equals" },
-        { "$ref": "#/$defs/rule_yaml_path_matches" },
-        { "$ref": "#/$defs/rule_toml_path_equals" },
-        { "$ref": "#/$defs/rule_toml_path_matches" },
-        { "$ref": "#/$defs/rule_xml_path_equals" },
-        { "$ref": "#/$defs/rule_xml_path_matches" },
-        { "$ref": "#/$defs/rule_json_schema_passes" },
-        { "$ref": "#/$defs/rule_commented_out_code" },
-        { "$ref": "#/$defs/rule_markdown_paths_resolve" },
-        { "$ref": "#/$defs/rule_git_no_denied_paths" },
-        { "$ref": "#/$defs/rule_git_commit_message" },
-        { "$ref": "#/$defs/rule_git_commit_signed_off" },
-        { "$ref": "#/$defs/rule_git_commit_subject_matches" },
-        { "$ref": "#/$defs/rule_git_commit_no_fixup" },
-        { "$ref": "#/$defs/rule_git_commit_author_allowlist" },
-        { "$ref": "#/$defs/rule_git_commit_gpg_signed" },
-        { "$ref": "#/$defs/rule_git_blame_age" },
-        { "$ref": "#/$defs/rule_changeset_requires_path" },
-        { "$ref": "#/$defs/rule_pair_changed_together" },
-        { "$ref": "#/$defs/rule_filename_case" },
-        { "$ref": "#/$defs/rule_filename_regex" },
-        { "$ref": "#/$defs/rule_pair" },
-        { "$ref": "#/$defs/rule_pair_hash" },
-        { "$ref": "#/$defs/rule_registry_paths_resolve" },
-        { "$ref": "#/$defs/rule_cross_file" },
-        { "$ref": "#/$defs/rule_file_graph" },
-        { "$ref": "#/$defs/rule_ordered_block" },
-        { "$ref": "#/$defs/rule_for_each_match" },
-        { "$ref": "#/$defs/rule_generated_file_fresh" },
-        { "$ref": "#/$defs/rule_import_gate" },
-        { "$ref": "#/$defs/rule_command_idempotent" },
-        { "$ref": "#/$defs/rule_for_each_dir" },
-        { "$ref": "#/$defs/rule_for_each_file" },
-        { "$ref": "#/$defs/rule_dir_only_contains" },
-        { "$ref": "#/$defs/rule_unique_by" },
-        { "$ref": "#/$defs/rule_dir_contains" },
-        { "$ref": "#/$defs/rule_every_matching_has" },
-        { "$ref": "#/$defs/rule_no_trailing_whitespace" },
-        { "$ref": "#/$defs/rule_final_newline" },
-        { "$ref": "#/$defs/rule_line_endings" },
-        { "$ref": "#/$defs/rule_line_max_width" },
-        { "$ref": "#/$defs/rule_no_merge_conflict_markers" },
-        { "$ref": "#/$defs/rule_no_bidi_controls" },
-        { "$ref": "#/$defs/rule_no_zero_width_chars" },
-        { "$ref": "#/$defs/rule_file_is_ascii" },
-        { "$ref": "#/$defs/rule_no_bom" },
-        { "$ref": "#/$defs/rule_file_hash" },
-        { "$ref": "#/$defs/rule_max_directory_depth" },
-        { "$ref": "#/$defs/rule_max_files_per_directory" },
-        { "$ref": "#/$defs/rule_no_empty_files" },
-        { "$ref": "#/$defs/rule_no_case_conflicts" },
-        { "$ref": "#/$defs/rule_no_illegal_windows_names" },
-        { "$ref": "#/$defs/rule_no_symlinks" },
-        { "$ref": "#/$defs/rule_executable_bit" },
-        { "$ref": "#/$defs/rule_executable_has_shebang" },
-        { "$ref": "#/$defs/rule_shebang_has_executable" },
-        { "$ref": "#/$defs/rule_no_submodules" },
-        { "$ref": "#/$defs/rule_indent_style" },
-        { "$ref": "#/$defs/rule_max_consecutive_blank_lines" },
-        { "$ref": "#/$defs/rule_file_starts_with" },
-        { "$ref": "#/$defs/rule_file_ends_with" },
-        { "$ref": "#/$defs/rule_command" }
-      ]
-    },
-
-    "nested_rule": {
-      "description": "A nested rule inside `require:`. Unlike top-level rules, `id` and `level` are synthesized from the parent; the user supplies only `kind` plus kind-specific options.",
-      "type": "object",
-      "required": ["kind"],
-      "properties": {
-        "kind": { "type": "string" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "message": { "type": "string" },
-        "policy_url": { "type": "string", "format": "uri" },
-        "when": { "type": "string" }
-      }
-    },
-
-    "rule_file_exists": {
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "file_exists" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "root_only": {
-          "type": "boolean",
-          "default": false,
-          "description": "If true, only files directly at the repository root satisfy the rule."
-        },
-        "git_tracked_only": { "$ref": "#/$defs/git_tracked_only" },
-        "respect_gitignore": { "$ref": "#/$defs/per_rule_respect_gitignore" }
-      }
-    },
-
-    "rule_file_absent": {
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "file_absent" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "git_tracked_only": { "$ref": "#/$defs/git_tracked_only" }
-      }
-    },
-
-    "rule_dir_exists": {
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "dir_exists" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "git_tracked_only": { "$ref": "#/$defs/git_tracked_only" }
-      }
-    },
-
-    "rule_dir_absent": {
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "dir_absent" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "git_tracked_only": { "$ref": "#/$defs/git_tracked_only" }
-      }
-    },
-
-    "git_tracked_only": {
-      "type": "boolean",
-      "default": false,
-      "description": "When true, restrict the rule to files / directories tracked in git's index. Outside a git repo the rule becomes a silent no-op for absence-style checks. Currently supported on `file_exists`, `file_absent`, `dir_exists`, `dir_absent`; other rule kinds ignore the field. See https://alint.org/docs/concepts/walker-and-gitignore/ for the full semantics."
-    },
-
-    "per_rule_respect_gitignore": {
-      "type": "boolean",
-      "description": "Per-rule override for the workspace-level `respect_gitignore:` setting. When `false`, this rule treats `.gitignore`-listed files as if they were untracked-but-on-disk: the rule sees them. The canonical use case is the bazel-style \"tracked AND gitignored\" pattern (a file like `.bazelversion` ships a default upstream and contributors override it locally without committing the override) — the workspace walker honours the gitignore, so `file_exists` reports \"no match\" against a file that's both on disk AND in `git ls-files`. This per-rule knob lets that single rule see the file without flipping the workspace-wide setting. Currently honoured by `file_exists` for literal-path patterns; other rule kinds + glob patterns fall through to the workspace setting. Default: inherit the workspace `respect_gitignore`. See `docs/development/CONFIG-AUTHORING.md` pitfall #18."
-    },
-
-    "scope_filter": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "Per-file rule scoping. `has_ancestor` (v0.9.6+) admits files whose ancestor chain contains a named manifest; `changed_since` (v0.11+) admits files in a `<ref>...HEAD` git diff. At least one must be set; setting both is an AND. Supported on per-file rules and on `dir_absent` (since v0.9.18). Cross-file rules (`pair`, `for_each_dir`, `file_exists`, etc.) reject `scope_filter:` at build time. Combine with the rule's existing `paths:` glob — all gates must match for the rule to fire.",
-      "anyOf": [
-        { "required": ["has_ancestor"] },
-        { "required": ["changed_since"] }
+      "required": [
+        "add_glob",
+        "since"
       ],
+      "type": "object"
+    },
+    "rule_command": {
+      "description": "Shell out to an external CLI per matched file. argv[0] is the program; remaining tokens support path-template substitution (`{path}`, `{dir}`, `{stem}`, `{ext}`, `{basename}`, `{parent_name}`). Working dir = repo root; stdin = /dev/null. Env: ALINT_PATH, ALINT_ROOT, ALINT_RULE_ID, ALINT_LEVEL, plus ALINT_VAR_<NAME> per `vars:` and ALINT_FACT_<NAME> per resolved fact. Verdict: exit 0 = pass; non-zero = one violation whose message is the (truncated) stdout+stderr. Trust-gated: only allowed in the user's top-level config (rejected at load-time when introduced via `extends:` or a bundled ruleset).",
       "properties": {
-        "has_ancestor": {
-          "description": "Manifest filename (or list of filenames) whose presence in any ancestor directory of the linted file admits the rule. Each entry is a literal filename like `Cargo.toml` or `package.json` — no path separators, no glob metacharacters; the ancestor walk handles \"anywhere up the tree\" by traversing `Path::parent()` upward.",
-          "oneOf": [
-            { "type": "string", "minLength": 1 },
-            {
-              "type": "array",
-              "minItems": 1,
-              "items": { "type": "string", "minLength": 1 }
-            }
+        "command": {
+          "description": "Argv tokens. The first token is the program (looked up via PATH if it's a bare name); remaining tokens accept `{path}` and friends.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "kind": {
+          "const": "command"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "timeout": {
+          "description": "Per-file timeout in seconds. Default 30. Past this, the child is killed and a violation reports the timeout.",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "paths",
+        "command"
+      ],
+      "type": "object"
+    },
+    "rule_command_idempotent": {
+      "description": "Run a user-declared formatter/checker in its --check (idempotence) mode once: exit 0 = the tree is formatter-clean (silent), non-zero = violation(s). alint never runs a mutating formatter and never writes the tree (the sibling of generated_file_fresh; same trust tier as the command rule — trust-gated to the user's own top-level config). With `files_from` (+ optional `files_pattern`) the tool's offender list is parsed into one violation per file. Single-shot, opt-in.",
+      "properties": {
+        "command": {
+          "description": "Checker argv (no shell), run in its --check / idempotence mode; exit 0 = clean.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "files_from": {
+          "description": "On failure, parse this stream into per-file violations (default: none = one violation for the whole invocation).",
+          "enum": [
+            "none",
+            "stdout",
+            "stderr"
           ]
         },
-        "changed_since": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Git ref; the rule only fires on files in the `<ref>...HEAD` diff (the same merge-base diff as `alint check --changed`). Right shape for grandfathering pre-existing files in a PR — e.g. require an SPDX header only on files the PR touched. Accepts the `{{env.X}}` interpolation (e.g. `changed_since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`). Outside a git repo the predicate matches nothing (silent); an unresolvable ref inside a repo is a hard error with a shallow-clone hint."
-        }
-      }
-    },
-
-    "rule_file_content_matches": {
-      "type": "object",
-      "required": ["paths", "pattern"],
-      "properties": {
-        "kind": { "enum": ["file_content_matches", "content_matches"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "pattern": {
-          "type": "string",
-          "description": "Rust regex. File contents must match."
-        }
-      }
-    },
-
-    "rule_file_content_forbidden": {
-      "type": "object",
-      "required": ["paths", "pattern"],
-      "properties": {
-        "kind": { "enum": ["file_content_forbidden", "content_forbidden"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "pattern": {
-          "type": "string",
-          "description": "Rust regex. File contents must NOT match."
-        }
-      }
-    },
-
-    "rule_file_header": {
-      "type": "object",
-      "required": ["paths", "pattern"],
-      "properties": {
-        "kind": { "enum": ["file_header", "header"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "pattern": {
-          "type": "string",
-          "description": "Rust regex. The first `lines` lines of each file in scope must match."
+        "files_pattern": {
+          "description": "Regex whose capture group 1 is a file path, applied per output line (requires `files_from`; omit for bare-path listers).",
+          "type": "string"
         },
-        "lines": {
-          "type": "integer",
+        "kind": {
+          "const": "command_idempotent"
+        },
+        "timeout": {
+          "description": "Checker timeout in seconds (default 120). On timeout the child is killed and one violation is emitted.",
           "minimum": 1,
-          "default": 20,
-          "description": "Number of leading lines to consider."
-        }
-      }
-    },
-
-    "rule_file_max_size": {
-      "type": "object",
-      "required": ["paths", "max_bytes"],
-      "properties": {
-        "kind": { "enum": ["file_max_size", "max_size"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "max_bytes": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Maximum allowed file size in bytes."
-        }
-      }
-    },
-
-    "rule_file_min_size": {
-      "description": "Files in scope must be at least `min_bytes` bytes. Catches placeholder / stub files that pass existence checks but contain no useful content (e.g. a 20-byte README).",
-      "type": "object",
-      "required": ["paths", "min_bytes"],
-      "properties": {
-        "kind": { "enum": ["file_min_size", "min_size"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "min_bytes": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Minimum allowed file size in bytes."
-        }
-      }
-    },
-
-    "rule_file_min_lines": {
-      "description": "Files in scope must have at least `min_lines` lines (where a line is `\\n`-terminated, with an unterminated trailing segment counting as one more, matching `wc -l` semantics). Common use: require README / CHANGELOG / SECURITY.md to be more than a title plus one sentence.",
-      "type": "object",
-      "required": ["paths", "min_lines"],
-      "properties": {
-        "kind": { "enum": ["file_min_lines", "min_lines"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "min_lines": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Minimum allowed line count."
-        }
-      }
-    },
-
-    "rule_file_max_lines": {
-      "description": "Files in scope must have at most `max_lines` lines, with the same `wc -l`-style accounting as `file_min_lines`. Use to catch the everything-module anti-pattern.",
-      "type": "object",
-      "required": ["paths", "max_lines"],
-      "properties": {
-        "kind": { "enum": ["file_max_lines", "max_lines"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "max_lines": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Maximum allowed line count."
-        }
-      }
-    },
-
-    "rule_file_footer": {
-      "description": "Last `lines` lines of each file in scope must match `pattern` (Rust regex). Mirror of `file_header` anchored at the END of the file. Use for license footers, signed-off-by trailers, generated-file sentinels.",
-      "type": "object",
-      "required": ["paths", "pattern"],
-      "properties": {
-        "kind": { "enum": ["file_footer", "footer"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "pattern": {
-          "type": "string",
-          "description": "Rust regex. The last `lines` lines of each file must match."
+          "type": "integer"
         },
-        "lines": {
-          "type": "integer",
-          "minimum": 1,
-          "default": 20,
-          "description": "Number of trailing lines to consider."
+        "workdir": {
+          "description": "Checker cwd, relative to the lint root (default: lint root).",
+          "type": "string"
         }
-      }
+      },
+      "required": [
+        "command"
+      ],
+      "type": "object"
     },
-
-    "rule_file_shebang": {
-      "description": "First line of each file in scope must match the `shebang` regex. Pairs with `executable_has_shebang` (presence) and `shebang_has_executable` (the inverse) to enforce shebang shape, e.g. require `^#!/usr/bin/env bash$`.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "enum": ["file_shebang", "shebang"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "shebang": {
-          "type": "string",
-          "default": "^#!",
-          "description": "Rust regex; the first line of every matched file must match. Default `^#!` only enforces shebang presence."
-        }
-      }
-    },
-
-    "rule_file_is_text": {
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "enum": ["file_is_text", "is_text"] },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_json_path_equals": {
-      "description": "Value at a JSONPath (RFC 9535) expression in every JSON file in `paths` must deep-equal `equals`. Multiple matches all must match; zero matches is a violation (value missing) unless `if_present: true`. Typical use: `$.license == \"MIT\"` on every `packages/*/package.json`.",
-      "type": "object",
-      "required": ["paths", "path", "equals"],
-      "properties": {
-        "kind": { "const": "json_path_equals" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "path": {
-          "type": "string",
-          "description": "JSONPath expression rooted at `$`. Supports dot-access (`$.foo.bar`), array index (`$.deps[0]`), wildcards (`$.deps[*]`), filters, and every other RFC 9535 construct."
-        },
-        "equals": {
-          "description": "Expected value. Any JSON type (string, number, boolean, null, array, object)."
-        },
-        "if_present": { "$ref": "#/$defs/if_present" }
-      }
-    },
-
-    "rule_json_path_matches": {
-      "description": "Value at a JSONPath in every JSON file in `paths` must be a string and must match `matches` (a Rust regex). Non-string matches produce a clear 'not a string' violation.",
-      "type": "object",
-      "required": ["paths", "path", "matches"],
-      "properties": {
-        "kind": { "const": "json_path_matches" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "path": { "type": "string" },
-        "matches": {
-          "type": "string",
-          "description": "Rust-regex pattern to match against the value at `path`."
-        },
-        "if_present": { "$ref": "#/$defs/if_present" }
-      }
-    },
-
-    "rule_yaml_path_equals": {
-      "description": "YAML sibling of `json_path_equals`. Parses the file as YAML before applying the JSONPath query. Use this on GitHub Actions workflows, docker-compose.yml, kubernetes manifests, `.gitlab-ci.yml`, etc.",
-      "type": "object",
-      "required": ["paths", "path", "equals"],
-      "properties": {
-        "kind": { "const": "yaml_path_equals" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "path": { "type": "string" },
-        "equals": {},
-        "if_present": { "$ref": "#/$defs/if_present" }
-      }
-    },
-
-    "rule_yaml_path_matches": {
-      "description": "YAML sibling of `json_path_matches`.",
-      "type": "object",
-      "required": ["paths", "path", "matches"],
-      "properties": {
-        "kind": { "const": "yaml_path_matches" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "path": { "type": "string" },
-        "matches": { "type": "string" },
-        "if_present": { "$ref": "#/$defs/if_present" }
-      }
-    },
-
-    "rule_toml_path_equals": {
-      "description": "TOML sibling of `json_path_equals`. Typical use: enforce `[package].edition == \"2024\"` on every `Cargo.toml`.",
-      "type": "object",
-      "required": ["paths", "path", "equals"],
-      "properties": {
-        "kind": { "const": "toml_path_equals" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "path": { "type": "string" },
-        "equals": {},
-        "if_present": { "$ref": "#/$defs/if_present" }
-      }
-    },
-
-    "rule_toml_path_matches": {
-      "description": "TOML sibling of `json_path_matches`.",
-      "type": "object",
-      "required": ["paths", "path", "matches"],
-      "properties": {
-        "kind": { "const": "toml_path_matches" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "path": { "type": "string" },
-        "matches": { "type": "string" },
-        "if_present": { "$ref": "#/$defs/if_present" }
-      }
-    },
-
-    "rule_xml_path_equals": {
-      "description": "XML sibling of `json_path_equals`. XML maps to the same value tree via the xmltodict-style convention: attributes are `@name` keys, repeated child elements become an array, a leaf element collapses to its text string, namespaces flatten to local names, and every leaf value is a string (quote your `equals:`, e.g. `equals: \"4.0.0\"`). Typical use: enforce `$.Project.PropertyGroup.TargetFramework == \"net8.0\"` on every `.csproj`, or a Maven `$.project.parent.version` across `pom.xml`.",
-      "type": "object",
-      "required": ["paths", "path", "equals"],
-      "properties": {
-        "kind": { "const": "xml_path_equals" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "path": { "type": "string" },
-        "equals": {},
-        "if_present": { "$ref": "#/$defs/if_present" }
-      }
-    },
-
-    "rule_xml_path_matches": {
-      "description": "XML sibling of `json_path_matches` (same xmltodict-style mapping as `xml_path_equals`; all XML leaf values are strings). Typical use: `$.Project.ItemGroup.PackageReference[*]['@Version']` matches a version pattern across `.csproj`.",
-      "type": "object",
-      "required": ["paths", "path", "matches"],
-      "properties": {
-        "kind": { "const": "xml_path_matches" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "path": { "type": "string" },
-        "matches": { "type": "string" },
-        "if_present": { "$ref": "#/$defs/if_present" }
-      }
-    },
-
-    "rule_json_schema_passes": {
-      "description": "Validate every JSON / YAML / TOML file in `paths` against the JSON Schema at `schema_path`. Each schema-violation error becomes one violation; a target that fails to parse produces one parse-error violation. Format is detected from the target's extension; pass `format:` to override.",
-      "type": "object",
-      "required": ["paths", "schema_path"],
-      "properties": {
-        "kind": { "const": "json_schema_passes" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "schema_path": {
-          "type": "string",
-          "description": "Path to a JSON Schema file relative to the lint root. Schema must itself be JSON even when validating YAML / TOML targets."
-        },
-        "format": {
-          "type": "string",
-          "enum": ["json", "yaml", "yml", "toml"],
-          "description": "Override the auto-detected target format. When omitted, format is inferred from each target file's extension (.json / .yaml / .yml / .toml)."
-        }
-      }
-    },
-
     "rule_commented_out_code": {
       "description": "Heuristic detector for blocks of commented-out source code (as opposed to prose comments, license headers, doc comments, or ASCII banners). For each consecutive run of comment lines (≥ `min_lines`), counts the fraction of non-whitespace characters that are structural punctuation strongly biased toward code (`( ) { } [ ] ; = < > & | ^`). Scores ≥ `threshold` (after a runs-of-5+-identical-chars defang to drop ASCII banners) fire as violations. Doc-comment blocks (`/// `, `/** … */`) are excluded; the file's first `skip_leading_lines` lines are skipped to pass over license headers without false-positive flagging. Severity defaults to `warning`; the rule explicitly does not ship at `error` because heuristics have non-zero FP rate and shouldn't gate commits on first adoption. Check-only — auto-removing commented-out code is destructive.",
-      "type": "object",
-      "required": ["paths"],
       "properties": {
-        "kind": { "const": "commented_out_code" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
+        "kind": {
+          "const": "commented_out_code"
+        },
         "language": {
-          "type": "string",
+          "default": "auto",
+          "description": "Comment-marker set to use. `auto` (default) infers from each file's extension. Files with extensions the resolver doesn't recognise are silently skipped.",
           "enum": [
             "auto",
             "rust",
@@ -930,1251 +685,2721 @@
             "ruby",
             "shell"
           ],
-          "default": "auto",
-          "description": "Comment-marker set to use. `auto` (default) infers from each file's extension. Files with extensions the resolver doesn't recognise are silently skipped."
+          "type": "string"
         },
         "min_lines": {
-          "type": "integer",
-          "minimum": 2,
           "default": 3,
-          "description": "Minimum consecutive comment-line count for a block to be considered. Default 3 — 1-2 line comments are almost always prose."
+          "description": "Minimum consecutive comment-line count for a block to be considered. Default 3 — 1-2 line comments are almost always prose.",
+          "minimum": 2,
+          "type": "integer"
         },
-        "threshold": {
-          "type": "number",
-          "minimum": 0.0,
-          "maximum": 1.0,
-          "default": 0.5,
-          "description": "Density floor for code-shapedness. Higher = stricter. Default 0.5 sits at the midpoint between obvious-prose (0.0) and obvious-code (1.0); lower it to widen the catch (more FPs), raise it to narrow."
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
         },
         "skip_leading_lines": {
-          "type": "integer",
-          "minimum": 0,
           "default": 30,
-          "description": "Skip blocks whose first line is at or before this line number. Default 30 — covers typical license headers without false-positive flagging them as commented-out code."
-        }
-      }
-    },
-
-    "rule_markdown_paths_resolve": {
-      "description": "Validate that backticked workspace paths in markdown files resolve to real files or directories in the repo. Targets the AGENTS.md / CLAUDE.md / .cursorrules staleness problem: agent-context files reference paths in inline backticks, and those paths drift as the codebase evolves. Skips fenced and 4-space-indented code blocks (those contain code samples, not factual claims about the tree). Required `prefixes` field marks which path-shapes to validate (e.g. `[\"src/\", \"crates/\", \"docs/\"]`); backticked tokens not starting with a configured prefix are ignored, eliminating the FP class of `\\`npm\\`` / `\\`function\\`` / etc.",
-      "type": "object",
-      "required": ["paths", "prefixes"],
-      "properties": {
-        "kind": { "const": "markdown_paths_resolve" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "prefixes": {
-          "type": "array",
-          "items": { "type": "string" },
-          "minItems": 1,
-          "description": "Path-shape prefixes to validate. A backticked token must start with one of these to be considered a path candidate. No defaults — declare the prefixes that mark a path in your codebase."
+          "description": "Skip blocks whose first line is at or before this line number. Default 30 — covers typical license headers without false-positive flagging them as commented-out code.",
+          "minimum": 0,
+          "type": "integer"
         },
-        "ignore_template_vars": {
-          "type": "boolean",
-          "default": true,
-          "description": "When true (default), skip backticked tokens containing `{{ … }}`, `${ … }`, or `<…>` template-variable markers. These are placeholders, not real paths."
-        }
-      }
-    },
-
-    "rule_git_no_denied_paths": {
-      "description": "Fire when any tracked path matches a configured glob denylist. Companion of `git_tracked_only` for the absence axis: catches secrets, large binaries, or accidentally-tracked artifacts that would otherwise need a `file_absent` per pattern. With `since:` set, only paths changed in the `<since>...HEAD` diff are flagged (PR-scoped). Outside a git repo, silently no-ops; a `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
-      "type": "object",
-      "required": ["denied"],
-      "properties": {
-        "kind": { "const": "git_no_denied_paths" },
-        "denied": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "type": "string" },
-          "description": "Globset patterns no tracked path may match. Both whole-path patterns (`secrets/**`) and basename-only patterns (`*.env`) work."
-        },
-        "since": {
-          "type": "string",
-          "description": "Optional git ref. When set, only denied paths that changed in the `<since>...HEAD` diff are flagged — catches a secret added in a PR even if HEAD's tree still tracks an older one. Accepts the `{{env.X}}` interpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`."
-        }
-      }
-    },
-
-    "rule_git_commit_message": {
-      "description": "Validate one or more commit messages against shape rules: regex, max subject length, body required. With `since:` unset, only HEAD is checked. With `since:` set to a ref, every commit in `<since>..HEAD` is checked (oldest first, merge commits excluded by default); right shape for PR-trigger workflows where HEAD is a synthetic `actions/checkout` merge commit. At least one of `pattern:` / `subject_max_length:` / `requires_body: true` must be set. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
-      "type": "object",
-      "properties": {
-        "kind": { "const": "git_commit_message" },
-        "pattern": {
-          "type": "string",
-          "description": "Rust-regex pattern the full message (subject + body, joined with newlines) must match. Use `(?s)` to make `.` match newlines."
-        },
-        "subject_max_length": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Maximum number of characters allowed in the subject line. Common values: 50 (Tim Pope's recommendation), 72 (GitHub PR-title cutoff)."
-        },
-        "requires_body": {
-          "type": "boolean",
-          "default": false,
-          "description": "When true, the message must have a non-empty body, that is, at least one line of content after the subject's blank-line separator."
-        },
-        "since": {
-          "type": "string",
-          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does: SHA (full or abbreviated), branch (`origin/main`), tag (`v1.2.3`), or relative ref (`HEAD~5`). Supports POSIX `${VAR}` and `${VAR:-default}` env-var interpolation so CI can pass a SHA via an env var (e.g. `since: ${ALINT_BASE_SHA:-origin/main}` with `ALINT_BASE_SHA` exported in a workflow step from `github.event.pull_request.base.sha`). The GitHub Actions double-brace template syntax `${{ ... }}` is NOT interpolated by alint."
-        },
-        "include_merges": {
-          "type": "boolean",
-          "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Defaults to `false` because merge commits in PR contexts are typically the synthetic merge `actions/checkout` produces (with an auto-generated subject the rule would always flag) or maintainer-resolved merges from the base branch. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error."
+        "threshold": {
+          "default": 0.5,
+          "description": "Density floor for code-shapedness. Higher = stricter. Default 0.5 sits at the midpoint between obvious-prose (0.0) and obvious-code (1.0); lower it to widen the catch (more FPs), raise it to narrow.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "type": "number"
         }
       },
-      "anyOf": [
-        { "required": ["pattern"] },
-        { "required": ["subject_max_length"] },
-        { "required": ["requires_body"] }
-      ]
+      "required": [
+        "paths"
+      ],
+      "type": "object"
     },
-
-    "rule_git_commit_signed_off": {
-      "description": "Assert every commit in scope carries a DCO `Signed-off-by:` trailer. With `since:` unset, only HEAD is checked; with `since:` set to a ref, every commit in `<since>..HEAD` is checked (oldest first, merge commits excluded by default) — the right shape for PR-trigger workflows. Required by CNCF / Linux Foundation / kernel-style projects. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
-      "type": "object",
+    "rule_common": {
       "properties": {
-        "kind": { "const": "git_commit_signed_off" },
-        "pattern": {
-          "type": "string",
-          "description": "Trailer pattern each commit message must contain. Defaults to the canonical DCO sign-off shape `(?m)^Signed-off-by: .+ <.+@.+>$`. Override to enforce a stricter form (e.g. a corporate-domain email)."
+        "fix": {
+          "$ref": "#/$defs/fix"
         },
-        "since": {
-          "type": "string",
-          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`."
+        "id": {
+          "$ref": "#/$defs/rule_id"
         },
-        "include_merges": {
-          "type": "boolean",
-          "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error."
-        }
-      }
-    },
-
-    "rule_git_commit_subject_matches": {
-      "description": "Each commit's subject line (the first line of its message) must match the `matches:` regex — the subject-grammar member of the commit family (e.g. `pkg/path: lowercase summary`, conventional-commit types). Anchored to the subject alone, unlike `git_commit_message`'s whole-message `pattern:`; use `git_commit_message`'s `subject_max_length:` for a length cap. With `since:` unset, only HEAD is checked; with `since:` set, every commit in `<since>..HEAD`. Outside a git repo / with no commits / when git is unavailable, silently no-ops; a bad `since:` ref hard-fails with a shallow-clone hint.",
-      "type": "object",
-      "required": ["matches"],
-      "properties": {
-        "kind": { "const": "git_commit_subject_matches" },
-        "matches": {
-          "type": "string",
-          "description": "Rust-regex the commit subject (first line of the message) must match."
+        "kind": {
+          "description": "The primitive rule kind. See docs/design/ARCHITECTURE.md §4.4 for the full catalog.",
+          "type": "string"
         },
-        "since": {
-          "type": "string",
-          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`."
+        "level": {
+          "$ref": "#/$defs/level"
         },
-        "include_merges": {
-          "type": "boolean",
-          "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error."
-        }
-      }
-    },
-
-    "rule_git_commit_no_fixup": {
-      "description": "Fail on residual `fixup!` / `squash!` / `amend!` commits in scope — the ones `git commit --fixup`/`--squash` produce, meant to be collapsed by `git rebase --autosquash` before merging. With `since:` unset, only HEAD is checked; with `since:` set to a ref, every commit in `<since>..HEAD` is checked. No configuration knobs — the matched prefixes are exactly what `--autosquash` understands. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
-      "type": "object",
-      "properties": {
-        "kind": { "const": "git_commit_no_fixup" },
-        "since": {
-          "type": "string",
-          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`."
+        "message": {
+          "description": "Override the default failure message. Supports `{{vars.*}}` and `{{ctx.*}}` substitution.",
+          "type": "string"
         },
-        "include_merges": {
-          "type": "boolean",
-          "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error."
-        }
-      }
-    },
-
-    "rule_git_commit_author_allowlist": {
-      "description": "Assert every commit author in scope matches an allowed email and/or name pattern. At least one of `email_pattern:` / `name_pattern:` is required; specifying both means BOTH must match (AND). A commit whose author fails any specified pattern fires one violation. With `since:` unset, only HEAD is checked; with `since:` set to a ref, every commit in `<since>..HEAD` is checked. Demand: enterprise repos enforcing contributor identity against a corporate domain; OSS projects catching sock-puppet / compromised-account commits. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
-      "type": "object",
-      "properties": {
-        "kind": { "const": "git_commit_author_allowlist" },
-        "email_pattern": {
-          "type": "string",
-          "description": "Rust-regex the author email (`git log %ae`) must match, e.g. `^.+@example\\.com$`."
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
         },
-        "name_pattern": {
-          "type": "string",
-          "description": "Rust-regex the author name (`git log %an`) must match."
+        "policy_url": {
+          "description": "Link to a human-readable policy justification.",
+          "format": "uri",
+          "type": "string"
         },
-        "since": {
-          "type": "string",
-          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`."
+        "scope_filter": {
+          "$ref": "#/$defs/scope_filter"
         },
-        "include_merges": {
-          "type": "boolean",
-          "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error."
+        "when": {
+          "description": "Gate the rule on a fact-based expression (available from v0.2).",
+          "type": "string"
         }
       },
-      "anyOf": [
-        { "required": ["email_pattern"] },
-        { "required": ["name_pattern"] }
-      ]
+      "required": [
+        "id",
+        "kind",
+        "level"
+      ],
+      "type": "object"
     },
-
-    "rule_git_commit_gpg_signed": {
-      "description": "Assert every commit in scope has a verifying signature (`git verify-commit` exits 0). A commit that is unsigned, or signed with a key that doesn't verify against the local keyring, fires one violation. With `since:` unset, only HEAD is checked; with `since:` set to a ref, every commit in `<since>..HEAD` is checked. Demand: kernel maintainers, security-sensitive OSS, GitHub 'Require signed commits' branch protection. Reflects git's own verdict — does NOT distinguish 'unsigned' from 'signed with an untrusted key' (trust is git's GPG config / `.git/allowed_signers`). Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
-      "type": "object",
-      "properties": {
-        "kind": { "const": "git_commit_gpg_signed" },
-        "since": {
-          "type": "string",
-          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`."
-        },
-        "include_merges": {
-          "type": "boolean",
-          "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error."
-        }
-      }
-    },
-
-    "rule_git_blame_age": {
-      "description": "Fire on lines matching a regex whose `git blame` author-time is older than `max_age_days`. Closes the gap between `level: warning` on every TODO (too noisy) and `level: off` (accepts unbounded debt accumulation). Use cases: stale TODO / FIXME / XXX / HACK markers, abandoned `@deprecated` JSDoc tags, model-attributed TODOs that nobody followed up on. Outside a git repo, on untracked files, or when blame fails for any other reason, the rule silently no-ops per file. Heuristic notes: formatting passes (cargo fmt, prettier) reset blame age unless the formatting commit is listed in `.git-blame-ignore-revs`; vendored / imported code carries the import commit's timestamp; squash-merged PRs collapse to a single date. Check-only — auto-removing matched lines is destructive.",
-      "type": "object",
-      "required": ["paths", "pattern", "max_age_days"],
-      "properties": {
-        "kind": { "const": "git_blame_age" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "pattern": {
-          "type": "string",
-          "description": "Rust-regex pattern applied to each blame line's content. Capture group 1 (when present) is exposed as `{{ctx.match}}` in the message template; without a capture group, `{{ctx.match}}` substitutes the full match."
-        },
-        "max_age_days": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Minimum line age (in days) for a matching line to fire as a violation. Lines younger than this pass silently. Common values: 90 (one quarter), 180 (half a year), 365 (a full year of debt)."
-        }
-      }
-    },
-
-    "rule_changeset_requires_path": {
-      "description": "The `<since>...HEAD` diff must ADD (git status A) at least one path matching `add_glob:` — the 'did you add a changelog entry?' gate (prettier `changelog_unreleased/`, cpython `Misc/NEWS.d/next/`, pnpm `.changeset/*.md`). `since:` (the base ref) is required. Optional `when_changed:` gates the requirement on some other glob having changed (don't demand a changelog for a docs-only PR); with no gate, any non-empty changeset triggers it. Diff-scoped: silent no-op outside a git repo / when nothing relevant changed; a `since:` that fails to resolve hard-fails with a shallow-clone hint. Check-only.",
-      "type": "object",
-      "required": ["add_glob", "since"],
-      "properties": {
-        "kind": { "const": "changeset_requires_path" },
-        "add_glob": {
-          "type": "string",
-          "description": "Glob; the diff must ADD at least one path matching it."
-        },
-        "when_changed": {
-          "type": "string",
-          "description": "Optional gate: only require the add when some path matching this glob changed (any status). Omit to require it on any non-empty changeset."
-        },
-        "since": {
-          "type": "string",
-          "description": "Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}` interpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`."
-        }
-      }
-    },
-
-    "rule_pair_changed_together": {
-      "description": "If the `<since>...HEAD` diff changes any path matching `if_changed:`, at least one path matching `then_changed:` must change in the same range — the co-change gate (a FORMAT_VERSION must bump when the format struct changes; version.txt and the lockfile change together). Both globs and `since:` (the base ref) are required. Directional: a `then_changed`-only change never triggers it (add a second rule with the globs swapped for a bidirectional pact). Diff-scoped: silent no-op outside a git repo / when `if_changed` didn't change; a `since:` that fails to resolve hard-fails with a shallow-clone hint. Check-only.",
-      "type": "object",
-      "required": ["if_changed", "then_changed", "since"],
-      "properties": {
-        "kind": { "const": "pair_changed_together" },
-        "if_changed": {
-          "type": "string",
-          "description": "Glob; the trigger. When the diff changes a path matching this, a `then_changed` co-change is required."
-        },
-        "then_changed": {
-          "type": "string",
-          "description": "Glob; the obligation. At least one changed path must match it whenever `if_changed` fired."
-        },
-        "since": {
-          "type": "string",
-          "description": "Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}` interpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`."
-        }
-      }
-    },
-
-    "if_present": {
-      "type": "boolean",
-      "default": false,
-      "description": "When true, a JSONPath query returning zero matches is silently OK — only real matches that fail the op produce violations. Use for predicates conditional on a field's presence (e.g. \"every `uses:` must be SHA-pinned\" where a workflow without `uses:` steps shouldn't be flagged)."
-    },
-
-    "rule_filename_case": {
-      "type": "object",
-      "required": ["paths", "case"],
-      "properties": {
-        "kind": { "const": "filename_case" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "case": { "$ref": "#/$defs/case_convention" }
-      }
-    },
-
-    "rule_filename_regex": {
-      "type": "object",
-      "required": ["paths", "pattern"],
-      "properties": {
-        "kind": { "const": "filename_regex" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "pattern": {
-          "type": "string",
-          "description": "Rust regex, automatically anchored with ^...$ by the engine."
-        },
-        "stem": {
-          "type": "boolean",
-          "default": false,
-          "description": "Match the file stem (no extension) instead of the full basename."
-        }
-      }
-    },
-
-    "rule_pair": {
-      "description": "For every file matching `primary`, a file matching the `partner` template must exist. Template tokens: {dir}, {stem}, {ext}, {basename}, {path}, {parent_name}.",
-      "type": "object",
-      "required": ["primary", "partner"],
-      "properties": {
-        "kind": { "const": "pair" },
-        "primary": {
-          "type": "string",
-          "description": "Glob selecting the primary files."
-        },
-        "partner": {
-          "type": "string",
-          "description": "Path template resolved per primary match. Example: \"{dir}/{stem}.h\"."
-        }
-      }
-    },
-
-    "rule_pair_hash": {
-      "description": "Cross-file: the `algorithm` digest of every file matching `source` must appear in the single `target` file — either as an embedded hex substring (`format: contains`, the default) or a coreutils / go-`.sum`-style `<hex>  <path>` manifest line (`format: sums-line`). Detection-only (alint never rewrites the manifest). A missing `target` is one violation; one violation per source whose digest is absent or mismatched. golang/go FIPS `fips140.sum` is the canonical use.",
-      "type": "object",
-      "required": ["source", "target"],
-      "properties": {
-        "kind": { "const": "pair_hash" },
-        "source": {
-          "type": "string",
-          "description": "Literal path or glob selecting the file(s) whose content is hashed (one check per match)."
-        },
-        "target": {
-          "type": "string",
-          "description": "The single file that must carry the digest (a `.sum` / `SHA256SUMS` / file with an embedded hash)."
-        },
-        "algorithm": {
-          "enum": ["sha256", "sha512"],
-          "description": "Digest algorithm (default: sha256)."
-        },
-        "format": {
-          "enum": ["contains", "sums-line"],
-          "description": "How the digest must appear in `target`: `contains` = hex substring anywhere (default); `sums-line` = a `<hex> [*]<path>` line whose path token is the source's path."
-        }
-      }
-    },
-
-    "rule_registry_paths_resolve": {
-      "description": "A manifest enumerates path entries; each must resolve to an on-disk artefact. `extract` selects how the entry list is pulled (structured-query toml/json/yaml, a line list, or regex capture group 1). Optional `orphans` adds the reverse check: on-disk artefacts under `space` that no entry references. Non-literal entries (interpolation / antiquotation) are skipped, not failed.",
-      "type": "object",
-      "required": ["source", "extract"],
-      "properties": {
-        "kind": { "const": "registry_paths_resolve" },
-        "source": {
-          "type": "string",
-          "description": "The manifest/registry file (path, or a glob to run once per matching manifest) that enumerates the path entries."
-        },
-        "extract": {
-          "type": "object",
-          "description": "Exactly one of: toml/json/yaml (RFC 9535 JSONPath string), lines (object; optional `comment` prefix, default `#`), regex (string; capture group 1 is the path).",
-          "minProperties": 1,
-          "maxProperties": 1,
-          "properties": {
-            "toml": { "type": "string" },
-            "json": { "type": "string" },
-            "yaml": { "type": "string" },
-            "lines": {
-              "type": "object",
-              "properties": { "comment": { "type": "string" } },
-              "additionalProperties": false
-            },
-            "regex": { "type": "string" }
-          },
-          "additionalProperties": false
-        },
-        "base": {
-          "type": "string",
-          "description": "Resolve entries relative to: registry_dir (default), lint_root, or an explicit path."
-        },
-        "entries_are_globs": { "type": "boolean" },
-        "expect": { "enum": ["any", "file", "dir"] },
-        "must_contain": { "type": "string" },
-        "exclude_query": { "type": "string" },
-        "orphans": {
-          "type": "object",
-          "required": ["space"],
-          "properties": {
-            "space": { "type": "string" },
-            "unreferenced": { "enum": ["warn", "error", "off"] }
-          },
-          "additionalProperties": false
-        }
-      }
-    },
-
-    "extract_spec": {
-      "type": "object",
-      "description": "Exactly one of: toml/json/yaml (RFC 9535 JSONPath string), lines (object; optional `comment` prefix, default `#`), regex (string; capture group 1 is the value), whole_file (object `{}`; the entire file content as one value — for byte-level cross_file comparison; the non-literal skip does not apply).",
-      "minProperties": 1,
-      "maxProperties": 1,
-      "properties": {
-        "toml": { "type": "string" },
-        "json": { "type": "string" },
-        "yaml": { "type": "string" },
-        "lines": {
-          "type": "object",
-          "properties": { "comment": { "type": "string" } },
-          "additionalProperties": false
-        },
-        "regex": { "type": "string" },
-        "whole_file": {
-          "type": "object",
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-
     "rule_cross_file": {
       "description": "A `source` file must hold a `relation` to one or more `targets` (or the filesystem). Value relations extract values: `equals` (default — every target value equals the single source value; the released `cross_file_value_equals`), `subset` / `superset` / `set_equals` (the source's extracted set vs each target's set). `identical` compares whole files byte-for-byte (no `extract`; optional `skip_header_lines`). `resolves` checks that each path the source extracts exists on disk (`source.extract`, no `targets` — the forward half of `registry_paths_resolve`). `targets` is a `{ files: <glob>, extract }` map or a `[{ file, extract }]` list. `normalize` relaxes value comparison. Non-literal values are skipped, not failed. `cross_file_value_equals` is a byte-compatible alias (relation defaults to equals). The per-relation shape (which of `source.extract` / `targets` is present) is validated at load.",
-      "type": "object",
-      "required": ["source"],
       "properties": {
-        "kind": { "enum": ["cross_file", "cross_file_value_equals"] },
-        "source": {
-          "type": "object",
+        "allow_missing_target": {
+          "type": "boolean"
+        },
+        "kind": {
+          "enum": [
+            "cross_file",
+            "cross_file_value_equals"
+          ]
+        },
+        "normalize": {
+          "description": "A normalize transform, or an ordered list of transforms applied left-to-right (`[trim, semver-minor]`). `semver-major` / `semver-minor` keep only the leading MAJOR / MAJOR.MINOR band (each token's leading digits, leading non-digits stripped) — the protobuf / pnpm version-format reconcile.",
           "oneOf": [
-            { "required": ["file"] },
-            { "required": ["files"] }
+            {
+              "enum": [
+                "none",
+                "trim",
+                "lower",
+                "semver-major",
+                "semver-minor"
+              ]
+            },
+            {
+              "items": {
+                "enum": [
+                  "none",
+                  "trim",
+                  "lower",
+                  "semver-major",
+                  "semver-minor"
+                ]
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "relation": {
+          "enum": [
+            "equals",
+            "subset",
+            "superset",
+            "set_equals",
+            "identical",
+            "resolves"
+          ]
+        },
+        "skip_header_lines": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "source": {
+          "additionalProperties": false,
+          "oneOf": [
+            {
+              "required": [
+                "file"
+              ]
+            },
+            {
+              "required": [
+                "files"
+              ]
+            }
           ],
           "properties": {
-            "file": { "type": "string", "description": "A single source file." },
-            "files": { "type": "string", "description": "A glob whose matches are read and whose extracted values are UNIONED into one set — for the set relations only (subset / superset / set_equals). The 'every match across a glob == a set' shape." },
-            "extract": { "$ref": "#/$defs/extract_spec" }
+            "extract": {
+              "$ref": "#/$defs/extract_spec"
+            },
+            "file": {
+              "description": "A single source file.",
+              "type": "string"
+            },
+            "files": {
+              "description": "A glob whose matches are read and whose extracted values are UNIONED into one set — for the set relations only (subset / superset / set_equals). The 'every match across a glob == a set' shape.",
+              "type": "string"
+            }
           },
-          "additionalProperties": false
+          "type": "object"
         },
         "targets": {
           "oneOf": [
             {
-              "type": "object",
-              "required": ["files"],
+              "additionalProperties": false,
               "properties": {
-                "files": { "type": "string" },
-                "extract": { "$ref": "#/$defs/extract_spec" }
+                "extract": {
+                  "$ref": "#/$defs/extract_spec"
+                },
+                "files": {
+                  "type": "string"
+                }
               },
-              "additionalProperties": false
+              "required": [
+                "files"
+              ],
+              "type": "object"
             },
             {
-              "type": "array",
               "items": {
-                "type": "object",
-                "required": ["file"],
+                "additionalProperties": false,
                 "properties": {
-                  "file": { "type": "string" },
-                  "extract": { "$ref": "#/$defs/extract_spec" }
+                  "extract": {
+                    "$ref": "#/$defs/extract_spec"
+                  },
+                  "file": {
+                    "type": "string"
+                  }
                 },
-                "additionalProperties": false
-              }
+                "required": [
+                  "file"
+                ],
+                "type": "object"
+              },
+              "type": "array"
             }
           ]
-        },
-        "relation": { "enum": ["equals", "subset", "superset", "set_equals", "identical", "resolves"] },
-        "normalize": {
-          "description": "A normalize transform, or an ordered list of transforms applied left-to-right (`[trim, semver-minor]`). `semver-major` / `semver-minor` keep only the leading MAJOR / MAJOR.MINOR band (each token's leading digits, leading non-digits stripped) — the protobuf / pnpm version-format reconcile.",
-          "oneOf": [
-            { "enum": ["none", "trim", "lower", "semver-major", "semver-minor"] },
-            {
-              "type": "array",
-              "items": { "enum": ["none", "trim", "lower", "semver-major", "semver-minor"] }
-            }
-          ]
-        },
-        "allow_missing_target": { "type": "boolean" },
-        "skip_header_lines": { "type": "integer", "minimum": 0 }
-      }
+        }
+      },
+      "required": [
+        "source"
+      ],
+      "type": "object"
     },
-
+    "rule_dir_absent": {
+      "properties": {
+        "git_tracked_only": {
+          "$ref": "#/$defs/git_tracked_only"
+        },
+        "kind": {
+          "const": "dir_absent"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_dir_contains": {
+      "description": "Every directory matching `select` must have at least one direct child basename matching each glob in `require`. Sugar over for_each_dir + file_exists; use for_each_dir for deeper semantics.",
+      "properties": {
+        "kind": {
+          "const": "dir_contains"
+        },
+        "require": {
+          "description": "Basename glob(s) — every dir matching `select` must have at least one child matching each.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          ]
+        },
+        "select": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "select",
+        "require"
+      ],
+      "type": "object"
+    },
+    "rule_dir_exists": {
+      "properties": {
+        "git_tracked_only": {
+          "$ref": "#/$defs/git_tracked_only"
+        },
+        "kind": {
+          "const": "dir_exists"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_dir_only_contains": {
+      "description": "Every direct child *file* of directories matching `select` must match at least one glob in `allow`. Subdirectories of the matched dir are not checked. Allow globs match the child's basename.",
+      "properties": {
+        "allow": {
+          "description": "Basename glob(s) accepted as direct children. Anything else is a violation.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          ]
+        },
+        "kind": {
+          "const": "dir_only_contains"
+        },
+        "select": {
+          "description": "Glob selecting the directories to enumerate.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "select",
+        "allow"
+      ],
+      "type": "object"
+    },
+    "rule_every_matching_has": {
+      "description": "Every file OR directory matching `select` must satisfy every nested rule in `require`. Sugar that combines for_each_file + for_each_dir into one rule. Optional `when_iter:` filters iterations.",
+      "properties": {
+        "kind": {
+          "const": "every_matching_has"
+        },
+        "require": {
+          "items": {
+            "$ref": "#/$defs/nested_rule"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "select": {
+          "description": "Glob(s) selecting the files/dirs to iterate — a single glob, or a list with `!`-prefixed excludes (e.g. [\"packages/*\", \"!packages/internal\"]).",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          ]
+        },
+        "when_iter": {
+          "description": "Per-iteration `when:` filter — see rule_for_each_dir.when_iter.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "select",
+        "require"
+      ],
+      "type": "object"
+    },
+    "rule_executable_bit": {
+      "description": "Assert that every file in scope either has the Unix +x bit set (`require: true`) or does not (`require: false`). No-op on non-Unix platforms. No fix op (chmod auto-apply deferred).",
+      "properties": {
+        "kind": {
+          "const": "executable_bit"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "require": {
+          "description": "`true`: +x must be set. `false`: +x must not be set.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "paths",
+        "require"
+      ],
+      "type": "object"
+    },
+    "rule_executable_has_shebang": {
+      "description": "Every file with the +x bit set must begin with a shebang (`#!`). Catches scripts that were marked executable but whose content is a plain text file or missing a shebang. No-op on non-Unix.",
+      "properties": {
+        "kind": {
+          "const": "executable_has_shebang"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_file_absent": {
+      "properties": {
+        "git_tracked_only": {
+          "$ref": "#/$defs/git_tracked_only"
+        },
+        "kind": {
+          "const": "file_absent"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_file_content_forbidden": {
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_content_forbidden",
+            "content_forbidden"
+          ]
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "pattern": {
+          "description": "Rust regex. File contents must NOT match.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths",
+        "pattern"
+      ],
+      "type": "object"
+    },
+    "rule_file_content_matches": {
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_content_matches",
+            "content_matches"
+          ]
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "pattern": {
+          "description": "Rust regex. File contents must match.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths",
+        "pattern"
+      ],
+      "type": "object"
+    },
+    "rule_file_ends_with": {
+      "description": "Every file in scope must end with the given suffix (byte-level). For a simple trailing-newline check, prefer `final_newline`. Check-only; pair with `file_append` if you want auto-append.",
+      "properties": {
+        "kind": {
+          "const": "file_ends_with"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "suffix": {
+          "description": "Required suffix, matched byte-for-byte.",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths",
+        "suffix"
+      ],
+      "type": "object"
+    },
+    "rule_file_exists": {
+      "properties": {
+        "git_tracked_only": {
+          "$ref": "#/$defs/git_tracked_only"
+        },
+        "kind": {
+          "const": "file_exists"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "respect_gitignore": {
+          "$ref": "#/$defs/per_rule_respect_gitignore"
+        },
+        "root_only": {
+          "default": false,
+          "description": "If true, only files directly at the repository root satisfy the rule.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_file_footer": {
+      "description": "Last `lines` lines of each file in scope must match `pattern` (Rust regex). Mirror of `file_header` anchored at the END of the file. Use for license footers, signed-off-by trailers, generated-file sentinels.",
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_footer",
+            "footer"
+          ]
+        },
+        "lines": {
+          "default": 20,
+          "description": "Number of trailing lines to consider.",
+          "format": "uint",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "pattern": {
+          "description": "Rust regex. The last `lines` lines of each file must match.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths",
+        "pattern"
+      ],
+      "type": "object"
+    },
     "rule_file_graph": {
       "description": "Assemble the repo's file→file reference graph and assert a global structural property the 1-level cross-file kinds can't. `nodes` (glob) selects the graph's files. `edges` is one of `from_content` (extract one reference per match — the `extract` one-of: toml/json/yaml JSONPath, lines, or regex capture group 1 — and resolve it to a path via `resolve`: relative_to_file default, or relative_to_repo_root; bare module names, absolute paths, URLs, computed/interpolated references, and paths that escape the repo root are dropped, not mis-resolved) or `derive_target` (a `from`→`to` name template deriving the target from the node path). `require` is one of: `acyclic` (no dependency cycle among the nodes); `no_dangling` (every path-shaped edge resolves to an existing path — with `derive_target`, the derived sibling must exist); `no_orphans` (no node unreferenced by another, bare or `{ no_orphans: { roots: [...] } }`); `{ forbidden_edges: [{ from, to }] }` (the layering firewall — no edge whose source matches `from` and resolved target matches `to`); or `{ fresh: { hash, marker } }` (the `derive_target` output embeds the source's current content hash, captured by `marker`). Pure-parse, cross-file (no spawn).",
-      "type": "object",
-      "required": ["nodes", "edges", "require"],
       "properties": {
-        "kind": { "const": "file_graph" },
-        "nodes": {
-          "type": "string",
-          "description": "Glob selecting the graph's node files."
-        },
         "edges": {
-          "type": "object",
+          "additionalProperties": false,
           "description": "Exactly one edge extractor: `from_content` (content references → the reference-graph modes) or `derive_target` (a name template → `fresh` codegen-freshness or `no_dangling` derived-sibling existence).",
-          "properties": {
-            "from_content": {
-              "type": "object",
-              "required": ["extract"],
-              "properties": {
-                "extract": { "$ref": "#/$defs/extract_spec" },
-                "resolve": { "enum": ["relative_to_file", "relative_to_repo_root"] }
-              },
-              "additionalProperties": false
+          "oneOf": [
+            {
+              "required": [
+                "from_content"
+              ]
             },
+            {
+              "required": [
+                "derive_target"
+              ]
+            }
+          ],
+          "properties": {
             "derive_target": {
-              "type": "object",
+              "additionalProperties": false,
               "description": "Derive the generated target's path from the source node's path: `from` is a regex matched against the node path, `to` is a replacement template using its captures (e.g. `to: $1.pb.go`).",
-              "required": ["from", "to"],
               "properties": {
-                "from": { "type": "string" },
-                "to": { "type": "string" }
+                "from": {
+                  "type": "string"
+                },
+                "to": {
+                  "type": "string"
+                }
               },
-              "additionalProperties": false
+              "required": [
+                "from",
+                "to"
+              ],
+              "type": "object"
+            },
+            "from_content": {
+              "additionalProperties": false,
+              "properties": {
+                "extract": {
+                  "$ref": "#/$defs/extract_spec"
+                },
+                "resolve": {
+                  "enum": [
+                    "relative_to_file",
+                    "relative_to_repo_root"
+                  ]
+                }
+              },
+              "required": [
+                "extract"
+              ],
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "oneOf": [
-            { "required": ["from_content"] },
-            { "required": ["derive_target"] }
-          ]
+          "type": "object"
+        },
+        "kind": {
+          "const": "file_graph"
+        },
+        "nodes": {
+          "description": "Glob selecting the graph's node files.",
+          "type": "string"
         },
         "require": {
           "description": "A bare-string mode (`acyclic` | `no_dangling` | `no_orphans`), or a map for a configured mode (`{ forbidden_edges: [{from,to}] }`, `{ no_orphans: { roots: [...] } }`, or `{ fresh: { hash, marker } }`). `no_dangling` = every path-shaped edge resolves to an existing path (with `edges.derive_target`, each node's derived sibling must exist — e.g. every `X-LICENSE.txt` needs an `X-NOTICE.txt`); `no_orphans` = no node is unreferenced except those matching a `roots` glob; `fresh` (needs `edges.derive_target`) = the derived output carries the source's current `hash` digest, captured by `marker` (group 1).",
           "oneOf": [
-            { "enum": ["acyclic", "no_dangling", "no_orphans"] },
             {
-              "type": "object",
-              "required": ["forbidden_edges"],
+              "enum": [
+                "acyclic",
+                "no_dangling",
+                "no_orphans"
+              ]
+            },
+            {
+              "additionalProperties": false,
               "properties": {
                 "forbidden_edges": {
-                  "type": "array",
-                  "minItems": 1,
                   "items": {
-                    "type": "object",
-                    "required": ["from", "to"],
+                    "additionalProperties": false,
                     "properties": {
-                      "from": { "type": "string" },
-                      "to": { "type": "string" }
+                      "from": {
+                        "type": "string"
+                      },
+                      "to": {
+                        "type": "string"
+                      }
                     },
-                    "additionalProperties": false
-                  }
+                    "required": [
+                      "from",
+                      "to"
+                    ],
+                    "type": "object"
+                  },
+                  "minItems": 1,
+                  "type": "array"
                 }
               },
-              "additionalProperties": false
+              "required": [
+                "forbidden_edges"
+              ],
+              "type": "object"
             },
             {
-              "type": "object",
-              "required": ["no_orphans"],
+              "additionalProperties": false,
               "properties": {
                 "no_orphans": {
-                  "type": "object",
+                  "additionalProperties": false,
                   "properties": {
                     "roots": {
-                      "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
                     }
                   },
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
-              "additionalProperties": false
+              "required": [
+                "no_orphans"
+              ],
+              "type": "object"
             },
             {
-              "type": "object",
-              "required": ["fresh"],
+              "additionalProperties": false,
               "properties": {
                 "fresh": {
-                  "type": "object",
-                  "required": ["marker"],
+                  "additionalProperties": false,
                   "properties": {
-                    "hash": { "enum": ["sha256", "sha512"] },
-                    "marker": { "type": "string" }
+                    "hash": {
+                      "enum": [
+                        "sha256",
+                        "sha512"
+                      ]
+                    },
+                    "marker": {
+                      "type": "string"
+                    }
                   },
-                  "additionalProperties": false
+                  "required": [
+                    "marker"
+                  ],
+                  "type": "object"
                 }
               },
-              "additionalProperties": false
+              "required": [
+                "fresh"
+              ],
+              "type": "object"
             }
           ]
         }
-      }
+      },
+      "required": [
+        "nodes",
+        "edges",
+        "require"
+      ],
+      "type": "object"
     },
-
-    "rule_ordered_block": {
-      "description": "The lines between a `start` / `end` marker pair must stay sorted (and, with `unique`, free of duplicates) under `comparator`. Both markers are optional: omit `end` to sort from `start` to EOF, omit both to sort the whole file (the markerless 'this file is one sorted list' form). The generic form of per-project keep-sorted scripts. Per-file: markers match the trimmed line; blank lines inside a block are ignored.",
-      "type": "object",
+    "rule_file_hash": {
+      "description": "Each file in scope must have content whose SHA-256 equals the declared `sha256`. Accepts a bare 64-char hex string or a `sha256:`-prefixed form.",
       "properties": {
-        "kind": { "const": "ordered_block" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "start": {
-          "type": "string",
-          "description": "Marker line opening a block (matched on the trimmed line). Optional — omit to anchor the block at the start of the file."
+        "kind": {
+          "const": "file_hash"
         },
-        "end": {
-          "type": "string",
-          "description": "Marker line closing a block. Optional — omit to run the block to EOF."
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
         },
-        "comparator": { "enum": ["lexical", "lexical-ci", "numeric"] },
-        "unique": { "type": "boolean" },
-        "select": {
-          "type": "string",
-          "description": "Regex; when set, only lines inside a block matching it are sortable entries (others — comments, group headers — pass through). The sectioned / keep-sorted-subset shape."
+        "sha256": {
+          "pattern": "^(sha256:)?[0-9a-fA-F]{64}$",
+          "type": "string"
         }
-      }
+      },
+      "required": [
+        "paths",
+        "sha256"
+      ],
+      "type": "object"
     },
-
-    "rule_for_each_match": {
-      "description": "For each line matching `select` (a regex), the line must satisfy the nested `require:` predicates: `matches` (the line matches all listed regexes), `forbid` (matches none), `equal` (the listed named `select` captures are all equal — checked on every `select` match on the line). The in-file line quantifier (the dual of `ordered_block`'s `select:`): one violation per offending line. Closes per-line changelog grammars ('every entry line must ALSO match Q1..Qn', which `file_content_matches` cannot express — its match is existence, not a per-line conjunction) and intra-line capture equality (RE2 has no backreference). Per-file.",
-      "type": "object",
-      "required": ["paths", "select", "require"],
+    "rule_file_header": {
       "properties": {
-        "kind": { "const": "for_each_match" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "select": {
-          "type": "string",
-          "description": "Regex; a line is a checked element iff it matches. Named captures are available to `require.equal`."
+        "kind": {
+          "enum": [
+            "file_header",
+            "header"
+          ]
+        },
+        "lines": {
+          "default": 20,
+          "description": "Number of leading lines to consider.",
+          "format": "uint",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "pattern": {
+          "description": "Rust regex. The first `lines` lines of each file in scope must match.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths",
+        "pattern"
+      ],
+      "type": "object"
+    },
+    "rule_file_is_ascii": {
+      "description": "Every byte in every file in scope must be < 0x80 (pure ASCII), except codepoints listed in `allow:`. Stricter than file_is_text; check-only — auto-replacement for non-ASCII bytes would silently lose meaning. With `allow:` the file is decoded as UTF-8 and checked per character; without it, the strict byte-level fast path is used.",
+      "properties": {
+        "allow": {
+          "description": "Permitted non-ASCII codepoints — each entry a single character (e.g. \"ö\"), a `U+XXXX` codepoint, or a `U+XXXX-U+YYYY` inclusive range.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "const": "file_is_ascii"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_file_is_text": {
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_is_text",
+            "is_text"
+          ]
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_file_max_lines": {
+      "description": "Files in scope must have at most `max_lines` lines, with the same `wc -l`-style accounting as `file_min_lines`. Use to catch the everything-module anti-pattern.",
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_max_lines",
+            "max_lines"
+          ]
+        },
+        "max_lines": {
+          "description": "Maximum allowed line count.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "max_lines"
+      ],
+      "type": "object"
+    },
+    "rule_file_max_size": {
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_max_size",
+            "max_size"
+          ]
+        },
+        "max_bytes": {
+          "description": "Maximum allowed file size in bytes.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "max_bytes"
+      ],
+      "type": "object"
+    },
+    "rule_file_min_lines": {
+      "description": "Files in scope must have at least `min_lines` lines (where a line is `\\n`-terminated, with an unterminated trailing segment counting as one more, matching `wc -l` semantics). Common use: require README / CHANGELOG / SECURITY.md to be more than a title plus one sentence.",
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_min_lines",
+            "min_lines"
+          ]
+        },
+        "min_lines": {
+          "description": "Minimum allowed line count.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "min_lines"
+      ],
+      "type": "object"
+    },
+    "rule_file_min_size": {
+      "description": "Files in scope must be at least `min_bytes` bytes. Catches placeholder / stub files that pass existence checks but contain no useful content (e.g. a 20-byte README).",
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_min_size",
+            "min_size"
+          ]
+        },
+        "min_bytes": {
+          "description": "Minimum allowed file size in bytes.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "min_bytes"
+      ],
+      "type": "object"
+    },
+    "rule_file_shebang": {
+      "description": "First line of each file in scope must match the `shebang` regex. Pairs with `executable_has_shebang` (presence) and `shebang_has_executable` (the inverse) to enforce shebang shape, e.g. require `^#!/usr/bin/env bash$`.",
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_shebang",
+            "shebang"
+          ]
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "shebang": {
+          "default": "^#!",
+          "description": "Rust regex; the first line of every matched file must match. Default\n`^#!` only enforces shebang presence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_file_starts_with": {
+      "description": "Every file in scope must begin with the given prefix (byte-level). Useful for SPDX headers, generated-file sentinels, magic bytes. Check-only; pair with `file_prepend` if you want auto-prepend (prevents silent duplication on near-matches).",
+      "properties": {
+        "kind": {
+          "const": "file_starts_with"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "prefix": {
+          "description": "Required prefix, matched byte-for-byte.",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths",
+        "prefix"
+      ],
+      "type": "object"
+    },
+    "rule_filename_case": {
+      "properties": {
+        "case": {
+          "$ref": "#/$defs/case_convention"
+        },
+        "kind": {
+          "const": "filename_case"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "case"
+      ],
+      "type": "object"
+    },
+    "rule_filename_regex": {
+      "properties": {
+        "kind": {
+          "const": "filename_regex"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "pattern": {
+          "description": "Rust regex, automatically anchored with ^...$ by the engine.",
+          "type": "string"
+        },
+        "stem": {
+          "default": false,
+          "description": "Match the file stem (no extension) instead of the full basename.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "paths",
+        "pattern"
+      ],
+      "type": "object"
+    },
+    "rule_final_newline": {
+      "description": "Every non-empty file in scope must end with a newline byte. Empty files are considered fine.",
+      "properties": {
+        "kind": {
+          "const": "final_newline"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_for_each_dir": {
+      "description": "For every directory matching `select`, every rule in `require` must pass. Path-template tokens in the nested rules are pre-substituted per iteration; use `{path}` to refer to the iterated directory itself. Optional `when_iter:` filters which iterations are evaluated, e.g. `iter.has_file(\"Cargo.toml\")` to scope to workspace members.",
+      "properties": {
+        "kind": {
+          "const": "for_each_dir"
         },
         "require": {
-          "type": "object",
+          "description": "Nested rules evaluated against each matched directory.",
+          "items": {
+            "$ref": "#/$defs/nested_rule"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "select": {
+          "description": "Glob(s) selecting the directories to iterate — a single glob, or a list with `!`-prefixed excludes (e.g. [\"src/*\", \"!src/internal\"]).",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          ]
+        },
+        "when_iter": {
+          "description": "Per-iteration `when:` filter — evaluated against `iter.*` in the iterated entry's context. Iterations whose verdict is false are skipped before any nested rule is built. Examples: `iter.has_file(\"Cargo.toml\")`, `iter.basename matches \"^pkg-\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "select",
+        "require"
+      ],
+      "type": "object"
+    },
+    "rule_for_each_file": {
+      "description": "For every file matching `select`, every rule in `require` must pass. Path-template tokens in the nested rules are pre-substituted per iteration. Optional `when_iter:` filters iterations.",
+      "properties": {
+        "kind": {
+          "const": "for_each_file"
+        },
+        "require": {
+          "description": "Nested rules evaluated against each matched file.",
+          "items": {
+            "$ref": "#/$defs/nested_rule"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "select": {
+          "description": "Glob(s) selecting the files to iterate — a single glob, or a list with `!`-prefixed excludes.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          ]
+        },
+        "when_iter": {
+          "description": "Per-iteration `when:` filter — see rule_for_each_dir.when_iter. `iter.has_file(...)` always evaluates to false on file iteration; useful predicates here include `iter.basename`, `iter.ext`, `iter.parent_name`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "select",
+        "require"
+      ],
+      "type": "object"
+    },
+    "rule_for_each_match": {
+      "description": "For each line matching `select` (a regex), the line must satisfy the nested `require:` predicates: `matches` (the line matches all listed regexes), `forbid` (matches none), `equal` (the listed named `select` captures are all equal — checked on every `select` match on the line). The in-file line quantifier (the dual of `ordered_block`'s `select:`): one violation per offending line. Closes per-line changelog grammars ('every entry line must ALSO match Q1..Qn', which `file_content_matches` cannot express — its match is existence, not a per-line conjunction) and intra-line capture equality (RE2 has no backreference). Per-file.",
+      "properties": {
+        "kind": {
+          "const": "for_each_match"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "require": {
+          "additionalProperties": false,
           "description": "Predicates applied to each selected line; at least one of `matches` / `forbid` / `equal` is required.",
           "properties": {
-            "matches": {
-              "type": "array",
-              "items": { "type": "string" },
-              "description": "The selected line must match ALL of these regexes."
+            "equal": {
+              "description": "These named `select` captures must all be equal (the only way to assert intra-line capture equality, since RE2 has no backreference).",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 2,
+              "type": "array"
             },
             "forbid": {
-              "type": "array",
-              "items": { "type": "string" },
-              "description": "The selected line must match NONE of these regexes."
+              "description": "The selected line must match NONE of these regexes.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             },
-            "equal": {
-              "type": "array",
-              "items": { "type": "string" },
-              "minItems": 2,
-              "description": "These named `select` captures must all be equal (the only way to assert intra-line capture equality, since RE2 has no backreference)."
+            "matches": {
+              "description": "The selected line must match ALL of these regexes.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
-          "additionalProperties": false
+          "type": "object"
+        },
+        "select": {
+          "description": "Regex; a line is a checked element iff it matches. Named captures are available to `require.equal`.",
+          "type": "string"
         }
-      }
+      },
+      "required": [
+        "paths",
+        "select",
+        "require"
+      ],
+      "type": "object"
     },
-
     "rule_generated_file_fresh": {
       "description": "A committed artefact must equal what a declared `command` generator produces. Two modes, selected by shape (exactly one of `file` / `outputs` required): STDOUT mode (`file`) compares one committed file to the generator's stdout — non-mutating, never writes the tree. MUTATING / in-place mode (`outputs`, a glob or list of globs) runs an in-place generator and asserts the regenerated files are unchanged: alint snapshots `outputs`, runs the generator, diffs, reports any stale / new / removed file, and RESTORES the snapshot — so `alint check` stays pure (no regenerated files left behind); the alint-native form of `make gen && git diff --exit-code`. Either mode runs a process, so the kind is trust-gated to the user's own top-level config (same tier as the `command` rule). Single-shot, opt-in.",
-      "type": "object",
-      "required": ["command"],
       "oneOf": [
-        { "required": ["file"] },
-        { "required": ["outputs"] }
+        {
+          "required": [
+            "file"
+          ]
+        },
+        {
+          "required": [
+            "outputs"
+          ]
+        }
       ],
       "properties": {
-        "kind": { "const": "generated_file_fresh" },
+        "command": {
+          "description": "Generator argv (no shell). STDOUT mode: emit the file's contents to stdout. MUTATING mode: write the `outputs` in place.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
         "file": {
-          "type": "string",
-          "description": "STDOUT mode: the committed generated file to verify against the generator's stdout."
+          "description": "STDOUT mode: the committed generated file to verify against the generator's stdout.",
+          "type": "string"
+        },
+        "kind": {
+          "const": "generated_file_fresh"
+        },
+        "normalize": {
+          "enum": [
+            "none",
+            "trim",
+            "final-newline"
+          ]
         },
         "outputs": {
           "description": "MUTATING mode: the glob (or list of globs) the in-place generator rewrites; its presence selects the mutating mode. alint snapshots these, runs the generator, diffs, and restores them.",
           "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
           ]
         },
-        "command": {
-          "type": "array",
-          "items": { "type": "string" },
-          "minItems": 1,
-          "description": "Generator argv (no shell). STDOUT mode: emit the file's contents to stdout. MUTATING mode: write the `outputs` in place."
+        "timeout": {
+          "description": "Generator timeout in seconds (default 120). On timeout the child is killed and one violation is emitted.",
+          "minimum": 1,
+          "type": "integer"
         },
         "workdir": {
-          "type": "string",
-          "description": "Generator cwd, relative to the lint root (default: lint root)."
-        },
-        "normalize": { "enum": ["none", "trim", "final-newline"] },
-        "timeout": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Generator timeout in seconds (default 120). On timeout the child is killed and one violation is emitted."
+          "description": "Generator cwd, relative to the lint root (default: lint root).",
+          "type": "string"
         }
-      }
-    },
-
-    "rule_import_gate": {
-      "description": "Forbid imports whose extracted target matches `forbid` (a regex), within the `paths` scope — an architectural import firewall. Matches the EXTRACTED import target (not the raw line), the precise low-false-positive specialisation of `file_content_forbidden`. `language` (go/python/rust/js/scala/java/dart/nix) selects a built-in import-line pattern; `import_pattern` overrides it (capture group 1 = target; required for `generic`). `allow` globs exempt files inside the scope. Per-file.",
-      "type": "object",
-      "required": ["forbid"],
-      "properties": {
-        "kind": { "const": "import_gate" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "forbid": {
-          "type": "string",
-          "description": "Regex tested against the extracted import target."
-        },
-        "language": { "enum": ["go", "python", "rust", "js", "scala", "java", "dart", "nix", "generic"] },
-        "import_pattern": {
-          "type": "string",
-          "description": "Explicit import-line regex (capture group 1 = imported target); overrides the language preset."
-        },
-        "allow": {
-          "type": "array",
-          "items": { "type": "string" },
-          "description": "File globs inside the scope exempt from the gate."
-        }
-      }
-    },
-
-    "rule_command_idempotent": {
-      "description": "Run a user-declared formatter/checker in its --check (idempotence) mode once: exit 0 = the tree is formatter-clean (silent), non-zero = violation(s). alint never runs a mutating formatter and never writes the tree (the sibling of generated_file_fresh; same trust tier as the command rule — trust-gated to the user's own top-level config). With `files_from` (+ optional `files_pattern`) the tool's offender list is parsed into one violation per file. Single-shot, opt-in.",
-      "type": "object",
-      "required": ["command"],
-      "properties": {
-        "kind": { "const": "command_idempotent" },
-        "command": {
-          "type": "array",
-          "items": { "type": "string" },
-          "minItems": 1,
-          "description": "Checker argv (no shell), run in its --check / idempotence mode; exit 0 = clean."
-        },
-        "workdir": {
-          "type": "string",
-          "description": "Checker cwd, relative to the lint root (default: lint root)."
-        },
-        "files_from": {
-          "enum": ["none", "stdout", "stderr"],
-          "description": "On failure, parse this stream into per-file violations (default: none = one violation for the whole invocation)."
-        },
-        "files_pattern": {
-          "type": "string",
-          "description": "Regex whose capture group 1 is a file path, applied per output line (requires `files_from`; omit for bare-path listers)."
-        },
-        "timeout": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Checker timeout in seconds (default 120). On timeout the child is killed and one violation is emitted."
-        }
-      }
-    },
-
-    "rule_for_each_dir": {
-      "description": "For every directory matching `select`, every rule in `require` must pass. Path-template tokens in the nested rules are pre-substituted per iteration; use `{path}` to refer to the iterated directory itself. Optional `when_iter:` filters which iterations are evaluated, e.g. `iter.has_file(\"Cargo.toml\")` to scope to workspace members.",
-      "type": "object",
-      "required": ["select", "require"],
-      "properties": {
-        "kind": { "const": "for_each_dir" },
-        "select": {
-          "description": "Glob(s) selecting the directories to iterate — a single glob, or a list with `!`-prefixed excludes (e.g. [\"src/*\", \"!src/internal\"]).",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" }, "minItems": 1 }
-          ]
-        },
-        "when_iter": {
-          "type": "string",
-          "description": "Per-iteration `when:` filter — evaluated against `iter.*` in the iterated entry's context. Iterations whose verdict is false are skipped before any nested rule is built. Examples: `iter.has_file(\"Cargo.toml\")`, `iter.basename matches \"^pkg-\"`."
-        },
-        "require": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/nested_rule" },
-          "description": "Nested rules evaluated against each matched directory."
-        }
-      }
-    },
-
-    "rule_for_each_file": {
-      "description": "For every file matching `select`, every rule in `require` must pass. Path-template tokens in the nested rules are pre-substituted per iteration. Optional `when_iter:` filters iterations.",
-      "type": "object",
-      "required": ["select", "require"],
-      "properties": {
-        "kind": { "const": "for_each_file" },
-        "select": {
-          "description": "Glob(s) selecting the files to iterate — a single glob, or a list with `!`-prefixed excludes.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" }, "minItems": 1 }
-          ]
-        },
-        "when_iter": {
-          "type": "string",
-          "description": "Per-iteration `when:` filter — see rule_for_each_dir.when_iter. `iter.has_file(...)` always evaluates to false on file iteration; useful predicates here include `iter.basename`, `iter.ext`, `iter.parent_name`."
-        },
-        "require": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/nested_rule" },
-          "description": "Nested rules evaluated against each matched file."
-        }
-      }
-    },
-
-    "rule_dir_only_contains": {
-      "description": "Every direct child *file* of directories matching `select` must match at least one glob in `allow`. Subdirectories of the matched dir are not checked. Allow globs match the child's basename.",
-      "type": "object",
-      "required": ["select", "allow"],
-      "properties": {
-        "kind": { "const": "dir_only_contains" },
-        "select": {
-          "type": "string",
-          "description": "Glob selecting the directories to enumerate."
-        },
-        "allow": {
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" }, "minItems": 1 }
-          ],
-          "description": "Basename glob(s) accepted as direct children. Anything else is a violation."
-        }
-      }
-    },
-
-    "rule_unique_by": {
-      "description": "Flag any group of files (matching `select`) sharing the same rendered `key`. One violation per collision group, anchored on the lexicographically-first file. Path-template tokens ({path}, {dir}, {basename}, {stem}, {ext}, {parent_name}) may appear in `key`. With `case_insensitive: true` the key is folded to lowercase before grouping, catching collisions that only occur on a case-insensitive filesystem (Windows / macOS).",
-      "type": "object",
-      "required": ["select"],
-      "properties": {
-        "kind": { "const": "unique_by" },
-        "select": {
-          "type": "string",
-          "description": "Glob selecting the files to deduplicate."
-        },
-        "key": {
-          "type": "string",
-          "default": "{basename}",
-          "description": "Path-template producing a key per matched file. Default: {basename}."
-        },
-        "case_insensitive": {
-          "type": "boolean",
-          "default": false,
-          "description": "Fold the key to lowercase before grouping (case-insensitive-filesystem collision detection)."
-        }
-      }
-    },
-
-    "rule_dir_contains": {
-      "description": "Every directory matching `select` must have at least one direct child basename matching each glob in `require`. Sugar over for_each_dir + file_exists; use for_each_dir for deeper semantics.",
-      "type": "object",
-      "required": ["select", "require"],
-      "properties": {
-        "kind": { "const": "dir_contains" },
-        "select": { "type": "string" },
-        "require": {
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" }, "minItems": 1 }
-          ],
-          "description": "Basename glob(s) — every dir matching `select` must have at least one child matching each."
-        }
-      }
-    },
-
-    "rule_every_matching_has": {
-      "description": "Every file OR directory matching `select` must satisfy every nested rule in `require`. Sugar that combines for_each_file + for_each_dir into one rule. Optional `when_iter:` filters iterations.",
-      "type": "object",
-      "required": ["select", "require"],
-      "properties": {
-        "kind": { "const": "every_matching_has" },
-        "select": {
-          "description": "Glob(s) selecting the files/dirs to iterate — a single glob, or a list with `!`-prefixed excludes (e.g. [\"packages/*\", \"!packages/internal\"]).",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" }, "minItems": 1 }
-          ]
-        },
-        "when_iter": {
-          "type": "string",
-          "description": "Per-iteration `when:` filter — see rule_for_each_dir.when_iter."
-        },
-        "require": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/nested_rule" }
-        }
-      }
-    },
-
-    "rule_no_trailing_whitespace": {
-      "description": "No line in any file in scope ends with a space or tab. Non-UTF-8 files are skipped silently.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_trailing_whitespace" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_final_newline": {
-      "description": "Every non-empty file in scope must end with a newline byte. Empty files are considered fine.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "final_newline" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_line_endings": {
-      "description": "Every line ending in every file in scope must use the `target` style (`lf` or `crlf`). Mixed endings within a file also fail.",
-      "type": "object",
-      "required": ["paths", "target"],
-      "properties": {
-        "kind": { "const": "line_endings" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "target": { "type": "string", "enum": ["lf", "crlf"] }
-      }
-    },
-
-    "rule_line_max_width": {
-      "description": "No line in any file in scope exceeds `max_width` Unicode scalar values (chars). Display width is NOT computed — use a formatter for that. Check-only; truncation is not a safe auto-fix.",
-      "type": "object",
-      "required": ["paths", "max_width"],
-      "properties": {
-        "kind": { "const": "line_max_width" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "max_width": { "type": "integer", "minimum": 1 }
-      }
-    },
-
-    "rule_no_merge_conflict_markers": {
-      "description": "Flag files that still contain git conflict markers at the start of a line (`<<<<<<< `, `=======`, `>>>>>>> `, `||||||| `). Check-only; conflict resolution requires human judgment.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_merge_conflict_markers" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_no_bidi_controls": {
-      "description": "Flag Unicode bidirectional control characters (U+202A–202E, U+2066–2069) anywhere in a file. Trojan Source (CVE-2021-42574) defense. Fixable via `file_strip_bidi`.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_bidi_controls" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_no_zero_width_chars": {
-      "description": "Flag zero-width characters (U+200B/C/D, plus body-internal U+FEFF). A leading U+FEFF (BOM) is not flagged here — use `no_bom` for that. Fixable via `file_strip_zero_width`.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_zero_width_chars" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_file_is_ascii": {
-      "description": "Every byte in every file in scope must be < 0x80 (pure ASCII), except codepoints listed in `allow:`. Stricter than file_is_text; check-only — auto-replacement for non-ASCII bytes would silently lose meaning. With `allow:` the file is decoded as UTF-8 and checked per character; without it, the strict byte-level fast path is used.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "file_is_ascii" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "allow": {
-          "type": "array",
-          "description": "Permitted non-ASCII codepoints — each entry a single character (e.g. \"ö\"), a `U+XXXX` codepoint, or a `U+XXXX-U+YYYY` inclusive range.",
-          "items": { "type": "string" }
-        }
-      }
-    },
-
-    "rule_no_bom": {
-      "description": "Flag files that start with a UTF-8 / UTF-16 / UTF-32 BOM. Fixable via `file_strip_bom`.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_bom" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_file_hash": {
-      "description": "Each file in scope must have content whose SHA-256 equals the declared `sha256`. Accepts a bare 64-char hex string or a `sha256:`-prefixed form.",
-      "type": "object",
-      "required": ["paths", "sha256"],
-      "properties": {
-        "kind": { "const": "file_hash" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "sha256": { "type": "string", "pattern": "^(sha256:)?[0-9a-fA-F]{64}$" }
-      }
-    },
-
-    "rule_max_directory_depth": {
-      "description": "Every path in scope must sit at depth ≤ `max_depth` (number of `/`-separated components). Check-only; file relocation is a human decision.",
-      "type": "object",
-      "required": ["paths", "max_depth"],
-      "properties": {
-        "kind": { "const": "max_directory_depth" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "max_depth": { "type": "integer", "minimum": 1 }
-      }
-    },
-
-    "rule_max_files_per_directory": {
-      "description": "Every directory containing at least one in-scope file must hold ≤ `max_files` in-scope files (immediate children, non-recursive). Check-only.",
-      "type": "object",
-      "required": ["paths", "max_files"],
-      "properties": {
-        "kind": { "const": "max_files_per_directory" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "max_files": { "type": "integer", "minimum": 1 }
-      }
-    },
-
-    "rule_no_empty_files": {
-      "description": "Flag zero-byte files. Fixable via `file_remove`, which deletes the empty file.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_empty_files" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_no_case_conflicts": {
-      "description": "Flag pairs of paths that differ only by case (e.g. README.md + readme.md). These can't coexist on macOS HFS+/APFS or Windows NTFS.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_case_conflicts" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_no_illegal_windows_names": {
-      "description": "Reject path components Windows can't represent: reserved device names (CON/PRN/AUX/NUL/COM1-9/LPT1-9 regardless of extension), trailing dots or spaces, and the forbidden chars <>:\"|?*.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_illegal_windows_names" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_no_symlinks": {
-      "description": "Flag tracked paths that are symbolic links. Symlinks are a portability headache across Windows/macOS/Linux and CI runners. Fixable via `file_remove`, which deletes the symlink.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_symlinks" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_executable_bit": {
-      "description": "Assert that every file in scope either has the Unix +x bit set (`require: true`) or does not (`require: false`). No-op on non-Unix platforms. No fix op (chmod auto-apply deferred).",
-      "type": "object",
-      "required": ["paths", "require"],
-      "properties": {
-        "kind": { "const": "executable_bit" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "require": {
-          "type": "boolean",
-          "description": "`true`: +x must be set. `false`: +x must not be set."
-        }
-      }
-    },
-
-    "rule_executable_has_shebang": {
-      "description": "Every file with the +x bit set must begin with a shebang (`#!`). Catches scripts that were marked executable but whose content is a plain text file or missing a shebang. No-op on non-Unix.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "executable_has_shebang" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_shebang_has_executable": {
-      "description": "Every file that starts with `#!` must have the Unix +x bit set. The inverse of `executable_has_shebang`. No-op on non-Unix. No fix op (chmod auto-apply deferred).",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "shebang_has_executable" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_no_submodules": {
-      "description": "Flag the presence of `.gitmodules` at the repo root. Always targets `.gitmodules` — no `paths` field accepted. Fixable via `file_remove`.",
-      "type": "object",
-      "required": ["kind"],
-      "properties": {
-        "kind": { "const": "no_submodules" }
       },
-      "not": {
-        "required": ["paths"]
-      }
+      "required": [
+        "command"
+      ],
+      "type": "object"
     },
-
-    "rule_indent_style": {
-      "description": "Every non-blank line must indent with the configured style. `tabs` rejects any leading space; `spaces` rejects any leading tab and optionally requires the leading-space count to be a multiple of `width`. Check-only — tab-width-aware reindentation is deferred.",
-      "type": "object",
-      "required": ["paths", "style"],
+    "rule_git_blame_age": {
+      "description": "Fire on lines matching a regex whose `git blame` author-time is older than `max_age_days`. Closes the gap between `level: warning` on every TODO (too noisy) and `level: off` (accepts unbounded debt accumulation). Use cases: stale TODO / FIXME / XXX / HACK markers, abandoned `@deprecated` JSDoc tags, model-attributed TODOs that nobody followed up on. Outside a git repo, on untracked files, or when blame fails for any other reason, the rule silently no-ops per file. Heuristic notes: formatting passes (cargo fmt, prettier) reset blame age unless the formatting commit is listed in `.git-blame-ignore-revs`; vendored / imported code carries the import commit's timestamp; squash-merged PRs collapse to a single date. Check-only — auto-removing matched lines is destructive.",
       "properties": {
-        "kind": { "const": "indent_style" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "style": {
-          "type": "string",
-          "enum": ["tabs", "spaces"]
+        "kind": {
+          "const": "git_blame_age"
         },
-        "width": {
-          "type": "integer",
+        "max_age_days": {
+          "description": "Minimum line age (in days) for a matching line to fire as a violation.\nLines younger than this pass silently.",
+          "format": "uint64",
           "minimum": 1,
-          "description": "When `style: spaces`, the leading-space count on every non-blank line must be a multiple of this. Ignored for `style: tabs`."
-        }
-      }
-    },
-
-    "rule_max_consecutive_blank_lines": {
-      "description": "Cap the number of blank lines that may appear in a row. A blank line is empty or only whitespace. Fixable via `file_collapse_blank_lines`, which collapses over-long runs to exactly `max` blank lines.",
-      "type": "object",
-      "required": ["paths", "max"],
-      "properties": {
-        "kind": { "const": "max_consecutive_blank_lines" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "max": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Maximum number of blank lines allowed in a row. `0` means no blank lines at all."
-        }
-      }
-    },
-
-    "rule_file_starts_with": {
-      "description": "Every file in scope must begin with the given prefix (byte-level). Useful for SPDX headers, generated-file sentinels, magic bytes. Check-only; pair with `file_prepend` if you want auto-prepend (prevents silent duplication on near-matches).",
-      "type": "object",
-      "required": ["paths", "prefix"],
-      "properties": {
-        "kind": { "const": "file_starts_with" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "prefix": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Required prefix, matched byte-for-byte."
-        }
-      }
-    },
-
-    "rule_file_ends_with": {
-      "description": "Every file in scope must end with the given suffix (byte-level). For a simple trailing-newline check, prefer `final_newline`. Check-only; pair with `file_append` if you want auto-append.",
-      "type": "object",
-      "required": ["paths", "suffix"],
-      "properties": {
-        "kind": { "const": "file_ends_with" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "suffix": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Required suffix, matched byte-for-byte."
-        }
-      }
-    },
-
-    "rule_command": {
-      "description": "Shell out to an external CLI per matched file. argv[0] is the program; remaining tokens support path-template substitution (`{path}`, `{dir}`, `{stem}`, `{ext}`, `{basename}`, `{parent_name}`). Working dir = repo root; stdin = /dev/null. Env: ALINT_PATH, ALINT_ROOT, ALINT_RULE_ID, ALINT_LEVEL, plus ALINT_VAR_<NAME> per `vars:` and ALINT_FACT_<NAME> per resolved fact. Verdict: exit 0 = pass; non-zero = one violation whose message is the (truncated) stdout+stderr. Trust-gated: only allowed in the user's top-level config (rejected at load-time when introduced via `extends:` or a bundled ruleset).",
-      "type": "object",
-      "required": ["paths", "command"],
-      "properties": {
-        "kind": { "const": "command" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "command": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "type": "string" },
-          "description": "Argv tokens. The first token is the program (looked up via PATH if it's a bare name); remaining tokens accept `{path}` and friends."
+          "type": "integer"
         },
-        "timeout": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Per-file timeout in seconds. Default 30. Past this, the child is killed and a violation reports the timeout."
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "pattern": {
+          "description": "Rust-regex pattern applied to each blame line's content. Capture group 1\n(when present) is exposed as `{{ctx.match}}` in the message template;\nwithout a capture group, `{{ctx.match}}` substitutes the full match.",
+          "type": "string"
         }
-      }
-    },
-
-    "fact": {
-      "description": "A single fact declaration. Each fact has an `id` plus exactly one kind-specific field.",
-      "type": "object",
-      "required": ["id"],
-      "properties": {
-        "id": { "$ref": "#/$defs/rule_id" }
       },
-      "oneOf": [
+      "required": [
+        "paths",
+        "pattern",
+        "max_age_days"
+      ],
+      "type": "object"
+    },
+    "rule_git_commit_author_allowlist": {
+      "anyOf": [
         {
-          "required": ["any_file_exists"],
-          "properties": {
-            "any_file_exists": { "$ref": "#/$defs/string_or_string_array" }
-          }
+          "required": [
+            "email_pattern"
+          ]
         },
         {
-          "required": ["all_files_exist"],
-          "properties": {
-            "all_files_exist": { "$ref": "#/$defs/string_or_string_array" }
-          }
-        },
-        {
-          "required": ["count_files"],
-          "properties": {
-            "count_files": { "type": "string" }
-          }
-        },
-        {
-          "required": ["file_content_matches"],
-          "properties": {
-            "file_content_matches": {
-              "type": "object",
-              "required": ["paths", "pattern"],
-              "additionalProperties": false,
-              "properties": {
-                "paths": { "$ref": "#/$defs/string_or_string_array" },
-                "pattern": {
-                  "type": "string",
-                  "description": "Rust-regex pattern matched against the content of every file in `paths`. The fact is true iff at least one file contains a match. Non-UTF-8 files are skipped."
-                }
-              }
-            }
-          }
-        },
-        {
-          "required": ["git_branch"],
-          "properties": {
-            "git_branch": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {},
-              "description": "Read `<repo>/.git/HEAD` and return the current branch name (string). Detached HEAD, no `.git/` directory, or any unrecognized layout resolves to an empty string (falsy under `when:`)."
-            }
-          }
-        },
-        {
-          "required": ["custom"],
-          "properties": {
-            "custom": {
-              "type": "object",
-              "required": ["argv"],
-              "additionalProperties": false,
-              "properties": {
-                "argv": {
-                  "type": "array",
-                  "minItems": 1,
-                  "items": { "type": "string" },
-                  "description": "Program + arguments, passed verbatim to the OS (no shell). Fact value is the process's stdout (trimmed). Non-zero exit, spawn failure, or non-UTF-8 output all resolve to an empty string. SECURITY: `custom:` is only valid in the user's top-level config — alint refuses to load an extended config that declares one."
-                }
-              }
-            }
-          }
+          "required": [
+            "name_pattern"
+          ]
         }
       ],
-      "unevaluatedProperties": false
+      "description": "Assert every commit author in scope matches an allowed email and/or name pattern. At least one of `email_pattern:` / `name_pattern:` is required; specifying both means BOTH must match (AND). A commit whose author fails any specified pattern fires one violation. With `since:` unset, only HEAD is checked; with `since:` set to a ref, every commit in `<since>..HEAD` is checked. Demand: enterprise repos enforcing contributor identity against a corporate domain; OSS projects catching sock-puppet / compromised-account commits. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
+      "properties": {
+        "email_pattern": {
+          "default": null,
+          "description": "Rust-regex the author email (`git log %ae`) must match, e.g.\n`^.+@example\\.com$`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "include_merges": {
+          "default": false,
+          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "type": "boolean"
+        },
+        "kind": {
+          "const": "git_commit_author_allowlist"
+        },
+        "name_pattern": {
+          "default": null,
+          "description": "Rust-regex the author name (`git log %an`) must match.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "since": {
+          "default": null,
+          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "rule_git_commit_gpg_signed": {
+      "description": "Assert every commit in scope has a verifying signature (`git verify-commit` exits 0). A commit that is unsigned, or signed with a key that doesn't verify against the local keyring, fires one violation. With `since:` unset, only HEAD is checked; with `since:` set to a ref, every commit in `<since>..HEAD` is checked. Demand: kernel maintainers, security-sensitive OSS, GitHub 'Require signed commits' branch protection. Reflects git's own verdict — does NOT distinguish 'unsigned' from 'signed with an untrusted key' (trust is git's GPG config / `.git/allowed_signers`). Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
+      "properties": {
+        "include_merges": {
+          "default": false,
+          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "type": "boolean"
+        },
+        "kind": {
+          "const": "git_commit_gpg_signed"
+        },
+        "since": {
+          "default": null,
+          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "rule_git_commit_message": {
+      "anyOf": [
+        {
+          "required": [
+            "pattern"
+          ]
+        },
+        {
+          "required": [
+            "subject_max_length"
+          ]
+        },
+        {
+          "required": [
+            "requires_body"
+          ]
+        }
+      ],
+      "description": "Validate one or more commit messages against shape rules: regex, max subject length, body required. With `since:` unset, only HEAD is checked. With `since:` set to a ref, every commit in `<since>..HEAD` is checked (oldest first, merge commits excluded by default); right shape for PR-trigger workflows where HEAD is a synthetic `actions/checkout` merge commit. At least one of `pattern:` / `subject_max_length:` / `requires_body: true` must be set. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
+      "properties": {
+        "include_merges": {
+          "default": false,
+          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset; combining `include_merges: true` with no\n`since:` is a load-time error.",
+          "type": "boolean"
+        },
+        "kind": {
+          "const": "git_commit_message"
+        },
+        "pattern": {
+          "default": null,
+          "description": "Rust-regex pattern the full message (subject + body, joined with\nnewlines) must match. Use `(?s)` to make `.` match newlines.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "requires_body": {
+          "default": false,
+          "description": "When true, the message must have a non-empty body, that is, at least\none line of content after the subject's blank-line separator.",
+          "type": "boolean"
+        },
+        "since": {
+          "default": null,
+          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does: SHA (full or abbreviated), branch (`origin/main`),\ntag (`v1.2.3`), or relative ref (`HEAD~5`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "subject_max_length": {
+          "default": null,
+          "description": "Maximum number of characters allowed in the subject line. Common\nvalues: 50 (Tim Pope's recommendation), 72 (GitHub PR-title cutoff).",
+          "format": "uint",
+          "minimum": 1,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "rule_git_commit_no_fixup": {
+      "description": "Fail on residual `fixup!` / `squash!` / `amend!` commits in scope — the ones `git commit --fixup`/`--squash` produce, meant to be collapsed by `git rebase --autosquash` before merging. With `since:` unset, only HEAD is checked; with `since:` set to a ref, every commit in `<since>..HEAD` is checked. No configuration knobs — the matched prefixes are exactly what `--autosquash` understands. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
+      "properties": {
+        "include_merges": {
+          "default": false,
+          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "type": "boolean"
+        },
+        "kind": {
+          "const": "git_commit_no_fixup"
+        },
+        "since": {
+          "default": null,
+          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "rule_git_commit_signed_off": {
+      "description": "Assert every commit in scope carries a DCO `Signed-off-by:` trailer. With `since:` unset, only HEAD is checked; with `since:` set to a ref, every commit in `<since>..HEAD` is checked (oldest first, merge commits excluded by default) — the right shape for PR-trigger workflows. Required by CNCF / Linux Foundation / kernel-style projects. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
+      "properties": {
+        "include_merges": {
+          "default": false,
+          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "type": "boolean"
+        },
+        "kind": {
+          "const": "git_commit_signed_off"
+        },
+        "pattern": {
+          "default": null,
+          "description": "Trailer pattern each commit message must contain. Defaults to the\ncanonical DCO sign-off shape. Override to enforce a stricter form\n(e.g. a corporate-domain email).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "since": {
+          "default": null,
+          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "rule_git_commit_subject_matches": {
+      "description": "Each commit's subject line (the first line of its message) must match the `matches:` regex — the subject-grammar member of the commit family (e.g. `pkg/path: lowercase summary`, conventional-commit types). Anchored to the subject alone, unlike `git_commit_message`'s whole-message `pattern:`; use `git_commit_message`'s `subject_max_length:` for a length cap. With `since:` unset, only HEAD is checked; with `since:` set, every commit in `<since>..HEAD`. Outside a git repo / with no commits / when git is unavailable, silently no-ops; a bad `since:` ref hard-fails with a shallow-clone hint.",
+      "properties": {
+        "include_merges": {
+          "default": false,
+          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "type": "boolean"
+        },
+        "kind": {
+          "const": "git_commit_subject_matches"
+        },
+        "matches": {
+          "description": "Rust-regex the commit subject (first line of the message) must match.",
+          "type": "string"
+        },
+        "since": {
+          "default": null,
+          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "matches"
+      ],
+      "type": "object"
+    },
+    "rule_git_no_denied_paths": {
+      "description": "Fire when any tracked path matches a configured glob denylist. Companion of `git_tracked_only` for the absence axis: catches secrets, large binaries, or accidentally-tracked artifacts that would otherwise need a `file_absent` per pattern. With `since:` set, only paths changed in the `<since>...HEAD` diff are flagged (PR-scoped). Outside a git repo, silently no-ops; a `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
+      "properties": {
+        "denied": {
+          "description": "Globset patterns no tracked path may match. Both whole-path patterns\n(`secrets/**`) and basename-only patterns (`*.env`) work.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "kind": {
+          "const": "git_no_denied_paths"
+        },
+        "since": {
+          "default": null,
+          "description": "Optional git ref. When set, only denied paths that changed in the\n`<since>...HEAD` diff are flagged, catches a secret added in a PR even if\nHEAD's tree still tracks an older one. Accepts the `{{env.X}}`\ninterpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "denied"
+      ],
+      "type": "object"
+    },
+    "rule_id": {
+      "description": "Unique kebab-case identifier for the rule.",
+      "pattern": "^[a-z][a-z0-9_-]*$",
+      "type": "string"
+    },
+    "rule_import_gate": {
+      "description": "Forbid imports whose extracted target matches `forbid` (a regex), within the `paths` scope — an architectural import firewall. Matches the EXTRACTED import target (not the raw line), the precise low-false-positive specialisation of `file_content_forbidden`. `language` (go/python/rust/js/scala/java/dart/nix) selects a built-in import-line pattern; `import_pattern` overrides it (capture group 1 = target; required for `generic`). `allow` globs exempt files inside the scope. Per-file.",
+      "properties": {
+        "allow": {
+          "description": "File globs inside the scope exempt from the gate.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "forbid": {
+          "description": "Regex tested against the extracted import target.",
+          "type": "string"
+        },
+        "import_pattern": {
+          "description": "Explicit import-line regex (capture group 1 = imported target); overrides the language preset.",
+          "type": "string"
+        },
+        "kind": {
+          "const": "import_gate"
+        },
+        "language": {
+          "enum": [
+            "go",
+            "python",
+            "rust",
+            "js",
+            "scala",
+            "java",
+            "dart",
+            "nix",
+            "generic"
+          ]
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "forbid"
+      ],
+      "type": "object"
+    },
+    "rule_indent_style": {
+      "description": "Every non-blank line must indent with the configured style. `tabs` rejects any leading space; `spaces` rejects any leading tab and optionally requires the leading-space count to be a multiple of `width`. Check-only — tab-width-aware reindentation is deferred.",
+      "properties": {
+        "kind": {
+          "const": "indent_style"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "style": {
+          "enum": [
+            "tabs",
+            "spaces"
+          ],
+          "type": "string"
+        },
+        "width": {
+          "description": "When `style: spaces`, the leading-space count on every non-blank line must be a multiple of this. Ignored for `style: tabs`.",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "paths",
+        "style"
+      ],
+      "type": "object"
+    },
+    "rule_json_path_equals": {
+      "description": "Value at a JSONPath (RFC 9535) expression in every JSON file in `paths` must deep-equal `equals`. Multiple matches all must match; zero matches is a violation (value missing) unless `if_present: true`. Typical use: `$.license == \"MIT\"` on every `packages/*/package.json`.",
+      "properties": {
+        "equals": {
+          "description": "Expected value. Any JSON type (string, number, boolean, null, array, object)."
+        },
+        "if_present": {
+          "$ref": "#/$defs/if_present"
+        },
+        "kind": {
+          "const": "json_path_equals"
+        },
+        "path": {
+          "description": "JSONPath expression rooted at `$`. Supports dot-access (`$.foo.bar`), array index (`$.deps[0]`), wildcards (`$.deps[*]`), filters, and every other RFC 9535 construct.",
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "path",
+        "equals"
+      ],
+      "type": "object"
+    },
+    "rule_json_path_matches": {
+      "description": "Value at a JSONPath in every JSON file in `paths` must be a string and must match `matches` (a Rust regex). Non-string matches produce a clear 'not a string' violation.",
+      "properties": {
+        "if_present": {
+          "$ref": "#/$defs/if_present"
+        },
+        "kind": {
+          "const": "json_path_matches"
+        },
+        "matches": {
+          "description": "Rust-regex pattern to match against the value at `path`.",
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "path",
+        "matches"
+      ],
+      "type": "object"
+    },
+    "rule_json_schema_passes": {
+      "description": "Validate every JSON / YAML / TOML file in `paths` against the JSON Schema at `schema_path`. Each schema-violation error becomes one violation; a target that fails to parse produces one parse-error violation. Format is detected from the target's extension; pass `format:` to override.",
+      "properties": {
+        "format": {
+          "description": "Override the auto-detected target format. When omitted, format is inferred from each target file's extension (.json / .yaml / .yml / .toml).",
+          "enum": [
+            "json",
+            "yaml",
+            "yml",
+            "toml"
+          ],
+          "type": "string"
+        },
+        "kind": {
+          "const": "json_schema_passes"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "schema_path": {
+          "description": "Path to a JSON Schema file relative to the lint root. Schema must itself be JSON even when validating YAML / TOML targets.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths",
+        "schema_path"
+      ],
+      "type": "object"
+    },
+    "rule_kind_dispatch": {
+      "description": "Dispatch on the `kind` discriminator. Each branch sets the required kind-specific fields.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/rule_file_exists"
+        },
+        {
+          "$ref": "#/$defs/rule_file_absent"
+        },
+        {
+          "$ref": "#/$defs/rule_dir_exists"
+        },
+        {
+          "$ref": "#/$defs/rule_dir_absent"
+        },
+        {
+          "$ref": "#/$defs/rule_file_content_matches"
+        },
+        {
+          "$ref": "#/$defs/rule_file_content_forbidden"
+        },
+        {
+          "$ref": "#/$defs/rule_file_header"
+        },
+        {
+          "$ref": "#/$defs/rule_file_max_size"
+        },
+        {
+          "$ref": "#/$defs/rule_file_min_size"
+        },
+        {
+          "$ref": "#/$defs/rule_file_min_lines"
+        },
+        {
+          "$ref": "#/$defs/rule_file_max_lines"
+        },
+        {
+          "$ref": "#/$defs/rule_file_footer"
+        },
+        {
+          "$ref": "#/$defs/rule_file_shebang"
+        },
+        {
+          "$ref": "#/$defs/rule_file_is_text"
+        },
+        {
+          "$ref": "#/$defs/rule_json_path_equals"
+        },
+        {
+          "$ref": "#/$defs/rule_json_path_matches"
+        },
+        {
+          "$ref": "#/$defs/rule_yaml_path_equals"
+        },
+        {
+          "$ref": "#/$defs/rule_yaml_path_matches"
+        },
+        {
+          "$ref": "#/$defs/rule_toml_path_equals"
+        },
+        {
+          "$ref": "#/$defs/rule_toml_path_matches"
+        },
+        {
+          "$ref": "#/$defs/rule_xml_path_equals"
+        },
+        {
+          "$ref": "#/$defs/rule_xml_path_matches"
+        },
+        {
+          "$ref": "#/$defs/rule_json_schema_passes"
+        },
+        {
+          "$ref": "#/$defs/rule_commented_out_code"
+        },
+        {
+          "$ref": "#/$defs/rule_markdown_paths_resolve"
+        },
+        {
+          "$ref": "#/$defs/rule_git_no_denied_paths"
+        },
+        {
+          "$ref": "#/$defs/rule_git_commit_message"
+        },
+        {
+          "$ref": "#/$defs/rule_git_commit_signed_off"
+        },
+        {
+          "$ref": "#/$defs/rule_git_commit_subject_matches"
+        },
+        {
+          "$ref": "#/$defs/rule_git_commit_no_fixup"
+        },
+        {
+          "$ref": "#/$defs/rule_git_commit_author_allowlist"
+        },
+        {
+          "$ref": "#/$defs/rule_git_commit_gpg_signed"
+        },
+        {
+          "$ref": "#/$defs/rule_git_blame_age"
+        },
+        {
+          "$ref": "#/$defs/rule_changeset_requires_path"
+        },
+        {
+          "$ref": "#/$defs/rule_pair_changed_together"
+        },
+        {
+          "$ref": "#/$defs/rule_filename_case"
+        },
+        {
+          "$ref": "#/$defs/rule_filename_regex"
+        },
+        {
+          "$ref": "#/$defs/rule_pair"
+        },
+        {
+          "$ref": "#/$defs/rule_pair_hash"
+        },
+        {
+          "$ref": "#/$defs/rule_registry_paths_resolve"
+        },
+        {
+          "$ref": "#/$defs/rule_cross_file"
+        },
+        {
+          "$ref": "#/$defs/rule_file_graph"
+        },
+        {
+          "$ref": "#/$defs/rule_ordered_block"
+        },
+        {
+          "$ref": "#/$defs/rule_for_each_match"
+        },
+        {
+          "$ref": "#/$defs/rule_generated_file_fresh"
+        },
+        {
+          "$ref": "#/$defs/rule_import_gate"
+        },
+        {
+          "$ref": "#/$defs/rule_command_idempotent"
+        },
+        {
+          "$ref": "#/$defs/rule_for_each_dir"
+        },
+        {
+          "$ref": "#/$defs/rule_for_each_file"
+        },
+        {
+          "$ref": "#/$defs/rule_dir_only_contains"
+        },
+        {
+          "$ref": "#/$defs/rule_unique_by"
+        },
+        {
+          "$ref": "#/$defs/rule_dir_contains"
+        },
+        {
+          "$ref": "#/$defs/rule_every_matching_has"
+        },
+        {
+          "$ref": "#/$defs/rule_no_trailing_whitespace"
+        },
+        {
+          "$ref": "#/$defs/rule_final_newline"
+        },
+        {
+          "$ref": "#/$defs/rule_line_endings"
+        },
+        {
+          "$ref": "#/$defs/rule_line_max_width"
+        },
+        {
+          "$ref": "#/$defs/rule_no_merge_conflict_markers"
+        },
+        {
+          "$ref": "#/$defs/rule_no_bidi_controls"
+        },
+        {
+          "$ref": "#/$defs/rule_no_zero_width_chars"
+        },
+        {
+          "$ref": "#/$defs/rule_file_is_ascii"
+        },
+        {
+          "$ref": "#/$defs/rule_no_bom"
+        },
+        {
+          "$ref": "#/$defs/rule_file_hash"
+        },
+        {
+          "$ref": "#/$defs/rule_max_directory_depth"
+        },
+        {
+          "$ref": "#/$defs/rule_max_files_per_directory"
+        },
+        {
+          "$ref": "#/$defs/rule_no_empty_files"
+        },
+        {
+          "$ref": "#/$defs/rule_no_case_conflicts"
+        },
+        {
+          "$ref": "#/$defs/rule_no_illegal_windows_names"
+        },
+        {
+          "$ref": "#/$defs/rule_no_symlinks"
+        },
+        {
+          "$ref": "#/$defs/rule_executable_bit"
+        },
+        {
+          "$ref": "#/$defs/rule_executable_has_shebang"
+        },
+        {
+          "$ref": "#/$defs/rule_shebang_has_executable"
+        },
+        {
+          "$ref": "#/$defs/rule_no_submodules"
+        },
+        {
+          "$ref": "#/$defs/rule_indent_style"
+        },
+        {
+          "$ref": "#/$defs/rule_max_consecutive_blank_lines"
+        },
+        {
+          "$ref": "#/$defs/rule_file_starts_with"
+        },
+        {
+          "$ref": "#/$defs/rule_file_ends_with"
+        },
+        {
+          "$ref": "#/$defs/rule_command"
+        }
+      ]
+    },
+    "rule_line_endings": {
+      "description": "Every line ending in every file in scope must use the `target` style (`lf` or `crlf`). Mixed endings within a file also fail.",
+      "properties": {
+        "kind": {
+          "const": "line_endings"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "target": {
+          "enum": [
+            "lf",
+            "crlf"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths",
+        "target"
+      ],
+      "type": "object"
+    },
+    "rule_line_max_width": {
+      "description": "No line in any file in scope exceeds `max_width` Unicode scalar values (chars). Display width is NOT computed — use a formatter for that. Check-only; truncation is not a safe auto-fix.",
+      "properties": {
+        "kind": {
+          "const": "line_max_width"
+        },
+        "max_width": {
+          "description": "Maximum number of Unicode scalar values (chars) allowed per line.",
+          "format": "uint",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "max_width"
+      ],
+      "type": "object"
+    },
+    "rule_markdown_paths_resolve": {
+      "description": "Validate that backticked workspace paths in markdown files resolve to real files or directories in the repo. Targets the AGENTS.md / CLAUDE.md / .cursorrules staleness problem: agent-context files reference paths in inline backticks, and those paths drift as the codebase evolves. Skips fenced and 4-space-indented code blocks (those contain code samples, not factual claims about the tree). Required `prefixes` field marks which path-shapes to validate (e.g. `[\"src/\", \"crates/\", \"docs/\"]`); backticked tokens not starting with a configured prefix are ignored, eliminating the FP class of `\\`npm\\`` / `\\`function\\`` / etc.",
+      "properties": {
+        "ignore_template_vars": {
+          "default": true,
+          "description": "Skip backticked tokens containing template-variable\nmarkers (`{{ }}`, `${ }`, `<…>`). Default true.",
+          "type": "boolean"
+        },
+        "kind": {
+          "const": "markdown_paths_resolve"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "prefixes": {
+          "description": "Whitelist of path-shape prefixes to validate. A backticked\ntoken must start with one of these to be considered a path\ncandidate. No defaults — every project's layout differs and\nthe user must declare which prefixes mark a path.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "paths",
+        "prefixes"
+      ],
+      "type": "object"
+    },
+    "rule_max_consecutive_blank_lines": {
+      "description": "Cap the number of blank lines that may appear in a row. A blank line is empty or only whitespace. Fixable via `file_collapse_blank_lines`, which collapses over-long runs to exactly `max` blank lines.",
+      "properties": {
+        "kind": {
+          "const": "max_consecutive_blank_lines"
+        },
+        "max": {
+          "description": "Maximum number of blank lines allowed in a row. `0` means\nno blank lines at all.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "max"
+      ],
+      "type": "object"
+    },
+    "rule_max_directory_depth": {
+      "description": "Every path in scope must sit at depth ≤ `max_depth` (number of `/`-separated components). Check-only; file relocation is a human decision.",
+      "properties": {
+        "kind": {
+          "const": "max_directory_depth"
+        },
+        "max_depth": {
+          "description": "Maximum allowed path depth (number of `/`-separated components).",
+          "format": "uint",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "max_depth"
+      ],
+      "type": "object"
+    },
+    "rule_max_files_per_directory": {
+      "description": "Every directory containing at least one in-scope file must hold ≤ `max_files` in-scope files (immediate children, non-recursive). Check-only.",
+      "properties": {
+        "kind": {
+          "const": "max_files_per_directory"
+        },
+        "max_files": {
+          "description": "Maximum number of in-scope files allowed as immediate children\nof any one directory (non-recursive).",
+          "format": "uint",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "max_files"
+      ],
+      "type": "object"
+    },
+    "rule_no_bidi_controls": {
+      "description": "Flag Unicode bidirectional control characters (U+202A–202E, U+2066–2069) anywhere in a file. Trojan Source (CVE-2021-42574) defense. Fixable via `file_strip_bidi`.",
+      "properties": {
+        "kind": {
+          "const": "no_bidi_controls"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_no_bom": {
+      "description": "Flag files that start with a UTF-8 / UTF-16 / UTF-32 BOM. Fixable via `file_strip_bom`.",
+      "properties": {
+        "kind": {
+          "const": "no_bom"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_no_case_conflicts": {
+      "description": "Flag pairs of paths that differ only by case (e.g. README.md + readme.md). These can't coexist on macOS HFS+/APFS or Windows NTFS.",
+      "properties": {
+        "kind": {
+          "const": "no_case_conflicts"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_no_empty_files": {
+      "description": "Flag zero-byte files. Fixable via `file_remove`, which deletes the empty file.",
+      "properties": {
+        "kind": {
+          "const": "no_empty_files"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_no_illegal_windows_names": {
+      "description": "Reject path components Windows can't represent: reserved device names (CON/PRN/AUX/NUL/COM1-9/LPT1-9 regardless of extension), trailing dots or spaces, and the forbidden chars <>:\"|?*.",
+      "properties": {
+        "kind": {
+          "const": "no_illegal_windows_names"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_no_merge_conflict_markers": {
+      "description": "Flag files that still contain git conflict markers at the start of a line (`<<<<<<< `, `=======`, `>>>>>>> `, `||||||| `). Check-only; conflict resolution requires human judgment.",
+      "properties": {
+        "kind": {
+          "const": "no_merge_conflict_markers"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_no_submodules": {
+      "description": "Flag the presence of `.gitmodules` at the repo root. Always targets `.gitmodules` — no `paths` field accepted. Fixable via `file_remove`.",
+      "not": {
+        "required": [
+          "paths"
+        ]
+      },
+      "properties": {
+        "kind": {
+          "const": "no_submodules"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    "rule_no_symlinks": {
+      "description": "Flag tracked paths that are symbolic links. Symlinks are a portability headache across Windows/macOS/Linux and CI runners. Fixable via `file_remove`, which deletes the symlink.",
+      "properties": {
+        "kind": {
+          "const": "no_symlinks"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_no_trailing_whitespace": {
+      "description": "No line in any file in scope ends with a space or tab. Non-UTF-8 files are skipped silently.",
+      "properties": {
+        "kind": {
+          "const": "no_trailing_whitespace"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_no_zero_width_chars": {
+      "description": "Flag zero-width characters (U+200B/C/D, plus body-internal U+FEFF). A leading U+FEFF (BOM) is not flagged here — use `no_bom` for that. Fixable via `file_strip_zero_width`.",
+      "properties": {
+        "kind": {
+          "const": "no_zero_width_chars"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_ordered_block": {
+      "description": "The lines between a `start` / `end` marker pair must stay sorted (and, with `unique`, free of duplicates) under `comparator`. Both markers are optional: omit `end` to sort from `start` to EOF, omit both to sort the whole file (the markerless 'this file is one sorted list' form). The generic form of per-project keep-sorted scripts. Per-file: markers match the trimmed line; blank lines inside a block are ignored.",
+      "properties": {
+        "comparator": {
+          "enum": [
+            "lexical",
+            "lexical-ci",
+            "numeric"
+          ]
+        },
+        "end": {
+          "description": "Marker line closing a block. Optional — omit to run the block to EOF.",
+          "type": "string"
+        },
+        "kind": {
+          "const": "ordered_block"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "select": {
+          "description": "Regex; when set, only lines inside a block matching it are sortable entries (others — comments, group headers — pass through). The sectioned / keep-sorted-subset shape.",
+          "type": "string"
+        },
+        "start": {
+          "description": "Marker line opening a block (matched on the trimmed line). Optional — omit to anchor the block at the start of the file.",
+          "type": "string"
+        },
+        "unique": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "rule_pair": {
+      "description": "For every file matching `primary`, a file matching the `partner` template must exist. Template tokens: {dir}, {stem}, {ext}, {basename}, {path}, {parent_name}.",
+      "properties": {
+        "kind": {
+          "const": "pair"
+        },
+        "partner": {
+          "description": "Path template resolved per primary match. Example: \"{dir}/{stem}.h\".",
+          "type": "string"
+        },
+        "primary": {
+          "description": "Glob selecting the primary files.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "primary",
+        "partner"
+      ],
+      "type": "object"
+    },
+    "rule_pair_changed_together": {
+      "description": "If the `<since>...HEAD` diff changes any path matching `if_changed:`, at least one path matching `then_changed:` must change in the same range — the co-change gate (a FORMAT_VERSION must bump when the format struct changes; version.txt and the lockfile change together). Both globs and `since:` (the base ref) are required. Directional: a `then_changed`-only change never triggers it (add a second rule with the globs swapped for a bidirectional pact). Diff-scoped: silent no-op outside a git repo / when `if_changed` didn't change; a `since:` that fails to resolve hard-fails with a shallow-clone hint. Check-only.",
+      "properties": {
+        "if_changed": {
+          "description": "Glob; the trigger. When the diff changes a path matching this, a\n`then_changed` co-change is required.",
+          "type": "string"
+        },
+        "kind": {
+          "const": "pair_changed_together"
+        },
+        "since": {
+          "description": "Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}`\ninterpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
+          "type": "string"
+        },
+        "then_changed": {
+          "description": "Glob; the obligation. At least one changed path must match it whenever\n`if_changed` fired.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "if_changed",
+        "then_changed",
+        "since"
+      ],
+      "type": "object"
+    },
+    "rule_pair_hash": {
+      "description": "Cross-file: the `algorithm` digest of every file matching `source` must appear in the single `target` file — either as an embedded hex substring (`format: contains`, the default) or a coreutils / go-`.sum`-style `<hex>  <path>` manifest line (`format: sums-line`). Detection-only (alint never rewrites the manifest). A missing `target` is one violation; one violation per source whose digest is absent or mismatched. golang/go FIPS `fips140.sum` is the canonical use.",
+      "properties": {
+        "algorithm": {
+          "description": "Digest algorithm (default: sha256).",
+          "enum": [
+            "sha256",
+            "sha512"
+          ]
+        },
+        "format": {
+          "description": "How the digest must appear in `target`: `contains` = hex substring anywhere (default); `sums-line` = a `<hex> [*]<path>` line whose path token is the source's path.",
+          "enum": [
+            "contains",
+            "sums-line"
+          ]
+        },
+        "kind": {
+          "const": "pair_hash"
+        },
+        "source": {
+          "description": "Literal path or glob selecting the file(s) whose content is hashed (one check per match).",
+          "type": "string"
+        },
+        "target": {
+          "description": "The single file that must carry the digest (a `.sum` / `SHA256SUMS` / file with an embedded hash).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source",
+        "target"
+      ],
+      "type": "object"
+    },
+    "rule_registry_paths_resolve": {
+      "description": "A manifest enumerates path entries; each must resolve to an on-disk artefact. `extract` selects how the entry list is pulled (structured-query toml/json/yaml, a line list, or regex capture group 1). Optional `orphans` adds the reverse check: on-disk artefacts under `space` that no entry references. Non-literal entries (interpolation / antiquotation) are skipped, not failed.",
+      "properties": {
+        "base": {
+          "description": "Resolve entries relative to: registry_dir (default), lint_root, or an explicit path.",
+          "type": "string"
+        },
+        "entries_are_globs": {
+          "type": "boolean"
+        },
+        "exclude_query": {
+          "type": "string"
+        },
+        "expect": {
+          "enum": [
+            "any",
+            "file",
+            "dir"
+          ]
+        },
+        "extract": {
+          "additionalProperties": false,
+          "description": "Exactly one of: toml/json/yaml (RFC 9535 JSONPath string), lines (object; optional `comment` prefix, default `#`), regex (string; capture group 1 is the path).",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "json": {
+              "type": "string"
+            },
+            "lines": {
+              "additionalProperties": false,
+              "properties": {
+                "comment": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "regex": {
+              "type": "string"
+            },
+            "toml": {
+              "type": "string"
+            },
+            "yaml": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "kind": {
+          "const": "registry_paths_resolve"
+        },
+        "must_contain": {
+          "type": "string"
+        },
+        "orphans": {
+          "additionalProperties": false,
+          "properties": {
+            "space": {
+              "type": "string"
+            },
+            "unreferenced": {
+              "enum": [
+                "warn",
+                "error",
+                "off"
+              ]
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        "source": {
+          "description": "The manifest/registry file (path, or a glob to run once per matching manifest) that enumerates the path entries.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source",
+        "extract"
+      ],
+      "type": "object"
+    },
+    "rule_shebang_has_executable": {
+      "description": "Every file that starts with `#!` must have the Unix +x bit set. The inverse of `executable_has_shebang`. No-op on non-Unix. No fix op (chmod auto-apply deferred).",
+      "properties": {
+        "kind": {
+          "const": "shebang_has_executable"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_template_instance": {
+      "description": "A rule entry that expands a `templates:` body. The instance's `id:` is required; `vars:` provides the substitutions for the template's `{{vars.<name>}}` placeholders. Any other field overrides the corresponding field in the expanded template.",
+      "properties": {
+        "extends_template": {
+          "description": "Id of an entry in the top-level `templates:` block to instantiate.",
+          "type": "string"
+        },
+        "id": {
+          "$ref": "#/$defs/rule_id"
+        },
+        "level": {
+          "$ref": "#/$defs/level"
+        },
+        "message": {
+          "type": "string"
+        },
+        "policy_url": {
+          "format": "uri",
+          "type": "string"
+        },
+        "vars": {
+          "additionalProperties": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ]
+          },
+          "description": "Map of `name → value` to substitute into `{{vars.<name>}}` placeholders in the template body.",
+          "type": "object"
+        },
+        "when": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "extends_template"
+      ],
+      "type": "object"
+    },
+    "rule_toml_path_equals": {
+      "description": "TOML sibling of `json_path_equals`. Typical use: enforce `[package].edition == \"2024\"` on every `Cargo.toml`.",
+      "properties": {
+        "equals": {},
+        "if_present": {
+          "$ref": "#/$defs/if_present"
+        },
+        "kind": {
+          "const": "toml_path_equals"
+        },
+        "path": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "path",
+        "equals"
+      ],
+      "type": "object"
+    },
+    "rule_toml_path_matches": {
+      "description": "TOML sibling of `json_path_matches`.",
+      "properties": {
+        "if_present": {
+          "$ref": "#/$defs/if_present"
+        },
+        "kind": {
+          "const": "toml_path_matches"
+        },
+        "matches": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "path",
+        "matches"
+      ],
+      "type": "object"
+    },
+    "rule_unique_by": {
+      "description": "Flag any group of files (matching `select`) sharing the same rendered `key`. One violation per collision group, anchored on the lexicographically-first file. Path-template tokens ({path}, {dir}, {basename}, {stem}, {ext}, {parent_name}) may appear in `key`. With `case_insensitive: true` the key is folded to lowercase before grouping, catching collisions that only occur on a case-insensitive filesystem (Windows / macOS).",
+      "properties": {
+        "case_insensitive": {
+          "default": false,
+          "description": "Fold the key to lowercase before grouping, so keys that\ncollide only under case-folding count as duplicates — the\ncase-insensitive-filesystem hazard (Windows / macOS).",
+          "type": "boolean"
+        },
+        "key": {
+          "default": "{basename}",
+          "description": "Path-template producing a key per matched file. Default: {basename}.",
+          "type": "string"
+        },
+        "kind": {
+          "const": "unique_by"
+        },
+        "select": {
+          "description": "Glob selecting the files to deduplicate.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "select"
+      ],
+      "type": "object"
+    },
+    "rule_xml_path_equals": {
+      "description": "XML sibling of `json_path_equals`. XML maps to the same value tree via the xmltodict-style convention: attributes are `@name` keys, repeated child elements become an array, a leaf element collapses to its text string, namespaces flatten to local names, and every leaf value is a string (quote your `equals:`, e.g. `equals: \"4.0.0\"`). Typical use: enforce `$.Project.PropertyGroup.TargetFramework == \"net8.0\"` on every `.csproj`, or a Maven `$.project.parent.version` across `pom.xml`.",
+      "properties": {
+        "equals": {},
+        "if_present": {
+          "$ref": "#/$defs/if_present"
+        },
+        "kind": {
+          "const": "xml_path_equals"
+        },
+        "path": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "path",
+        "equals"
+      ],
+      "type": "object"
+    },
+    "rule_xml_path_matches": {
+      "description": "XML sibling of `json_path_matches` (same xmltodict-style mapping as `xml_path_equals`; all XML leaf values are strings). Typical use: `$.Project.ItemGroup.PackageReference[*]['@Version']` matches a version pattern across `.csproj`.",
+      "properties": {
+        "if_present": {
+          "$ref": "#/$defs/if_present"
+        },
+        "kind": {
+          "const": "xml_path_matches"
+        },
+        "matches": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "path",
+        "matches"
+      ],
+      "type": "object"
+    },
+    "rule_yaml_path_equals": {
+      "description": "YAML sibling of `json_path_equals`. Parses the file as YAML before applying the JSONPath query. Use this on GitHub Actions workflows, docker-compose.yml, kubernetes manifests, `.gitlab-ci.yml`, etc.",
+      "properties": {
+        "equals": {},
+        "if_present": {
+          "$ref": "#/$defs/if_present"
+        },
+        "kind": {
+          "const": "yaml_path_equals"
+        },
+        "path": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "path",
+        "equals"
+      ],
+      "type": "object"
+    },
+    "rule_yaml_path_matches": {
+      "description": "YAML sibling of `json_path_matches`.",
+      "properties": {
+        "if_present": {
+          "$ref": "#/$defs/if_present"
+        },
+        "kind": {
+          "const": "yaml_path_matches"
+        },
+        "matches": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "path",
+        "matches"
+      ],
+      "type": "object"
+    },
+    "scope_filter": {
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": [
+            "has_ancestor"
+          ]
+        },
+        {
+          "required": [
+            "changed_since"
+          ]
+        }
+      ],
+      "description": "Per-file rule scoping. `has_ancestor` (v0.9.6+) admits files whose ancestor chain contains a named manifest; `changed_since` (v0.11+) admits files in a `<ref>...HEAD` git diff. At least one must be set; setting both is an AND. Supported on per-file rules and on `dir_absent` (since v0.9.18). Cross-file rules (`pair`, `for_each_dir`, `file_exists`, etc.) reject `scope_filter:` at build time. Combine with the rule's existing `paths:` glob — all gates must match for the rule to fire.",
+      "properties": {
+        "changed_since": {
+          "description": "Git ref; the rule only fires on files in the `<ref>...HEAD` diff (the same merge-base diff as `alint check --changed`). Right shape for grandfathering pre-existing files in a PR — e.g. require an SPDX header only on files the PR touched. Accepts the `{{env.X}}` interpolation (e.g. `changed_since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`). Outside a git repo the predicate matches nothing (silent); an unresolvable ref inside a repo is a hard error with a shallow-clone hint.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "has_ancestor": {
+          "description": "Manifest filename (or list of filenames) whose presence in any ancestor directory of the linted file admits the rule. Each entry is a literal filename like `Cargo.toml` or `package.json` — no path separators, no glob metacharacters; the ancestor walk handles \"anywhere up the tree\" by traversing `Path::parent()` upward.",
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "items": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "string_or_string_array": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "template": {
+      "additionalProperties": true,
+      "description": "A reusable rule shape. Identical to a regular rule except `level` is optional (instances may add it) and the body is matched after `{{vars.<name>}}` substitution.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/rule_id"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
     }
-  }
+  },
+  "$id": "https://raw.githubusercontent.com/asamarts/alint/main/schemas/v1/config.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Schema for .alint.yml configuration files. Authoritative reference: docs/design/ARCHITECTURE.md in the alint repository.",
+  "properties": {
+    "allow_out_of_root": {
+      "description": "Top-level-only escape hatch for path confinement: permit rules to read a config-declared path that escapes the repo root. `true` allows every rule; a map `{ kinds: [...], rules: [...] }` allows only the listed rule kinds / ids. Absent or `false` keeps the secure default (every config-derived path read is confined). REJECTED from `extends:`'d rulesets — only the user's own top-level config may set it. Applies to file reads (currently `registry_paths_resolve` source, `json_schema_passes` schema_path, `pair_hash` target); resolve/index checks stay confined. Permitted reads emit an informational note. See docs/design/v0.12/allow_out_of_root.md.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "kinds": {
+              "description": "Rule kinds permitted to read out of the repo root.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "rules": {
+              "description": "Rule ids permitted to read out of the repo root.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "extends": {
+      "description": "Configs to inherit from. Each entry is either a bare string (local path, `https://` URL with SRI, or `alint://bundled/<name>@<rev>`) or a mapping `{url, only?, except?}` that filters the inherited rule set before merging.\n\nEntries resolved left-to-right; later entries override earlier ones, and the current file's own definitions override everything it extends.\n\n**Rule merging is field-level by `id`.** A child can override just the fields it wants to change — `rules: [{id: inherited, level: warning}]` keeps the parent's `kind`/`paths`/etc. and only downgrades severity. `{id: inherited, level: off}` disables a rule without redeclaring it.\n\n**Selective adoption** via `only:` (keep these ids, drop everything else) or `except:` (drop these ids). The two are mutually exclusive on a single entry. Unknown ids are a load-time error so typos surface immediately.\n\nRemote and bundled configs cannot themselves declare `extends:` (no principled base for relative resolution in a fetched body); nest extends locally instead.",
+      "items": {
+        "$ref": "#/$defs/extends_entry"
+      },
+      "type": "array"
+    },
+    "facts": {
+      "description": "Properties of the repository evaluated once per run; referenced from `when` clauses as facts.<id>.",
+      "items": {
+        "$ref": "#/$defs/fact"
+      },
+      "type": "array"
+    },
+    "fix_size_limit": {
+      "default": 1048576,
+      "description": "Max bytes a content-editing fix will touch. Files over this limit are reported as Skipped with a stderr warning. Default: 1 MiB. Explicit null disables the cap. Path-only fixes (file_create, file_remove, file_rename) ignore this setting.",
+      "minimum": 0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "ignore": {
+      "description": "Additional glob patterns excluded on top of .gitignore.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "nested_configs": {
+      "default": false,
+      "description": "Opt in to discovery of nested `.alint.yml` / `.alint.yaml` files in subdirectories. When true, the loader walks the tree from this config's directory (honoring `.gitignore` + `ignore`) and finds any nested config files. Each nested rule's path-like scope fields (`paths`, `select`, `primary`) are automatically prefixed with the nested config's relative directory, so rules declared in `packages/frontend/.alint.yml` apply only under `packages/frontend/**`. Id collisions across configs are rejected with a clear error — per-subtree overrides aren't supported in this release (use `when:` on the root rule for that). Only the root config sets this; nested configs can't spawn further nested discovery.",
+      "type": "boolean"
+    },
+    "respect_gitignore": {
+      "default": true,
+      "description": "Whether to honor .gitignore files during the walk.",
+      "type": "boolean"
+    },
+    "rules": {
+      "description": "Rules evaluated against the repository tree.",
+      "items": {
+        "$ref": "#/$defs/rule"
+      },
+      "type": "array"
+    },
+    "templates": {
+      "description": "Reusable rule shapes referenced by `extends_template:` in `rules:` entries. Each template carries an `id:` and any other rule-spec fields; `{{vars.<name>}}` placeholders in those fields substitute from each instance's `vars:` map at expansion time. Templates are leaf-only — a template may not itself `extends_template:` another. Templates merge through the `extends:` chain by id, so a downstream config can override an upstream template's body.",
+      "items": {
+        "$ref": "#/$defs/template"
+      },
+      "type": "array"
+    },
+    "vars": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Free-form string variables referenced from rule messages as {{vars.<name>}} and from `when` clauses as vars.<name>.",
+      "type": "object"
+    },
+    "version": {
+      "const": 1,
+      "description": "Config schema version. Always 1 for this schema."
+    }
+  },
+  "required": [
+    "version"
+  ],
+  "title": "alint configuration (v1)",
+  "type": "object"
 }

--- a/crates/alint-rules/Cargo.toml
+++ b/crates/alint-rules/Cargo.toml
@@ -17,6 +17,7 @@ authors.workspace = true
 
 [dependencies]
 alint-core.workspace = true
+schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml_ng.workspace = true

--- a/crates/alint-rules/src/changeset_requires_path.rs
+++ b/crates/alint-rules/src/changeset_requires_path.rs
@@ -26,21 +26,21 @@ use alint_core::git::{
 use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Scope, Violation};
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// Glob; the diff must ADD (git status `A`) at least one path
-    /// matching it.
+    /// Glob; the diff must ADD at least one path matching it.
     add_glob: String,
-    /// Optional gate: only require the add when some path matching
-    /// this glob changed (any status). Unset → any non-empty
-    /// changeset triggers the requirement.
+    /// Optional gate: only require the add when some path matching this glob
+    /// changed (any status). Omit to require it on any non-empty changeset.
     #[serde(default)]
     when_changed: Option<String>,
-    /// Base ref for the `<since>...HEAD` diff. The canonical
-    /// `{{env.X}}` interpolation is resolved at config load.
+    /// Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}`
+    /// interpolation, e.g. `since: "{{env.ALINT_BASE_SHA | default('origin/main')}}"`.
     since: String,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct ChangesetRequiresPathRule {

--- a/crates/alint-rules/src/command.rs
+++ b/crates/alint-rules/src/command.rs
@@ -69,15 +69,21 @@ const OUTPUT_CAP_BYTES: usize = 16 * 1024;
 /// idle while the child runs.
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Argv tokens. The first token is the program (looked up via PATH if it's
+    /// a bare name); remaining tokens accept `{path}` and friends.
+    #[schemars(length(min = 1))]
     command: Vec<String>,
-    /// Per-file timeout in seconds. Default
-    /// [`DEFAULT_TIMEOUT_SECS`].
+    /// Per-file timeout in seconds. Default 30. Past this, the child is killed
+    /// and a violation reports the timeout.
     #[serde(default)]
+    #[schemars(range(min = 1))]
     timeout: Option<u64>,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct CommandRule {

--- a/crates/alint-rules/src/command_idempotent.rs
+++ b/crates/alint-rules/src/command_idempotent.rs
@@ -37,7 +37,7 @@ use serde::Deserialize;
 /// legible (mirrors the `command` rule's output cap intent).
 const OUTPUT_SNIPPET_CAP: usize = 400;
 
-#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 enum FilesFrom {
     /// One violation for the whole invocation (default).
@@ -49,23 +49,32 @@ enum FilesFrom {
     Stderr,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Checker argv (no shell), run in its --check / idempotence mode; exit
+    /// 0 = clean.
+    #[schemars(length(min = 1))]
     command: Vec<String>,
+    /// Checker cwd, relative to the lint root (default: lint root).
     #[serde(default)]
     workdir: Option<String>,
+    /// On failure, parse this stream into per-file violations (default: none =
+    /// one violation for the whole invocation).
     #[serde(default)]
     files_from: FilesFrom,
-    /// Regex whose capture group 1 is a file path, applied per
-    /// output line (only with `files_from`).
+    /// Regex whose capture group 1 is a file path, applied per output line
+    /// (requires `files_from`; omit for bare-path listers).
     #[serde(default)]
     files_pattern: Option<String>,
-    /// Child timeout in seconds. Default
-    /// [`crate::spawn::DEFAULT_SPAWN_TIMEOUT_SECS`].
+    /// Checker timeout in seconds (default 120). On timeout the child is killed
+    /// and one violation is emitted.
     #[serde(default)]
+    #[schemars(range(min = 1))]
     timeout: Option<u64>,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct CommandIdempotentRule {

--- a/crates/alint-rules/src/commented_out_code.rs
+++ b/crates/alint-rules/src/commented_out_code.rs
@@ -64,6 +64,7 @@ struct Options {
     /// each file's extension. Explicit override useful for
     /// embedded DSLs or cases where the extension lies.
     #[serde(default)]
+    #[schemars(extend("default" = "auto"))]
     language: Language,
     /// Minimum consecutive comment-line count for a block to
     /// be considered. 1-2 line comments are almost always
@@ -71,14 +72,15 @@ struct Options {
     #[serde(default = "default_min_lines")]
     #[schemars(range(min = 2))]
     min_lines: usize,
-    /// Token-density floor (0.0-1.0). Higher = stricter (only
-    /// the most code-shaped blocks fire). Default 0.5.
+    /// Density floor for code-shapedness. Higher = stricter. Default 0.5 sits
+    /// at the midpoint between obvious-prose (0.0) and obvious-code (1.0);
+    /// lower it to widen the catch (more FPs), raise it to narrow.
     #[serde(default = "default_threshold")]
     #[schemars(range(min = 0.0, max = 1.0))]
     threshold: f64,
-    /// Skip the first N lines of any file. Defaults to 30 to
-    /// pass over license headers without false-positive
-    /// flagging them as commented-out code.
+    /// Skip blocks whose first line is at or before this line number. Default
+    /// 30 - covers typical license headers without false-positive flagging
+    /// them as commented-out code.
     #[serde(default = "default_skip_leading_lines")]
     skip_leading_lines: usize,
 }

--- a/crates/alint-rules/src/commented_out_code.rs
+++ b/crates/alint-rules/src/commented_out_code.rs
@@ -57,7 +57,7 @@ use alint_core::{
 };
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
     /// `auto` (default) infers the comment-marker set from
@@ -69,10 +69,12 @@ struct Options {
     /// be considered. 1-2 line comments are almost always
     /// prose; 3+ starts looking like dead code. Default 3.
     #[serde(default = "default_min_lines")]
+    #[schemars(range(min = 2))]
     min_lines: usize,
     /// Token-density floor (0.0-1.0). Higher = stricter (only
     /// the most code-shaped blocks fire). Default 0.5.
     #[serde(default = "default_threshold")]
+    #[schemars(range(min = 0.0, max = 1.0))]
     threshold: f64,
     /// Skip the first N lines of any file. Defaults to 30 to
     /// pass over license headers without false-positive
@@ -80,6 +82,8 @@ struct Options {
     #[serde(default = "default_skip_leading_lines")]
     skip_leading_lines: usize,
 }
+
+crate::options_schema_for!(Options);
 
 fn default_min_lines() -> usize {
     3
@@ -91,7 +95,7 @@ fn default_skip_leading_lines() -> usize {
     30
 }
 
-#[derive(Debug, Deserialize, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Default, Clone, Copy, PartialEq, Eq, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 enum Language {
     #[default]

--- a/crates/alint-rules/src/file_content_forbidden.rs
+++ b/crates/alint-rules/src/file_content_forbidden.rs
@@ -6,11 +6,14 @@ use alint_core::{Context, Error, Level, PerFileRule, Result, Rule, RuleSpec, Sco
 use regex::Regex;
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Rust regex. File contents must NOT match.
     pattern: String,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct FileContentForbiddenRule {

--- a/crates/alint-rules/src/file_content_matches.rs
+++ b/crates/alint-rules/src/file_content_matches.rs
@@ -10,11 +10,14 @@ use serde::Deserialize;
 
 use crate::fixers::FileAppendFixer;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Rust regex. File contents must match.
     pattern: String,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct FileContentMatchesRule {

--- a/crates/alint-rules/src/file_ends_with.rs
+++ b/crates/alint-rules/src/file_ends_with.rs
@@ -18,12 +18,15 @@ use serde::Deserialize;
 
 use crate::io::read_suffix_n;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// The required suffix. Matched byte-for-byte.
+    /// Required suffix, matched byte-for-byte.
+    #[schemars(length(min = 1))]
     suffix: String,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct FileEndsWithRule {

--- a/crates/alint-rules/src/file_footer.rs
+++ b/crates/alint-rules/src/file_footer.rs
@@ -24,13 +24,18 @@ use serde::Deserialize;
 
 use crate::fixers::FileAppendFixer;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Rust regex. The last `lines` lines of each file must match.
     pattern: String,
+    /// Number of trailing lines to consider.
     #[serde(default = "default_lines")]
+    #[schemars(range(min = 1))]
     lines: usize,
 }
+
+crate::options_schema_for!(Options);
 
 fn default_lines() -> usize {
     20

--- a/crates/alint-rules/src/file_hash.rs
+++ b/crates/alint-rules/src/file_hash.rs
@@ -16,13 +16,16 @@ use alint_core::{
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
     /// Expected SHA-256 in lowercase hex (64 chars). Accepting
     /// uppercase and the `sha256:` prefix keeps the field forgiving.
+    #[schemars(regex(pattern = r"^(sha256:)?[0-9a-fA-F]{64}$"))]
     sha256: String,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct FileHashRule {

--- a/crates/alint-rules/src/file_header.rs
+++ b/crates/alint-rules/src/file_header.rs
@@ -18,6 +18,7 @@ struct Options {
     pattern: String,
     /// Number of leading lines to consider.
     #[serde(default = "default_lines")]
+    #[schemars(range(min = 1))]
     lines: usize,
 }
 
@@ -25,52 +26,7 @@ fn default_lines() -> usize {
     20
 }
 
-/// The `$defs/rule_file_header` JSON-Schema branch, assembled from the
-/// schemars-derived `Options` schema (field types and descriptions) plus the
-/// common `kind`/`paths` discriminator and the validating `lines` minimum.
-///
-/// Consumed by `xtask gen-schema`. This is the keystone-prototype kind: the
-/// first whose schema branch is generated from its Rust type rather than
-/// hand-written in `schemas/v1/config.json`. See ADR-0001 and
-/// `docs/design/spec-driven-development.md`.
-#[must_use]
-pub fn rule_def_schema() -> serde_json::Value {
-    let derived = serde_json::to_value(schemars::schema_for!(Options))
-        .expect("Options JSON schema serializes to a value");
-
-    let mut properties = serde_json::Map::new();
-    properties.insert(
-        "kind".to_string(),
-        serde_json::json!({ "enum": ["file_header", "header"] }),
-    );
-    properties.insert(
-        "paths".to_string(),
-        serde_json::json!({ "$ref": "#/$defs/paths_spec" }),
-    );
-    if let Some(opts) = derived
-        .get("properties")
-        .and_then(serde_json::Value::as_object)
-    {
-        for (key, value) in opts {
-            properties.insert(key.clone(), value.clone());
-        }
-    }
-    // `lines` is a usize, so schemars emits `minimum: 0`; the rule's contract is
-    // `lines >= 1`. Apply the validating constraint in the assembler rather than
-    // a schemars attribute to keep the constraint visible next to its rationale.
-    if let Some(lines) = properties
-        .get_mut("lines")
-        .and_then(serde_json::Value::as_object_mut)
-    {
-        lines.insert("minimum".to_string(), serde_json::json!(1));
-    }
-
-    serde_json::json!({
-        "type": "object",
-        "required": ["paths", "pattern"],
-        "properties": properties,
-    })
-}
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct FileHeaderRule {

--- a/crates/alint-rules/src/file_header.rs
+++ b/crates/alint-rules/src/file_header.rs
@@ -6,12 +6,11 @@ use alint_core::{
     Context, Error, FixSpec, Fixer, Level, PerFileRule, Result, Rule, RuleSpec, Scope, Violation,
 };
 use regex::Regex;
-use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::fixers::FilePrependFixer;
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
     /// Rust regex. The first `lines` lines of each file in scope must match.

--- a/crates/alint-rules/src/file_header.rs
+++ b/crates/alint-rules/src/file_header.rs
@@ -6,20 +6,70 @@ use alint_core::{
     Context, Error, FixSpec, Fixer, Level, PerFileRule, Result, Rule, RuleSpec, Scope, Violation,
 };
 use regex::Regex;
+use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::fixers::FilePrependFixer;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Rust regex. The first `lines` lines of each file in scope must match.
     pattern: String,
+    /// Number of leading lines to consider.
     #[serde(default = "default_lines")]
     lines: usize,
 }
 
 fn default_lines() -> usize {
     20
+}
+
+/// The `$defs/rule_file_header` JSON-Schema branch, assembled from the
+/// schemars-derived `Options` schema (field types and descriptions) plus the
+/// common `kind`/`paths` discriminator and the validating `lines` minimum.
+///
+/// Consumed by `xtask gen-schema`. This is the keystone-prototype kind: the
+/// first whose schema branch is generated from its Rust type rather than
+/// hand-written in `schemas/v1/config.json`. See ADR-0001 and
+/// `docs/design/spec-driven-development.md`.
+#[must_use]
+pub fn rule_def_schema() -> serde_json::Value {
+    let derived = serde_json::to_value(schemars::schema_for!(Options))
+        .expect("Options JSON schema serializes to a value");
+
+    let mut properties = serde_json::Map::new();
+    properties.insert(
+        "kind".to_string(),
+        serde_json::json!({ "enum": ["file_header", "header"] }),
+    );
+    properties.insert(
+        "paths".to_string(),
+        serde_json::json!({ "$ref": "#/$defs/paths_spec" }),
+    );
+    if let Some(opts) = derived
+        .get("properties")
+        .and_then(serde_json::Value::as_object)
+    {
+        for (key, value) in opts {
+            properties.insert(key.clone(), value.clone());
+        }
+    }
+    // `lines` is a usize, so schemars emits `minimum: 0`; the rule's contract is
+    // `lines >= 1`. Apply the validating constraint in the assembler rather than
+    // a schemars attribute to keep the constraint visible next to its rationale.
+    if let Some(lines) = properties
+        .get_mut("lines")
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        lines.insert("minimum".to_string(), serde_json::json!(1));
+    }
+
+    serde_json::json!({
+        "type": "object",
+        "required": ["paths", "pattern"],
+        "properties": properties,
+    })
 }
 
 #[derive(Debug)]

--- a/crates/alint-rules/src/file_is_ascii.rs
+++ b/crates/alint-rules/src/file_is_ascii.rs
@@ -26,14 +26,17 @@ use alint_core::{
 };
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// Permitted non-ASCII codepoints — each a single character
-    /// (`"ö"`), a `U+XXXX` codepoint, or a `U+XXXX-U+YYYY` range.
+    /// Permitted non-ASCII codepoints - each a single character
+    /// (e.g. "o-umlaut"), a `U+XXXX` codepoint, or a `U+XXXX-U+YYYY`
+    /// inclusive range.
     #[serde(default)]
     allow: Vec<String>,
 }
+
+crate::options_schema_for!(Options);
 
 /// Parse one `allow:` entry into an inclusive codepoint range.
 fn parse_allow_entry(s: &str) -> std::result::Result<(u32, u32), String> {

--- a/crates/alint-rules/src/file_max_lines.rs
+++ b/crates/alint-rules/src/file_max_lines.rs
@@ -17,11 +17,14 @@ use alint_core::{
 };
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Maximum allowed line count.
     max_lines: u64,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct FileMaxLinesRule {

--- a/crates/alint-rules/src/file_max_size.rs
+++ b/crates/alint-rules/src/file_max_size.rs
@@ -3,11 +3,14 @@
 use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Scope, Violation};
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Maximum allowed file size in bytes.
     max_bytes: u64,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct FileMaxSizeRule {

--- a/crates/alint-rules/src/file_min_lines.rs
+++ b/crates/alint-rules/src/file_min_lines.rs
@@ -22,11 +22,14 @@ use alint_core::{
 };
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Minimum allowed line count.
     min_lines: u64,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct FileMinLinesRule {

--- a/crates/alint-rules/src/file_min_size.rs
+++ b/crates/alint-rules/src/file_min_size.rs
@@ -14,11 +14,14 @@
 use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Scope, Violation};
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Minimum allowed file size in bytes.
     min_bytes: u64,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct FileMinSizeRule {

--- a/crates/alint-rules/src/file_shebang.rs
+++ b/crates/alint-rules/src/file_shebang.rs
@@ -23,12 +23,16 @@ use alint_core::{
 use regex::Regex;
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Rust regex; the first line of every matched file must match. Default
+    /// `^#!` only enforces shebang presence.
     #[serde(default = "default_shebang")]
     shebang: String,
 }
+
+crate::options_schema_for!(Options);
 
 fn default_shebang() -> String {
     "^#!".to_string()

--- a/crates/alint-rules/src/file_starts_with.rs
+++ b/crates/alint-rules/src/file_starts_with.rs
@@ -18,12 +18,15 @@ use serde::Deserialize;
 
 use crate::io::read_prefix_n;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// The required prefix. Matched byte-for-byte.
+    /// Required prefix, matched byte-for-byte.
+    #[schemars(length(min = 1))]
     prefix: String,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct FileStartsWithRule {

--- a/crates/alint-rules/src/filename_regex.rs
+++ b/crates/alint-rules/src/filename_regex.rs
@@ -6,15 +6,17 @@ use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Scope, Violation
 use regex::Regex;
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Rust regex, automatically anchored with ^...$ by the engine.
     pattern: String,
-    /// Check against the file *stem* (no final extension) instead of the
-    /// full basename. Defaults to `false` (full basename is matched).
+    /// Match the file stem (no extension) instead of the full basename.
     #[serde(default)]
     stem: bool,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct FilenameRegexRule {

--- a/crates/alint-rules/src/git_blame_age.rs
+++ b/crates/alint-rules/src/git_blame_age.rs
@@ -33,7 +33,8 @@ struct Options {
     /// without a capture group, `{{ctx.match}}` substitutes the full match.
     pattern: String,
     /// Minimum line age (in days) for a matching line to fire as a violation.
-    /// Lines younger than this pass silently.
+    /// Lines younger than this pass silently. Common values: 90 (one quarter),
+    /// 180 (half a year), 365 (a full year of debt).
     #[schemars(range(min = 1))]
     max_age_days: u64,
 }

--- a/crates/alint-rules/src/git_blame_age.rs
+++ b/crates/alint-rules/src/git_blame_age.rs
@@ -25,20 +25,20 @@ use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Scope, Violation
 use regex::Regex;
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// Regex applied to each blame line's content. Same flavour
-    /// as `file_content_forbidden`'s pattern. Captured groups
-    /// are exposed as `{{ctx.match}}` in the message template
-    /// (defaults to the full match when no capture group is
-    /// present).
+    /// Rust-regex pattern applied to each blame line's content. Capture group 1
+    /// (when present) is exposed as `{{ctx.match}}` in the message template;
+    /// without a capture group, `{{ctx.match}}` substitutes the full match.
     pattern: String,
-    /// Minimum line age (in days) for a matching line to fire as
-    /// a violation. Lines younger than this pass silently.
-    /// Required.
+    /// Minimum line age (in days) for a matching line to fire as a violation.
+    /// Lines younger than this pass silently.
+    #[schemars(range(min = 1))]
     max_age_days: u64,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct GitBlameAgeRule {

--- a/crates/alint-rules/src/git_commit_author_allowlist.rs
+++ b/crates/alint-rules/src/git_commit_author_allowlist.rs
@@ -21,25 +21,28 @@ use serde::Deserialize;
 
 use crate::commit_range::{collect_commits, format_commit_violation};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// Regex the author email (`git log %ae`) must match. At least
-    /// one of `email_pattern:` / `name_pattern:` is required.
+    /// Rust-regex the author email (`git log %ae`) must match, e.g.
+    /// `^.+@example\.com$`.
     #[serde(default)]
     email_pattern: Option<String>,
-    /// Regex the author name (`git log %an`) must match.
+    /// Rust-regex the author name (`git log %an`) must match.
     #[serde(default)]
     name_pattern: Option<String>,
-    /// Base ref for range mode. Unset → HEAD only. The canonical
-    /// `{{env.X}}` interpolation is resolved at config load.
+    /// Git ref to use as the base of the commit range. When set, validates
+    /// every commit in `<since>..HEAD` instead of just HEAD. Accepts anything
+    /// `git rev-parse` does.
     #[serde(default)]
     since: Option<String>,
-    /// Include merge commits when checking a range. No effect without
-    /// `since:`.
+    /// When validating a range (`since:` set), include merge commits. Has no
+    /// effect when `since:` is unset.
     #[serde(default)]
     include_merges: bool,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct GitCommitAuthorAllowlistRule {

--- a/crates/alint-rules/src/git_commit_author_allowlist.rs
+++ b/crates/alint-rules/src/git_commit_author_allowlist.rs
@@ -33,11 +33,14 @@ struct Options {
     name_pattern: Option<String>,
     /// Git ref to use as the base of the commit range. When set, validates
     /// every commit in `<since>..HEAD` instead of just HEAD. Accepts anything
-    /// `git rev-parse` does.
+    /// `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to
+    /// pass a SHA via an env var, e.g.
+    /// `since: "{{env.ALINT_BASE_SHA | default('origin/main')}}"`.
     #[serde(default)]
     since: Option<String>,
     /// When validating a range (`since:` set), include merge commits. Has no
-    /// effect when `since:` is unset.
+    /// effect when `since:` is unset; combining `include_merges: true` with no
+    /// `since:` is a load-time error.
     #[serde(default)]
     include_merges: bool,
 }

--- a/crates/alint-rules/src/git_commit_gpg_signed.rs
+++ b/crates/alint-rules/src/git_commit_gpg_signed.rs
@@ -24,18 +24,21 @@ use serde::Deserialize;
 
 use crate::commit_range::{collect_commits, format_commit_violation};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// Base ref for range mode. Unset → HEAD only. The canonical
-    /// `{{env.X}}` interpolation is resolved at config load.
+    /// Git ref to use as the base of the commit range. When set, validates
+    /// every commit in `<since>..HEAD` instead of just HEAD. Accepts anything
+    /// `git rev-parse` does.
     #[serde(default)]
     since: Option<String>,
-    /// Include merge commits when checking a range. No effect without
-    /// `since:`.
+    /// When validating a range (`since:` set), include merge commits. Has no
+    /// effect when `since:` is unset.
     #[serde(default)]
     include_merges: bool,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct GitCommitGpgSignedRule {

--- a/crates/alint-rules/src/git_commit_gpg_signed.rs
+++ b/crates/alint-rules/src/git_commit_gpg_signed.rs
@@ -29,11 +29,14 @@ use crate::commit_range::{collect_commits, format_commit_violation};
 struct Options {
     /// Git ref to use as the base of the commit range. When set, validates
     /// every commit in `<since>..HEAD` instead of just HEAD. Accepts anything
-    /// `git rev-parse` does.
+    /// `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to
+    /// pass a SHA via an env var, e.g.
+    /// `since: "{{env.ALINT_BASE_SHA | default('origin/main')}}"`.
     #[serde(default)]
     since: Option<String>,
     /// When validating a range (`since:` set), include merge commits. Has no
-    /// effect when `since:` is unset.
+    /// effect when `since:` is unset; combining `include_merges: true` with no
+    /// `since:` is a load-time error.
     #[serde(default)]
     include_merges: bool,
 }

--- a/crates/alint-rules/src/git_commit_message.rs
+++ b/crates/alint-rules/src/git_commit_message.rs
@@ -40,48 +40,36 @@ use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Violation};
 use regex::Regex;
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// Regex the full commit message (subject + body, joined with
-    /// newlines) must match. When omitted, no regex check is
-    /// applied. Use `(?s)` to make `.` match newlines if you want
-    /// to assert about content past the subject.
+    /// Rust-regex pattern the full message (subject + body, joined with
+    /// newlines) must match. Use `(?s)` to make `.` match newlines.
     #[serde(default)]
     pattern: Option<String>,
-    /// Maximum length of the subject line (the message's first
-    /// line, before any body). When omitted, no length cap.
-    /// Common values: 50 (Tim Pope's recommendation), 72 (GitHub's
-    /// PR-title cutoff).
+    /// Maximum number of characters allowed in the subject line. Common
+    /// values: 50 (Tim Pope's recommendation), 72 (GitHub PR-title cutoff).
     #[serde(default)]
+    #[schemars(range(min = 1))]
     subject_max_length: Option<usize>,
-    /// When `true`, the message must have a non-empty body — at
-    /// least one line of content after the subject's trailing
-    /// blank line. Useful for mandating an explanation on `fix:`
-    /// commits etc.
+    /// When true, the message must have a non-empty body, that is, at least
+    /// one line of content after the subject's blank-line separator.
     #[serde(default)]
     requires_body: bool,
-    /// Git ref to use as the base of the commit range. When set,
-    /// the rule validates every commit in `<since>..HEAD` instead
-    /// of just `HEAD`. Anything `git rev-parse` accepts works: a
-    /// 40-char or abbreviated SHA, a branch (`origin/main`), a tag
-    /// (`v1.2.3`), or a relative ref (`HEAD~5`). Supports POSIX
-    /// `${VAR}` and `${VAR:-default}` env-var interpolation so CI
-    /// can pass a SHA in via an env var (see the GitHub Actions
-    /// integration doc for the canonical recipe).
+    /// Git ref to use as the base of the commit range. When set, validates
+    /// every commit in `<since>..HEAD` instead of just HEAD. Accepts anything
+    /// `git rev-parse` does: SHA (full or abbreviated), branch (`origin/main`),
+    /// tag (`v1.2.3`), or relative ref (`HEAD~5`).
     #[serde(default)]
     since: Option<String>,
-    /// When validating a range (`since:` set), include merge
-    /// commits in the set of commits to check. Default `false`
-    /// because merge commits in a PR context are typically the
-    /// synthetic merge `actions/checkout` produces (with an
-    /// auto-generated subject the rule would always flag) or
-    /// maintainer-resolved merges from the base branch (also
-    /// uninteresting). Set `true` to lint them anyway. Has no
-    /// effect when `since:` is unset.
+    /// When validating a range (`since:` set), include merge commits. Has no
+    /// effect when `since:` is unset; combining `include_merges: true` with no
+    /// `since:` is a load-time error.
     #[serde(default)]
     include_merges: bool,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct GitCommitMessageRule {

--- a/crates/alint-rules/src/git_commit_message.rs
+++ b/crates/alint-rules/src/git_commit_message.rs
@@ -59,12 +59,20 @@ struct Options {
     /// Git ref to use as the base of the commit range. When set, validates
     /// every commit in `<since>..HEAD` instead of just HEAD. Accepts anything
     /// `git rev-parse` does: SHA (full or abbreviated), branch (`origin/main`),
-    /// tag (`v1.2.3`), or relative ref (`HEAD~5`).
+    /// tag (`v1.2.3`), or relative ref (`HEAD~5`). Supports POSIX `${VAR}` and
+    /// `${VAR:-default}` env-var interpolation so CI can pass a SHA via an env
+    /// var (e.g. `since: ${ALINT_BASE_SHA:-origin/main}` with `ALINT_BASE_SHA`
+    /// exported in a workflow step from `github.event.pull_request.base.sha`).
+    /// The GitHub Actions double-brace template syntax `${{ ... }}` is NOT
+    /// interpolated by alint.
     #[serde(default)]
     since: Option<String>,
-    /// When validating a range (`since:` set), include merge commits. Has no
-    /// effect when `since:` is unset; combining `include_merges: true` with no
-    /// `since:` is a load-time error.
+    /// When validating a range (`since:` set), include merge commits. Defaults
+    /// to `false` because merge commits in PR contexts are typically the
+    /// synthetic merge `actions/checkout` produces (with an auto-generated
+    /// subject the rule would always flag) or maintainer-resolved merges from
+    /// the base branch. Has no effect when `since:` is unset; combining
+    /// `include_merges: true` with no `since:` is a load-time error.
     #[serde(default)]
     include_merges: bool,
 }

--- a/crates/alint-rules/src/git_commit_no_fixup.rs
+++ b/crates/alint-rules/src/git_commit_no_fixup.rs
@@ -22,18 +22,21 @@ use crate::commit_range::{collect_commits, format_commit_violation};
 /// Subject prefixes `git rebase --autosquash` recognises.
 const FIXUP_PREFIXES: &[&str] = &["fixup! ", "squash! ", "amend! "];
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// Base ref for range mode. Unset → HEAD only. The canonical
-    /// `{{env.X}}` interpolation is resolved at config load.
+    /// Git ref to use as the base of the commit range. When set, validates
+    /// every commit in `<since>..HEAD` instead of just HEAD. Accepts anything
+    /// `git rev-parse` does.
     #[serde(default)]
     since: Option<String>,
-    /// Include merge commits when checking a range. No effect without
-    /// `since:`.
+    /// When validating a range (`since:` set), include merge commits. Has no
+    /// effect when `since:` is unset.
     #[serde(default)]
     include_merges: bool,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct GitCommitNoFixupRule {

--- a/crates/alint-rules/src/git_commit_no_fixup.rs
+++ b/crates/alint-rules/src/git_commit_no_fixup.rs
@@ -27,11 +27,14 @@ const FIXUP_PREFIXES: &[&str] = &["fixup! ", "squash! ", "amend! "];
 struct Options {
     /// Git ref to use as the base of the commit range. When set, validates
     /// every commit in `<since>..HEAD` instead of just HEAD. Accepts anything
-    /// `git rev-parse` does.
+    /// `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to
+    /// pass a SHA via an env var, e.g.
+    /// `since: "{{env.ALINT_BASE_SHA | default('origin/main')}}"`.
     #[serde(default)]
     since: Option<String>,
     /// When validating a range (`since:` set), include merge commits. Has no
-    /// effect when `since:` is unset.
+    /// effect when `since:` is unset; combining `include_merges: true` with no
+    /// `since:` is a load-time error.
     #[serde(default)]
     include_merges: bool,
 }

--- a/crates/alint-rules/src/git_commit_signed_off.rs
+++ b/crates/alint-rules/src/git_commit_signed_off.rs
@@ -25,24 +25,26 @@ use crate::commit_range::{collect_commits, format_commit_violation};
 /// just the whole message. Matches `Signed-off-by: Name <email>`.
 const DEFAULT_PATTERN: &str = r"(?m)^Signed-off-by: .+ <.+@.+>$";
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// Trailer pattern each commit message must contain. Defaults to
-    /// the DCO sign-off shape; override to enforce a stricter form
+    /// Trailer pattern each commit message must contain. Defaults to the
+    /// canonical DCO sign-off shape. Override to enforce a stricter form
     /// (e.g. a corporate-domain email).
     #[serde(default)]
     pattern: Option<String>,
-    /// Base ref for range mode. Unset → HEAD only. Accepts anything
-    /// `git rev-parse` does. The canonical `{{env.X}}` interpolation
-    /// is resolved at config load.
+    /// Git ref to use as the base of the commit range. When set, validates
+    /// every commit in `<since>..HEAD` instead of just HEAD. Accepts anything
+    /// `git rev-parse` does.
     #[serde(default)]
     since: Option<String>,
-    /// Include merge commits when checking a range. No effect without
-    /// `since:`.
+    /// When validating a range (`since:` set), include merge commits. Has no
+    /// effect when `since:` is unset.
     #[serde(default)]
     include_merges: bool,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct GitCommitSignedOffRule {

--- a/crates/alint-rules/src/git_commit_signed_off.rs
+++ b/crates/alint-rules/src/git_commit_signed_off.rs
@@ -29,17 +29,20 @@ const DEFAULT_PATTERN: &str = r"(?m)^Signed-off-by: .+ <.+@.+>$";
 #[serde(deny_unknown_fields)]
 struct Options {
     /// Trailer pattern each commit message must contain. Defaults to the
-    /// canonical DCO sign-off shape. Override to enforce a stricter form
-    /// (e.g. a corporate-domain email).
+    /// canonical DCO sign-off shape `(?m)^Signed-off-by: .+ <.+@.+>$`. Override
+    /// to enforce a stricter form (e.g. a corporate-domain email).
     #[serde(default)]
     pattern: Option<String>,
     /// Git ref to use as the base of the commit range. When set, validates
     /// every commit in `<since>..HEAD` instead of just HEAD. Accepts anything
-    /// `git rev-parse` does.
+    /// `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to
+    /// pass a SHA via an env var, e.g.
+    /// `since: "{{env.ALINT_BASE_SHA | default('origin/main')}}"`.
     #[serde(default)]
     since: Option<String>,
     /// When validating a range (`since:` set), include merge commits. Has no
-    /// effect when `since:` is unset.
+    /// effect when `since:` is unset; combining `include_merges: true` with no
+    /// `since:` is a load-time error.
     #[serde(default)]
     include_merges: bool,
 }

--- a/crates/alint-rules/src/git_commit_subject_matches.rs
+++ b/crates/alint-rules/src/git_commit_subject_matches.rs
@@ -27,21 +27,22 @@ use serde::Deserialize;
 
 use crate::commit_range::{collect_commits, format_commit_violation};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// Regex the commit subject (first line of the message) must
-    /// match.
+    /// Rust-regex the commit subject (first line of the message) must match.
     matches: String,
-    /// Base ref for range mode. Unset → HEAD only. The canonical
-    /// `{{env.X}}` interpolation is resolved at config load.
+    /// Git ref to use as the base of the commit range. When set, validates
+    /// every commit in `<since>..HEAD` instead of just HEAD.
     #[serde(default)]
     since: Option<String>,
-    /// Include merge commits when checking a range. No effect
-    /// without `since:`.
+    /// When validating a range (`since:` set), include merge commits. Has no
+    /// effect when `since:` is unset.
     #[serde(default)]
     include_merges: bool,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct GitCommitSubjectMatchesRule {

--- a/crates/alint-rules/src/git_commit_subject_matches.rs
+++ b/crates/alint-rules/src/git_commit_subject_matches.rs
@@ -33,11 +33,14 @@ struct Options {
     /// Rust-regex the commit subject (first line of the message) must match.
     matches: String,
     /// Git ref to use as the base of the commit range. When set, validates
-    /// every commit in `<since>..HEAD` instead of just HEAD.
+    /// every commit in `<since>..HEAD` instead of just HEAD. Use the canonical
+    /// `{{env.X}}` interpolation to pass a SHA via an env var, e.g.
+    /// `since: "{{env.ALINT_BASE_SHA | default('origin/main')}}"`.
     #[serde(default)]
     since: Option<String>,
     /// When validating a range (`since:` set), include merge commits. Has no
-    /// effect when `since:` is unset.
+    /// effect when `since:` is unset; combining `include_merges: true` with no
+    /// `since:` is a load-time error.
     #[serde(default)]
     include_merges: bool,
 }

--- a/crates/alint-rules/src/git_no_denied_paths.rs
+++ b/crates/alint-rules/src/git_no_denied_paths.rs
@@ -24,23 +24,22 @@ use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Violation};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// Glob patterns (`globset` syntax — same as `paths:` on
-    /// other rules) that no tracked path may match. Patterns
-    /// that match the whole path (e.g. `secrets/**`) and
-    /// basename-only patterns (`*.env`) both work; `globset`'s
-    /// matcher checks both forms.
+    /// Globset patterns no tracked path may match. Both whole-path patterns
+    /// (`secrets/**`) and basename-only patterns (`*.env`) work.
+    #[schemars(length(min = 1))]
     denied: Vec<String>,
-    /// Optional git ref. When set, only denied paths that changed
-    /// in the `<since>...HEAD` diff are flagged (the PR-scoped
-    /// shape — catches a secret added in the PR even if HEAD's
-    /// tree still tracks an older one). Accepts the `{{env.X}}`
-    /// interpolation (resolved at config load).
+    /// Optional git ref. When set, only denied paths that changed in the
+    /// `<since>...HEAD` diff are flagged, catches a secret added in a PR even if
+    /// HEAD's tree still tracks an older one. Accepts the `{{env.X}}`
+    /// interpolation, e.g. `since: "{{env.ALINT_BASE_SHA | default('origin/main')}}"`.
     #[serde(default)]
     since: Option<String>,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct GitNoDeniedPathsRule {

--- a/crates/alint-rules/src/indent_style.rs
+++ b/crates/alint-rules/src/indent_style.rs
@@ -24,15 +24,22 @@ use alint_core::{
 };
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Required indentation style: `tabs` rejects any leading space; `spaces`
+    /// rejects any leading tab.
     style: StyleName,
+    /// When `style: spaces`, the leading-space count on every non-blank line
+    /// must be a multiple of this. Ignored for `style: tabs`.
     #[serde(default)]
+    #[schemars(range(min = 1))]
     width: Option<u32>,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+crate::options_schema_for!(Options);
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 enum StyleName {
     Tabs,

--- a/crates/alint-rules/src/lib.rs
+++ b/crates/alint-rules/src/lib.rs
@@ -188,6 +188,21 @@ pub fn migrated_option_schemas() -> Vec<(&'static str, serde_json::Value)> {
             pair_changed_together::options_schema(),
         ),
         ("rule_pair", pair::options_schema()),
+        ("rule_line_endings", line_endings::options_schema()),
+        ("rule_indent_style", indent_style::options_schema()),
+        ("rule_file_is_ascii", file_is_ascii::options_schema()),
+        ("rule_ordered_block", ordered_block::options_schema()),
+        ("rule_file_hash", file_hash::options_schema()),
+        ("rule_pair_hash", pair_hash::options_schema()),
+        (
+            "rule_commented_out_code",
+            commented_out_code::options_schema(),
+        ),
+        ("rule_command", command::options_schema()),
+        (
+            "rule_command_idempotent",
+            command_idempotent::options_schema(),
+        ),
     ]
 }
 

--- a/crates/alint-rules/src/lib.rs
+++ b/crates/alint-rules/src/lib.rs
@@ -86,6 +86,19 @@ pub mod structured_path;
 mod test_support;
 pub mod unique_by;
 
+/// Rule kinds whose `$defs/rule_*` schema branch is generated from Rust types
+/// via schemars, rather than hand-written in `schemas/v1/config.json`. Consumed
+/// by `xtask gen-schema`.
+///
+/// Migration is incremental (see ADR-0001 and
+/// `docs/design/spec-driven-development.md`): a kind absent from this list keeps
+/// its hand-written branch, which `gen-schema` passes through verbatim, so the
+/// published schema stays complete and valid at every step.
+#[must_use]
+pub fn migrated_rule_defs() -> Vec<(&'static str, serde_json::Value)> {
+    vec![("rule_file_header", file_header::rule_def_schema())]
+}
+
 /// Register every built-in rule kind into the given registry.
 ///
 /// Naming convention: rules that have a `dir_*` sibling keep

--- a/crates/alint-rules/src/lib.rs
+++ b/crates/alint-rules/src/lib.rs
@@ -130,6 +130,64 @@ pub fn migrated_option_schemas() -> Vec<(&'static str, serde_json::Value)> {
         ),
         ("rule_file_shebang", file_shebang::options_schema()),
         ("rule_filename_regex", filename_regex::options_schema()),
+        ("rule_file_starts_with", file_starts_with::options_schema()),
+        ("rule_file_ends_with", file_ends_with::options_schema()),
+        ("rule_line_max_width", line_max_width::options_schema()),
+        (
+            "rule_max_directory_depth",
+            max_directory_depth::options_schema(),
+        ),
+        (
+            "rule_max_files_per_directory",
+            max_files_per_directory::options_schema(),
+        ),
+        (
+            "rule_max_consecutive_blank_lines",
+            max_consecutive_blank_lines::options_schema(),
+        ),
+        ("rule_unique_by", unique_by::options_schema()),
+        (
+            "rule_markdown_paths_resolve",
+            markdown_paths_resolve::options_schema(),
+        ),
+        (
+            "rule_git_commit_message",
+            git_commit_message::options_schema(),
+        ),
+        (
+            "rule_git_commit_signed_off",
+            git_commit_signed_off::options_schema(),
+        ),
+        (
+            "rule_git_commit_no_fixup",
+            git_commit_no_fixup::options_schema(),
+        ),
+        (
+            "rule_git_commit_subject_matches",
+            git_commit_subject_matches::options_schema(),
+        ),
+        (
+            "rule_git_commit_gpg_signed",
+            git_commit_gpg_signed::options_schema(),
+        ),
+        (
+            "rule_git_commit_author_allowlist",
+            git_commit_author_allowlist::options_schema(),
+        ),
+        ("rule_git_blame_age", git_blame_age::options_schema()),
+        (
+            "rule_git_no_denied_paths",
+            git_no_denied_paths::options_schema(),
+        ),
+        (
+            "rule_changeset_requires_path",
+            changeset_requires_path::options_schema(),
+        ),
+        (
+            "rule_pair_changed_together",
+            pair_changed_together::options_schema(),
+        ),
+        ("rule_pair", pair::options_schema()),
     ]
 }
 

--- a/crates/alint-rules/src/lib.rs
+++ b/crates/alint-rules/src/lib.rs
@@ -120,6 +120,16 @@ pub fn migrated_option_schemas() -> Vec<(&'static str, serde_json::Value)> {
         ("rule_file_min_size", file_min_size::options_schema()),
         ("rule_file_max_lines", file_max_lines::options_schema()),
         ("rule_file_min_lines", file_min_lines::options_schema()),
+        (
+            "rule_file_content_matches",
+            file_content_matches::options_schema(),
+        ),
+        (
+            "rule_file_content_forbidden",
+            file_content_forbidden::options_schema(),
+        ),
+        ("rule_file_shebang", file_shebang::options_schema()),
+        ("rule_filename_regex", filename_regex::options_schema()),
     ]
 }
 

--- a/crates/alint-rules/src/lib.rs
+++ b/crates/alint-rules/src/lib.rs
@@ -5,6 +5,21 @@
 
 use alint_core::RuleRegistry;
 
+/// Generates a migrated rule kind's `options_schema()` fn: the schemars-derived
+/// JSON Schema for its `Options` struct. `xtask gen-schema` composes the result
+/// with the `kind`/`paths` structure preserved from the committed base branch.
+/// See [`migrated_option_schemas`] and ADR-0001.
+macro_rules! options_schema_for {
+    ($ty:ty) => {
+        #[must_use]
+        pub fn options_schema() -> ::serde_json::Value {
+            ::serde_json::to_value(::schemars::schema_for!($ty))
+                .expect("options JSON schema serializes to a value")
+        }
+    };
+}
+pub(crate) use options_schema_for;
+
 pub mod case;
 pub mod changeset_requires_path;
 pub mod command;
@@ -86,17 +101,26 @@ pub mod structured_path;
 mod test_support;
 pub mod unique_by;
 
-/// Rule kinds whose `$defs/rule_*` schema branch is generated from Rust types
-/// via schemars, rather than hand-written in `schemas/v1/config.json`. Consumed
-/// by `xtask gen-schema`.
+/// Rule kinds whose options schema is generated from Rust types via schemars,
+/// rather than hand-written in `schemas/v1/config.json`. Each entry maps a
+/// `$defs/rule_<kind>` definition name to that kind's derived options schema;
+/// `xtask gen-schema` composes it with the `kind`/`paths`/`required` structure
+/// preserved from the committed base branch.
 ///
 /// Migration is incremental (see ADR-0001 and
 /// `docs/design/spec-driven-development.md`): a kind absent from this list keeps
-/// its hand-written branch, which `gen-schema` passes through verbatim, so the
-/// published schema stays complete and valid at every step.
+/// its hand-written branch verbatim, so the published schema stays complete and
+/// valid at every step.
 #[must_use]
-pub fn migrated_rule_defs() -> Vec<(&'static str, serde_json::Value)> {
-    vec![("rule_file_header", file_header::rule_def_schema())]
+pub fn migrated_option_schemas() -> Vec<(&'static str, serde_json::Value)> {
+    vec![
+        ("rule_file_header", file_header::options_schema()),
+        ("rule_file_footer", file_footer::options_schema()),
+        ("rule_file_max_size", file_max_size::options_schema()),
+        ("rule_file_min_size", file_min_size::options_schema()),
+        ("rule_file_max_lines", file_max_lines::options_schema()),
+        ("rule_file_min_lines", file_min_lines::options_schema()),
+    ]
 }
 
 /// Register every built-in rule kind into the given registry.

--- a/crates/alint-rules/src/line_endings.rs
+++ b/crates/alint-rules/src/line_endings.rs
@@ -12,13 +12,17 @@ use serde::Deserialize;
 
 use crate::fixers::{FileNormalizeLineEndingsFixer, LineEndingTarget};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Required line ending style: `lf` or `crlf`. Mixed endings within a
+    /// file also fail.
     target: TargetName,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize)]
+crate::options_schema_for!(Options);
+
+#[derive(Debug, Clone, Copy, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 enum TargetName {
     Lf,

--- a/crates/alint-rules/src/line_max_width.rs
+++ b/crates/alint-rules/src/line_max_width.rs
@@ -16,11 +16,15 @@ use alint_core::{
 };
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Maximum number of Unicode scalar values (chars) allowed per line.
+    #[schemars(range(min = 1))]
     max_width: usize,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct LineMaxWidthRule {

--- a/crates/alint-rules/src/markdown_paths_resolve.rs
+++ b/crates/alint-rules/src/markdown_paths_resolve.rs
@@ -17,13 +17,14 @@ use alint_core::{
 };
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
     /// Whitelist of path-shape prefixes to validate. A backticked
     /// token must start with one of these to be considered a path
     /// candidate. No defaults — every project's layout differs and
     /// the user must declare which prefixes mark a path.
+    #[schemars(length(min = 1))]
     prefixes: Vec<String>,
 
     /// Skip backticked tokens containing template-variable
@@ -31,6 +32,8 @@ struct Options {
     #[serde(default = "default_ignore_template_vars")]
     ignore_template_vars: bool,
 }
+
+crate::options_schema_for!(Options);
 
 fn default_ignore_template_vars() -> bool {
     true

--- a/crates/alint-rules/src/markdown_paths_resolve.rs
+++ b/crates/alint-rules/src/markdown_paths_resolve.rs
@@ -27,8 +27,9 @@ struct Options {
     #[schemars(length(min = 1))]
     prefixes: Vec<String>,
 
-    /// Skip backticked tokens containing template-variable
-    /// markers (`{{ }}`, `${ }`, `<…>`). Default true.
+    /// When true (default), skip backticked tokens containing `{{ ... }}`,
+    /// `${ ... }`, or `<...>` template-variable markers. These are
+    /// placeholders, not real paths.
     #[serde(default = "default_ignore_template_vars")]
     ignore_template_vars: bool,
 }

--- a/crates/alint-rules/src/max_consecutive_blank_lines.rs
+++ b/crates/alint-rules/src/max_consecutive_blank_lines.rs
@@ -20,13 +20,15 @@ use serde::Deserialize;
 
 use crate::fixers::{FileCollapseBlankLinesFixer, line_is_blank};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
     /// Maximum number of blank lines allowed in a row. `0` means
     /// no blank lines at all.
     max: u32,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct MaxConsecutiveBlankLinesRule {

--- a/crates/alint-rules/src/max_directory_depth.rs
+++ b/crates/alint-rules/src/max_directory_depth.rs
@@ -10,11 +10,15 @@
 use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Scope, Violation};
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Maximum allowed path depth (number of `/`-separated components).
+    #[schemars(range(min = 1))]
     max_depth: usize,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct MaxDirectoryDepthRule {

--- a/crates/alint-rules/src/max_files_per_directory.rs
+++ b/crates/alint-rules/src/max_files_per_directory.rs
@@ -11,11 +11,16 @@ use std::path::PathBuf;
 use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Scope, Violation};
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Maximum number of in-scope files allowed as immediate children
+    /// of any one directory (non-recursive).
+    #[schemars(range(min = 1))]
     max_files: usize,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct MaxFilesPerDirectoryRule {

--- a/crates/alint-rules/src/ordered_block.rs
+++ b/crates/alint-rules/src/ordered_block.rs
@@ -29,7 +29,7 @@ use alint_core::{
 use regex::Regex;
 use serde::Deserialize;
 
-#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq, schemars::JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 enum Comparator {
     /// Rust `str` `Ord` — byte-wise over the UTF-8.
@@ -73,26 +73,30 @@ fn leading_int(s: &str) -> Option<i64> {
     s[..digits_end].parse::<i64>().ok()
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// Block start marker (matched on the trimmed line). Omit to
-    /// anchor the block at the start of the file.
+    /// Marker line opening a block (matched on the trimmed line). Optional -
+    /// omit to anchor the block at the start of the file.
     #[serde(default)]
     start: Option<String>,
-    /// Block end marker (matched on the trimmed line). Omit to run
-    /// the block to EOF.
+    /// Marker line closing a block. Optional - omit to run the block to EOF.
     #[serde(default)]
     end: Option<String>,
+    /// Comparator used to order entries: lexical (default), lexical-ci, or
+    /// numeric.
     #[serde(default)]
     comparator: Comparator,
+    /// When true, also forbid duplicate (equal) entries within a block.
     #[serde(default)]
     unique: bool,
-    /// When set, only lines matching this regex are sortable
-    /// entries; other lines inside the block pass through.
+    /// Regex; when set, only lines inside a block matching it are sortable
+    /// entries (others, such as comments or group headers, pass through).
     #[serde(default)]
     select: Option<String>,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct OrderedBlockRule {

--- a/crates/alint-rules/src/ordered_block.rs
+++ b/crates/alint-rules/src/ordered_block.rs
@@ -91,7 +91,8 @@ struct Options {
     #[serde(default)]
     unique: bool,
     /// Regex; when set, only lines inside a block matching it are sortable
-    /// entries (others, such as comments or group headers, pass through).
+    /// entries (others, such as comments or group headers, pass through). The
+    /// sectioned / keep-sorted-subset shape.
     #[serde(default)]
     select: Option<String>,
 }

--- a/crates/alint-rules/src/pair.rs
+++ b/crates/alint-rules/src/pair.rs
@@ -23,12 +23,16 @@ use alint_core::template::{PathTokens, render_message, render_path};
 use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Scope, Violation};
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Glob selecting the primary files.
     primary: String,
+    /// Path template resolved per primary match. Example: "{dir}/{stem}.h".
     partner: String,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct PairRule {

--- a/crates/alint-rules/src/pair_changed_together.rs
+++ b/crates/alint-rules/src/pair_changed_together.rs
@@ -27,19 +27,21 @@ use alint_core::git::{CommitRangeError, collect_changed_paths_checked};
 use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Scope, Violation};
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// Glob; the trigger. When the diff changes a path matching this,
-    /// the rule requires a `then_changed` co-change.
+    /// Glob; the trigger. When the diff changes a path matching this, a
+    /// `then_changed` co-change is required.
     if_changed: String,
-    /// Glob; the obligation. At least one changed path must match it
-    /// whenever `if_changed` fired.
+    /// Glob; the obligation. At least one changed path must match it whenever
+    /// `if_changed` fired.
     then_changed: String,
-    /// Base ref for the `<since>...HEAD` diff. The canonical
-    /// `{{env.X}}` interpolation is resolved at config load.
+    /// Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}`
+    /// interpolation, e.g. `since: "{{env.ALINT_BASE_SHA | default('origin/main')}}"`.
     since: String,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct PairChangedTogetherRule {

--- a/crates/alint-rules/src/pair_hash.rs
+++ b/crates/alint-rules/src/pair_hash.rs
@@ -28,7 +28,7 @@ use sha2::{Digest, Sha256, Sha512};
 // `pub(crate)` so the `file_graph` `fresh` mode reuses one digest
 // enum instead of triplicating it (the third sha consumer after
 // `file_hash` / `pair_hash`).
-#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum Algorithm {
     #[default]
@@ -53,7 +53,7 @@ impl Algorithm {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq, schemars::JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 enum Format {
     /// The digest must appear as a substring anywhere in `target`.
@@ -64,18 +64,26 @@ enum Format {
     SumsLine,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Literal path or glob selecting the file(s) whose content is
+    /// hashed (one check per match).
     source: String,
     /// The single file that must carry the digest (a `.sum` /
     /// `SHA256SUMS` / a file with an embedded hash).
     target: String,
+    /// Digest algorithm (default: sha256).
     #[serde(default)]
     algorithm: Algorithm,
+    /// How the digest must appear in `target`: `contains` = hex
+    /// substring anywhere (default); `sums-line` = a `<hex> [*]<path>`
+    /// line whose path token is the source's path.
     #[serde(default)]
     format: Format,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct PairHashRule {

--- a/crates/alint-rules/src/unique_by.rs
+++ b/crates/alint-rules/src/unique_by.rs
@@ -24,10 +24,12 @@ use alint_core::template::{PathTokens, render_message, render_path};
 use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Scope, Violation};
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Glob selecting the files to deduplicate.
     select: String,
+    /// Path-template producing a key per matched file. Default: {basename}.
     #[serde(default = "default_key")]
     key: String,
     /// Fold the key to lowercase before grouping, so keys that
@@ -36,6 +38,8 @@ struct Options {
     #[serde(default)]
     case_insensitive: bool,
 }
+
+crate::options_schema_for!(Options);
 
 fn default_key() -> String {
     "{basename}".to_string()

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,55 @@
+---
+status: proposed
+date: YYYY-MM-DD
+decision-makers: who-decided
+---
+
+# NNNN. Short title of the decision
+
+<!--
+HOW TO USE THIS TEMPLATE
+
+- Copy this file to docs/adr/NNNN-kebab-case-title.md, using the next free
+  four-digit number (the directory is sorted by number).
+- Keep the three headings `## Status`, `## Context`, and `## Decision`. alint's
+  own bundled `docs/adr@v1` ruleset is wired into .alint.yml and checks for them,
+  so the project dogfoods its own ADR linter on its own ADRs.
+- ADRs are immutable records, not living documents. To change a decision, add a
+  NEW ADR and set this one's status to `Superseded by ADR-NNNN`. Do not rewrite
+  the substance of an accepted ADR.
+- Format: MADR 4.0.0 (https://adr.github.io/madr/). Sections after Decision are
+  optional; delete the ones you do not need.
+- This file (0000-template.md) is itself a valid ADR shape so it both passes the
+  ruleset and stays a working example. Never assign 0000 to a real decision.
+-->
+
+## Status
+
+Proposed. (One of: Proposed | Accepted | Rejected | Deprecated | Superseded by ADR-NNNN.)
+
+## Context
+
+What is the problem or force that prompts this decision? State the constraints and
+the decision drivers in plain language. Link to the design doc, issue, or PR.
+
+## Decision
+
+The decision in active voice: "We will ...". Be specific enough that a reader can
+tell whether a later change contradicts it.
+
+## Consequences
+
+What becomes easier and what becomes harder as a result. Include the negative
+consequences honestly; an ADR with only upsides is usually underexamined.
+
+## Considered Options
+
+- Option A: ...
+- Option B: ...
+
+(Optional. Delete if there were no real alternatives.)
+
+## More Information
+
+Links to the design doc, related ADRs, the PRs or commits that implement this, and
+any follow-up work. (Optional.)

--- a/docs/adr/0001-adopt-spec-driven-development.md
+++ b/docs/adr/0001-adopt-spec-driven-development.md
@@ -1,0 +1,87 @@
+---
+status: accepted
+date: 2026-06-10
+decision-makers: asamarts
+---
+
+# 1. Adopt spec-driven development
+
+## Status
+
+Accepted (2026-06-10).
+
+## Context
+
+alint already has a strong, mostly-implicit spec-driven culture: a design-doc-first
+workflow, a JSON Schema for the config DSL, a canonical `all_kinds.yaml`, declarative
+bundled rulesets, and a real multi-layer drift-control system (the `coverage_audit_*`
+tests, `check-version-pins.sh`, `xtask docs-export`). Roughly 70 percent of a
+spec-driven model is therefore already in place.
+
+Three weaknesses remain, ranked by risk:
+
+1. The DSL JSON Schema (`schemas/v1/config.json`) is over 2000 lines of hand-written
+   JSON kept in sync with the Rust types by human discipline plus a byte-copy into the
+   crate. No test checks that its per-kind option keys match the actual serde structs,
+   so a field rename propagates only by hand. This is the largest untracked drift class.
+2. The alint.org marketing surface (version strings, counts, feature claims) lives in a
+   separate repo and is not audited from here, so it can advertise a stale reality.
+3. Per-kind reference prose, several "second list" hazards, and architecture intent are
+   maintained by hand with no machine check, and there is no architecture decision log,
+   despite alint shipping a ruleset that lints ADRs in other repos.
+
+A full analysis is in `docs/design/spec-driven-development.md`.
+
+## Decision
+
+We will adopt an explicit spec-driven development model, governed by one rule:
+
+> Put machine-checkable contracts on the highest rung (generate everything downstream
+> from one source; fail CI on any diff). Keep prose specs (design docs, ADRs) as
+> point-in-time scaffolding. Never make English prose a regenerable source of truth.
+
+Concretely, we will execute the five-workstream program in
+`docs/design/spec-driven-development.md`:
+
+- WS1 Contracts as source of truth: derive the JSON Schema from the Rust types
+  (`schemars`); generate the rule and CLI reference; pin output with `insta`/`trycmd`;
+  emit a `facts.json` manifest. The keystone.
+- WS2 Architecture Decision Records: MADR 4.0.0 in `docs/adr/`, dogfooded by alint's own
+  `docs/adr@v1` ruleset.
+- WS3 Architecture diagrams: a hand-modeled Structurizr C4 model (CI-rendered) plus
+  code-extracted crate and module graphs.
+- WS4 Pragmatic formal methods: Kani (panic/overflow freedom on the pure core), Miri,
+  `contracts`, and at most one Stateright model. Heavyweight deductive verifiers
+  (Verus/Creusot/Prusti) are explicitly out of scope.
+- WS5 Close the alint.org drift loop via the `facts.json` contract.
+
+Wherever a CI gate is needed, we prefer an alint rule (for example `generated_file_fresh`
+for regenerate-and-diff freshness) over a bespoke script, so alint enforces its own
+spec-driven discipline on itself.
+
+## Consequences
+
+Positive: most drift becomes machine-detectable and auto-fixable; the schema can no
+longer disagree with the parser; "alint's own docs and marketing are enforced by alint"
+becomes a true, on-brand claim; architectural decisions gain a durable, reviewable record.
+
+Negative and accepted: schemars adoption requires a fidelity spike before the hand-written
+schema can be retired; the program adds CI jobs (Kani, Miri) and new dev-dependencies that
+must clear `cargo-deny`; ADRs add a small per-decision authoring cost. These are bounded and
+the program is phased so each step ships independently and leaves the tree green.
+
+## Considered Options
+
+- Status quo (extend the `coverage_audit_*` audits only): cheap, but leaves the keystone
+  schema-drift class and the alint.org surface unaddressed.
+- Heavyweight formal verification of the engine (Verus/Creusot): high assurance, but a
+  ~5:1 proof-to-code burden that is not maintainable for a small team on application logic.
+- The chosen middle path: generate-and-gate for contracts, pragmatic formal methods only
+  where they pay off, prose specs kept as scaffolding.
+
+## More Information
+
+- Full proposal and phased rollout: `docs/design/spec-driven-development.md`.
+- Constitution of invariants: `docs/design/constitution.md`.
+- Related backfilled decisions: ADR-0002 (config language), ADR-0003 (engine dispatch and
+  determinism), ADR-0004 (extends trust boundary).

--- a/docs/adr/0002-config-language-is-yaml.md
+++ b/docs/adr/0002-config-language-is-yaml.md
@@ -1,0 +1,51 @@
+---
+status: accepted
+date: 2026-06-10
+decision-makers: asamarts
+---
+
+# 2. The configuration language is YAML with extends-based composition
+
+## Status
+
+Accepted. Backfilled on 2026-06-10; the decision itself predates this record and is
+documented here retrospectively as part of adopting ADRs (see ADR-0001).
+
+## Context
+
+alint needs a declarative configuration format that non-Rust users (CI and platform
+engineers) can author and review, that supports composition and reuse across many repos,
+and that editors can validate. The candidates were YAML, TOML, JSON, and a bespoke DSL.
+
+## Decision
+
+We will use YAML for `.alint.yml` and for the bundled rulesets, parsed via `serde_yaml_ng`.
+
+- A `version: 1` envelope gates the schema generation.
+- Composition is expressed with `extends:` (local paths, HTTPS URLs, and
+  `alint://bundled/...` rulesets), resolved at the YAML value layer so a child can override
+  individual fields of an inherited rule by `id` (last write wins). `only:`/`except:` filter
+  inherited rules.
+- A JSON Schema at `schemas/v1/config.json` is the authoritative shape and gives editors
+  autocomplete and validation; it is embedded into `alint-dsl` via `include_str!`.
+- Rules are deserialized from merged mappings into typed `RuleSpec`s only after the extends
+  chain resolves, so unknown fields are caught at load time.
+
+## Consequences
+
+Positive: familiar to the target audience; reuse via `extends` and bundled rulesets;
+editor support through the schema.
+
+Negative and accepted: YAML has real footguns (the `key: value` frontmatter trap,
+single-quote escaping, type coercion of unquoted scalars). These are mitigated by the
+schema, the `coverage_audit_site_docs_frontmatter` test, and the CONFIG-AUTHORING pitfalls
+catalogue, but they remain a source of user error.
+
+The hand-written schema is itself a drift risk; ADR-0001 and `docs/design/spec-driven-development.md`
+record the decision to generate it from the Rust types instead, which supersedes only the
+"hand-written" mechanism, not the choice of YAML.
+
+## More Information
+
+- `docs/design/ARCHITECTURE.md` (DSL and composition model).
+- ADR-0004 (the trust boundary that constrains what an `extends`'d ruleset may do).

--- a/docs/adr/0003-rule-engine-dispatch-and-determinism.md
+++ b/docs/adr/0003-rule-engine-dispatch-and-determinism.md
@@ -1,0 +1,53 @@
+---
+status: accepted
+date: 2026-06-10
+decision-makers: asamarts
+---
+
+# 3. Rule engine dispatch model and determinism guarantee
+
+## Status
+
+Accepted. Backfilled on 2026-06-10; the decision itself predates this record (see ADR-0001).
+
+## Context
+
+alint must evaluate many rules over trees that can reach a million files, efficiently and
+reproducibly. Reproducibility is required for snapshot testing, the deterministic perf gate,
+and trustworthy CI output. A naive "each rule reads each file it wants" design re-reads hot
+files once per matching rule and offers no ordering guarantee.
+
+## Decision
+
+We will use a single `Rule` trait with three dispatch classes, a single shared file walk, and
+a hard determinism guarantee.
+
+- Dispatch classes:
+  - Rule-major (default): the rule iterates the `FileIndex` itself. Used by existence and
+    cross-file rules.
+  - Per-file (opt-in via `as_per_file()`): the engine reads each matched file once and
+    dispatches it to every applicable per-file rule against the same buffer (read coalescing).
+  - Full-index cross-file (`requires_full_index() == true`): the rule sees the whole tree even
+    in `--changed` mode and must declare no path scope (`path_scope() == None`). This invariant
+    is enforced by the test `v010_cross_file_kinds_require_full_index_and_no_path_scope`.
+- A single parallel walk produces one `FileIndex` with lazily-built indices (path set,
+  parent-to-children, git-tracked filter) reused by all rules.
+- Determinism: the walk result is sorted post-walk; rules that accumulate cross-file results
+  sort their output; formatters sort where needed. Output (report, violations, fixes) is
+  byte-identical across runs on the same input. No reliance on HashMap iteration or readdir order.
+
+## Consequences
+
+Positive: read coalescing makes the per-file hot path scale; one walk amortizes indexing;
+determinism enables snapshots, benches, and the Valgrind perf gate.
+
+Negative and accepted: the cross-file invariant (`requires_full_index` with no path scope) is
+load-bearing and easy to violate in a new rule; it is protected by a test and by build-time
+rejection of `scope_filter:` on cross-file rules, and it is listed in the constitution.
+
+## More Information
+
+- `docs/design/ARCHITECTURE.md` (rule model, dispatch flip, memory layout).
+- `docs/design/constitution.md` (the determinism and cross-file invariants).
+- ADR-0001 (the Stateright spike in WS4 targets exactly the cross-file dispatch determinism
+  invariant recorded here).

--- a/docs/adr/0004-extends-trust-boundary-and-path-confinement.md
+++ b/docs/adr/0004-extends-trust-boundary-and-path-confinement.md
@@ -1,0 +1,51 @@
+---
+status: accepted
+date: 2026-06-10
+decision-makers: asamarts
+---
+
+# 4. Extends trust boundary and path confinement
+
+## Status
+
+Accepted. Backfilled on 2026-06-10; the decision and its hardening cycle predate this record
+(see ADR-0001). The path-confinement portion was strengthened in the v0.12 security cycle.
+
+## Context
+
+`extends:` lets a config pull rulesets from local paths, HTTPS URLs, and bundled sources. A
+fetched or shared ruleset is, in effect, third-party code. Without a boundary, an `extends`'d
+ruleset could run arbitrary commands or read files outside the repository, turning "reuse a
+governance ruleset" into a remote code execution and exfiltration risk.
+
+## Decision
+
+We will treat only the user's own top-level config as trusted for privileged operations, and
+confine all file access to the repository root by default.
+
+- Process-spawning rule kinds (`SPAWNING_RULE_KINDS`: `command`, `generated_file_fresh`,
+  `command_idempotent`) are honored only in the top-level config and rejected in any
+  `extends`'d ruleset (`reject_command_rules_in`).
+- Custom facts that spawn a process, and the `allow_out_of_root:` escape hatch, are likewise
+  top-level-only (`reject_allow_out_of_root_in`).
+- File access is confined to the repo root by default; the walker prunes symlinks that escape
+  the root, and git-backed rules sanitize range arguments (the `since:` argument-injection fix).
+
+Whenever a new rule kind can spawn a process or read outside the root, it must be added to the
+appropriate gate. This is a release-blocking invariant, not a convention.
+
+## Consequences
+
+Positive: detection-only rulesets can be shared and extended safely; the blast radius of a
+malicious or careless ruleset is bounded.
+
+Negative and accepted: legitimate uses of spawning kinds or out-of-root reads must be declared
+in the user's own config, which is slightly less ergonomic for shared rulesets, but the safety
+property is worth it. Every new spawning-capable kind adds a gate-maintenance obligation, which
+the constitution and a regression test enforce.
+
+## More Information
+
+- `docs/design/ARCHITECTURE.md` (trust model).
+- `docs/design/constitution.md` (the spawning-kind and path-confinement invariants).
+- The v0.12 CHANGELOG security entries (allow_out_of_root, walker symlink pruning, git `since:` fix).

--- a/docs/design/TEMPLATE.md
+++ b/docs/design/TEMPLATE.md
@@ -1,0 +1,51 @@
+# Design doc: <feature or rule kind>
+
+Status: Draft. (Draft | Implemented in <commit> | Superseded by <doc>.)
+Decisions: <ADR-NNNN, if this introduces or changes an architectural decision; else "none">
+Demand evidence: <link to case-study / launch-evidence rows, for rule kinds>
+
+<!--
+This is the canonical design-doc template. It codifies the seven-section convention the
+project has followed since v0.7. Copy it into docs/design/vX.Y/<name>.md before writing
+code. At merge time, flip Status to "Implemented in <commit>". The doc is the spec; it is
+not generated from code and it is not rewritten after the version ships (it becomes the
+archival record under that version's directory).
+
+If the work changes an architectural decision (a new dispatch class, a new trust gate, a
+new dependency of consequence), also write an ADR under docs/adr/ and link it above.
+-->
+
+## 1. Problem
+
+The user pain, with concrete real-repo evidence. Why this is worth building. What breaks
+or stays unsolved without it.
+
+## 2. Surface area
+
+The engine, DSL, and schema changes required. Sketch the exact YAML the user writes,
+including every option key and its default.
+
+## 3. Semantics
+
+What the engine does on each evaluation path: inputs, the matching and extraction steps,
+what counts as a violation, fix behavior, dispatch class (per-file / cross-file / single-shot).
+
+## 4. False-positive surface
+
+What could fire wrongly, and the planned mitigations. This section is mandatory; a rule kind
+with no analysis of its false positives is not ready.
+
+## 5. Implementation notes
+
+Module location, new dependencies (and their cargo-deny status), complexity estimate, and any
+invariant from `../constitution.md` the implementation must uphold.
+
+## 6. Tests
+
+The coverage plan: the firing scenario, the silent scenario, unit gaps, and any bench-compare
+thresholds. Every registered kind needs both a firing and a silent e2e scenario (constitution 8).
+
+## 7. Open questions
+
+Decisions to resolve before implementation. Resolve them inline with an editorial note when the
+work lands, so the doc records both the question and its answer.

--- a/docs/design/constitution.md
+++ b/docs/design/constitution.md
@@ -1,0 +1,56 @@
+# alint constitution
+
+Status: living document. Last reviewed 2026-06-10.
+
+These are alint's load-bearing invariants: the properties that must hold on every change,
+stated once so they stop being re-derived each cycle. Each invariant names its enforcing
+mechanism where one exists. Changing an invariant requires an ADR (see `../adr/`), not just
+a code edit.
+
+This document is prose scaffolding (it is allowed to lag reality and is corrected on review);
+the enforcing tests and gates are the actual source of truth. Where they disagree, the test
+wins and this document is wrong.
+
+## Correctness and behavior
+
+1. Determinism. Output (report, violations, fixes) is byte-identical across runs on the same
+   input. No reliance on HashMap iteration order or filesystem readdir order. Enforced by the
+   post-walk sort and per-rule output sorting; see ADR-0003.
+2. Cross-file dispatch. A rule with `requires_full_index() == true` must have
+   `path_scope() == None`. Enforced by `v010_cross_file_kinds_require_full_index_and_no_path_scope`
+   and by build-time rejection of `scope_filter:` on cross-file rules. See ADR-0003.
+3. Bounded analysis reads. Whole-file analysis reads (not fixers) go through
+   `crate::io::read_capped` (256 MiB `MAX_ANALYZE_BYTES`); over-cap files produce a clear
+   violation, never a silent skip or OOM.
+4. Bounded fixes. Content-editing fixers skip files over `fix_size_limit` (default 1 MiB) with
+   a Skipped status; path-only operations bypass the cap.
+
+## Security
+
+5. Extends trust boundary. Every process-spawning rule kind is a member of `SPAWNING_RULE_KINDS`
+   and is honored only in the user's own top-level config. Custom process-spawning facts and the
+   `allow_out_of_root:` escape hatch are likewise top-level-only. See ADR-0004.
+6. Path confinement. File access is confined to the repository root by default; the walker prunes
+   escaping symlinks; git-backed rules sanitize range arguments. See ADR-0004.
+
+## Coverage and consistency (the anti-drift floor)
+
+7. Every registered rule kind has a schema dispatch entry. Enforced by `coverage_audit_schema_drift`.
+8. Every registered rule kind has at least one firing scenario and one silent scenario. Enforced by
+   `coverage_audit_pass_fail`.
+9. Numeric claims in the README and the about page are derived from code and fixtures, not hand-typed.
+   Enforced by `coverage_audit_readme_claims`.
+10. User-facing install-snippet version pins match `[workspace.package].version`. Enforced by
+    `check-version-pins.sh` (surfaced in dogfood as `install-snippets-match-workspace-version`).
+11. Generated artifacts are committed and gated: regenerate, then fail on any diff. New generated
+    artifacts use `generated_file_fresh` in `.alint.yml` where practical. (Introduced by ADR-0001;
+    being rolled out across the schema, reference docs, and `facts.json`.)
+
+## Process
+
+12. Design-doc-first. A behavior-bearing rule kind ships with a design doc under
+    `docs/design/vX.Y/` following `docs/design/TEMPLATE.md`, drafted before implementation.
+13. Architectural decisions are recorded as ADRs under `docs/adr/` (MADR 4.0.0), linted by alint's
+    own `docs/adr@v1` ruleset. ADRs are immutable; supersede rather than rewrite.
+14. Top-level user-facing docs contain no em dashes or smart quotes. Enforced by the dogfood rules
+    `top-level-docs-no-em-dash` and `top-level-docs-no-smart-quotes`.

--- a/docs/design/spec-driven-development.md
+++ b/docs/design/spec-driven-development.md
@@ -1,7 +1,15 @@
 # Spec-Driven Development for alint: A Proposal
 
 Status: Accepted (2026-06-10), recorded as ADR-0001. Full program (all five
-workstreams) approved; ADR home is docs/adr/. Phase 0 implemented.
+workstreams) approved; ADR home is docs/adr/. Phase 0 + Phase 1 implemented on
+branch `spec-driven-development`: 38 of ~56 option-bearing rule kinds now derive
+their `schemas/v1/config.json` branch from their Rust types (schemars), gated by
+`gen-schema --check`. The remaining kinds stay hand-written passthrough by design:
+the deeply nested ones (cross_file, file_graph, registry_paths_resolve, for_each_*,
+dir_contains/dir_only_contains, every_matching_has, generated_file_fresh, import_gate,
+the structured-query family) plus two whose option type can't be faithfully derived
+(filename_case's custom case-alias deserializer, json_schema_passes's runtime-validated
+format string). Phases 2-5 pending.
 Scope: cross-cutting (engine, DSL, schema, docs, CI, alint.org)
 Related: [ARCHITECTURE.md](./ARCHITECTURE.md), [ROADMAP.md](./ROADMAP.md), [deterministic-perf-gating.md](./deterministic-perf-gating.md)
 

--- a/docs/design/spec-driven-development.md
+++ b/docs/design/spec-driven-development.md
@@ -1,0 +1,556 @@
+# Spec-Driven Development for alint: A Proposal
+
+Status: Accepted (2026-06-10), recorded as ADR-0001. Full program (all five
+workstreams) approved; ADR home is docs/adr/. Phase 0 implemented.
+Scope: cross-cutting (engine, DSL, schema, docs, CI, alint.org)
+Related: [ARCHITECTURE.md](./ARCHITECTURE.md), [ROADMAP.md](./ROADMAP.md), [deterministic-perf-gating.md](./deterministic-perf-gating.md)
+
+---
+
+## TL;DR
+
+This proposal moves alint to an explicit spec-driven model with four goals: capture
+architectural decisions as ADRs, maintain formal specs and models (with verification
+where it pays off), auto-generate architecture diagrams, and drive every drift between
+spec, code, tests, docs, and marketing toward zero, as automatically as possible.
+
+The central finding of the analysis is that **alint is already about 70 percent of the
+way there.** It has a mature design-doc-first culture, a JSON Schema for its DSL, a
+canonical `all_kinds.yaml`, declarative bundled rulesets, and a real multi-layer
+drift-control system (the `coverage_audit_*` tests, `check-version-pins.sh`,
+`xtask docs-export`). This is an **extension and consolidation**, not a greenfield
+transformation, and it is deliberately calibrated to a one-to-two-person team.
+
+The organizing idea is a single rule, drawn from how the industry actually succeeds and
+fails at this (see Appendix B):
+
+> **Put machine-checkable contracts on the highest rung (generate everything downstream
+> from one source, fail CI on any diff). Keep prose specs (design docs, ADRs) as
+> point-in-time scaffolding. Never try to make English prose a regenerable source of
+> truth.**
+
+The keystone change is small and high-leverage: the DSL JSON Schema is currently 2180
+lines of **hand-written JSON** that can silently disagree with the Rust types that
+actually parse configs. Derive it from the types instead. Then generate the rule
+reference, the CLI reference, and a `facts.json` manifest from code, and gate all of it
+with a regenerate-and-diff check. alint already ships the rule kind that enforces exactly
+this kind of gate (`generated_file_fresh`), so **alint can enforce its own spec-driven
+discipline on itself** - which is both the most automated option and a genuine marketing
+asset for an anti-drift linter.
+
+Heavy deductive verifiers (Verus, Creusot, Prusti) are explicitly out of scope: they
+target systems/crypto code at roughly 5:1 proof-to-code ratios and are not maintainable
+for application logic by a small team. Formal methods are confined to a pragmatic tier
+(Kani for panic/overflow freedom on the pure core, Miri on the test suite, and at most
+one Rust-native Stateright model for the single genuinely subtle ordering invariant).
+
+---
+
+## 1. Where alint stands today (honest baseline)
+
+### 1.1 What already exists (and is good)
+
+**A real spec-driven culture.** Every behavior-bearing rule kind ships with a design doc
+under `docs/design/vX.Y/` following an informal seven-section convention (Problem,
+Surface area, Semantics, False-positive surface, Implementation notes, Tests, Open
+questions). The workflow is "design-doc draft commit, then atomic implementation commit
+that flips the doc's Status to Implemented." This is spec-first development done well.
+
+**Contracts that already function as specs:**
+
+- `schemas/v1/config.json` - JSON Schema (draft 2020-12) for the DSL, embedded into
+  `alint-dsl` via `include_str!` and validated against representative configs.
+- `crates/alint-dsl/tests/fixtures/all_kinds.yaml` - the canonical enumeration of every
+  rule kind with its options; the source of truth that `coverage_audit_readme_claims`
+  counts against.
+- `crates/alint-dsl/rulesets/v1/**/*.yml` - the bundled rulesets, which are themselves
+  declarative governance specs.
+- `crates/alint-testkit/TREE_SPEC.md` - a small declarative DSL for test-fixture trees.
+
+**A multi-layer drift-control system already in production.** This is the most important
+existing asset and the proof that the team already believes in this model:
+
+| Layer | Mechanism | Pins |
+| --- | --- | --- |
+| README/about claims | `coverage_audit_readme_claims` | counts (kinds, families, rulesets, fixers, formats, subcommands) derived from code/fixtures |
+| Schema vs registry | `coverage_audit_schema_drift` | every registered kind has a schema dispatch entry |
+| Rule pass/fail coverage | `coverage_audit_pass_fail` | every kind has a firing and a silent e2e scenario |
+| Site frontmatter | `coverage_audit_site_docs_frontmatter` | every site page has parseable YAML frontmatter |
+| Bench trajectory | `coverage_audit_benchmarks_trajectory` | latest release surfaces on top |
+| Version pins | `check-version-pins.sh` | install snippets pin the workspace version |
+| Dep floors | `check-workspace-dep-floors.sh` | internal version pins do not exceed workspace version |
+| Perf | `det-perf-gate.sh` (Valgrind) | instruction/cycle regressions vs merge-base |
+| CLI docs | `cli_reference_subcmds_match_command_enum` | docs subcommand list matches the `Command` enum |
+
+**The dogfooding ethos.** alint already lints itself (`.alint.yml` + `ci/scripts/dogfood.sh`),
+including a `bundled-ruleset-has-uri-header` rule and an `install-snippets-match-workspace-version`
+command rule. The instinct to "enforce our own discipline with our own tool" is the exact
+instinct this proposal builds on.
+
+### 1.2 The gaps (what actually drifts)
+
+The drift-surface analysis (Section 4) found these concrete weaknesses, ranked by risk:
+
+1. **The schema is hand-maintained.** `schemas/v1/config.json` is 2180 lines of
+   hand-written JSON kept in sync with the Rust types by human discipline plus a
+   *byte-copy* into `crates/alint-dsl/schemas/v1/config.json`. There is no test that the
+   schema's per-kind option keys match the actual serde struct fields. A field rename in a
+   rule (the kind of rename that happened in the v0.10 Phase 1 work: `registry:` to
+   `source:`, `in:` to `target:`) propagates only by hand across the struct, the schema,
+   the docs, the examples, and the bundled rulesets. **This is the single largest
+   untracked drift class.**
+
+2. **alint.org marketing surfaces are not audited from this repo.** Version strings, the
+   JSON-LD `softwareVersion`, the "Latest release" line, and any feature/count claims in
+   blog or landing copy live in a separate repo and can advertise a stale reality
+   undetected.
+
+3. **Per-kind reference prose is hand-written.** `docs/rules.md` and `docs/site/reference/`
+   describe each rule and its options in prose that no audit checks against the code.
+
+4. **Two-list hazards.** `xtask`'s `CLI_REFERENCE_SUBCMDS`, the in-crate schema byte-copy,
+   and the README ruleset prose-list are each a second copy that can fall behind their
+   source even where a count audit passes.
+
+5. **No formal architecture diagrams, no ADRs.** Architecture intent lives only in prose
+   (`ARCHITECTURE.md`) and in the maintainer's head. There is no decision log, despite
+   alint *shipping a ruleset that lints ADRs in other repos.*
+
+### 1.3 What alint already ships that we can turn on itself
+
+This is the lever that makes "maximally automated" realistic. alint's own rule kinds are,
+almost exactly, the anti-drift primitives the industry reaches for:
+
+- **`generated_file_fresh`** runs a declared generator and diffs its output against the
+  committed file. This *is* the rust-analyzer / Ruff "regenerate and `git diff --exit-code`"
+  codegen gate, as a first-class rule. Every generated artifact in this proposal can be
+  guarded by it.
+- **`command_idempotent`** runs a checker in `--check` mode and parses its offender list -
+  the generic form of the same gate.
+- **`cross_file_value_equals`** / **`file_graph`** / **`registry_paths_resolve`** can assert
+  that a value in one file matches another, that references resolve, and that declared sets
+  stay consistent - i.e. they can pin cross-file invariants between spec and code.
+- **The `docs/adr@v1` bundled ruleset** already enforces MADR ADR hygiene. alint's own
+  `docs/adr/` can be linted by alint's own shipped ruleset with zero new code.
+
+The recurring theme below: **prefer an alint rule over a bespoke CI script** wherever the
+two are equivalent, because it is more automated, it is self-documenting, and every such
+use is a real-world test of alint.
+
+---
+
+## 2. The organizing principle: the spec maturity ladder
+
+Martin Fowler's team classifies spec-driven approaches on a three-rung ladder, and it
+dissolves most of the confusion in this space:
+
+1. **Spec-first** - specs written before code, then discarded as scaffolding.
+2. **Spec-anchored** - specs persist; downstream artifacts are regenerated from them.
+3. **Spec-as-source** - humans edit only the spec; the rest is generated and marked
+   "DO NOT EDIT."
+
+The field's evidence (Appendix B) is blunt about the failure mode: pushing **prose** to
+the high rungs fails, because reality changes faster than prose specs do, and a stale
+prose spec misleads confidently. Even Google admits it does not keep design docs current.
+
+So the rule for alint:
+
+| Artifact class | Target rung | Why |
+| --- | --- | --- |
+| DSL schema, CLI interface, rule/option reference, counts, `facts.json` | **Spec-as-source** (generate + gate) | Machine-checkable; drift is detectable and fixable automatically |
+| Architecture *structure* (crate/module graphs) | **Spec-as-source** (code-extracted) | Derivable from `cargo metadata`; cannot drift |
+| Architecture *intent* (C4 context/container) | **Spec-anchored** (hand-modeled, CI-rendered, consistency-gated) | Low churn; a small gate keeps it honest |
+| Design docs, ADRs, the constitution | **Spec-first** (point-in-time scaffolding) | Prose; valuable as decision record, not as regenerable truth |
+
+This single table is the spine of the whole proposal. Everything below is an application
+of it.
+
+---
+
+## 3. The five workstreams
+
+### WS1 - Contracts as the single source of truth (the anti-drift core)
+
+This is the highest-ROI workstream and the prerequisite for closing most of the drift
+surface. Ordered by dependency.
+
+**1a. Derive the schema from the Rust types (the keystone).**
+Adopt `schemars` (v1.x, actively maintained, honors serde attributes) so the JSON Schema
+is generated from the config structs instead of hand-written. The guarantee is structural:
+the schema cannot disagree with what serde actually parses. Concretely:
+
+- Add `#[derive(JsonSchema)]` to the config/`RuleSpec`/per-kind option structs.
+- Add an `xtask gen-schema` step that writes `schemas/v1/config.json` and the in-crate copy
+  from `schema_for!`.
+- Retire the hand-maintained 2180-line file and the byte-copy hazard in one move.
+- This closes drift sources #1 and #4 from Section 1.2 at the root, and would have caught
+  the dashed-key JSONPath bug recorded in project history.
+
+Caveat to validate during implementation: the current schema may encode constraints
+(per-kind `oneOf` dispatch, descriptions, `additionalProperties: false`) that need
+`schemars` attributes or a small post-processing pass to reproduce. Budget a spike to
+confirm fidelity before deleting the hand-written file; keep the existing
+`coverage_audit_schema_drift` test as the safety net during migration.
+
+**1b. Generate the rule/option reference from rule metadata.**
+This is the Ruff model (a near-perfect analogue: a linter with a large rule and option
+surface whose `cargo dev generate-all` emits the schema, the config docs, and the rules
+pages from rule structs). Widen the existing `xtask docs-export` so that per-kind reference
+content (options, defaults, one canonical example) is generated from the same metadata that
+feeds the schema, not hand-written in `docs/rules.md`. Mark generated sections with a
+`DO NOT EDIT - generated by xtask` banner.
+
+**1c. Generate the CLI reference from clap.**
+Use `clap_mangen` (maintained, part of the clap project; its own docs recommend the xtask
+pattern alint already uses) to emit man pages, plus a small in-repo Markdown emitter for the
+CLI docs. Do not depend on `clap-markdown` (archived). This retires the hand-maintained
+`CLI_REFERENCE_SUBCMDS` two-list hazard.
+
+**1d. Make documentation executable (snapshots + CLI conformance).**
+- Adopt `insta` to snapshot generated output (`--help` per subcommand, the rules table, the
+  emitted `facts.json`). Drift becomes a reviewable failing snapshot.
+- Adopt `trycmd` to run every documented `alint ...` invocation (including examples embedded
+  in `README.md` and the site) as a conformance test against the real binary. A stale example
+  becomes a failing test.
+- Schema-validate every example config (repo `examples/`, docs, the v0.12 corpus, bundled
+  rulesets) against the generated schema in CI. This is provider/consumer contract testing
+  adapted to a DSL.
+
+**1e. Emit `facts.json` (the contract for everything downstream, including alint.org).**
+Add an `alint facts --json` (or an `xtask` emitter) that prints a machine-readable manifest:
+version, rule-kind count, bundled-ruleset count, supported languages, the rule catalogue,
+output formats, and any comparison-table cells the marketing site asserts. This single file
+becomes the contract that the README badges, the docs, and the website all consume, rather
+than restating numbers in prose. (See WS5 for the alint.org side.)
+
+**1f. The regenerate-and-gate mechanism - dogfooded.**
+Every generated artifact (schema, rule reference, CLI reference, `facts.json`) is committed
+and guarded by a regenerate-then-diff check. Implement the gate as an alint rule using
+`generated_file_fresh` in `.alint.yml` rather than a bespoke shell loop, so the gate is
+itself an alint feature under test. Keep `git diff --exit-code` as the CI backstop. Prefer
+content-diff over any mtime-based staleness check (mtime is unreliable on fresh CI clones).
+
+**WS1 net effect:** the schema, the rule reference, the CLI reference, and the public facts
+all become generated, snapshot-pinned, and gated. Drift sources #1, #3, #4 are closed; #2 is
+set up for WS5.
+
+---
+
+### WS2 - Architecture Decision Records
+
+**Format and home.** Adopt MADR 4.0.0 (dual MIT/CC0; vendor the bare template into the repo).
+Store ADRs in `docs/adr/` rather than MADR's default `docs/decisions/`, for one decisive
+reason: **alint's own shipped `docs/adr@v1` ruleset defaults to `docs/adr/*.md`,** so the
+project's ADRs are linted by alint's own ruleset out of the box, with zero path overrides.
+This is the credibility play - the tool that lints ADRs must keep exemplary ADRs.
+
+**Mechanics.** Files `NNNN-title.md`; YAML front-matter `status: {proposed | accepted |
+deprecated | superseded by ADR-NNNN}`; immutable records (supersede, do not rewrite);
+PR/commit links in "More Information." A generated index. Optionally surface them via
+`log4brains` (ships a GitHub Pages action) later; the markdown files alone are sufficient to
+start.
+
+**Backfill the load-bearing decisions** that currently live only in prose or memory, for
+example: DSL is YAML; the rule-kind taxonomy and the three dispatch classes; the
+path-confinement / `allow_out_of_root` security model; `SPAWNING_RULE_KINDS` as the
+code-execution trust boundary; LSP as a separate crate; determinism as a hard guarantee;
+the design-doc-first workflow itself; the Valgrind-based perf gate. Each is one short ADR.
+
+**Relationship to design docs.** Design docs stay where they are and keep their role
+(detailed, version-scoped feature specs). ADRs are the *durable, cross-cutting decision log*
+that design docs reference. ARCHITECTURE.md Section 9 (or a new section) links to the ADR
+index.
+
+---
+
+### WS3 - Architecture diagrams (hand-modeled intent + code-extracted structure)
+
+The anti-drift answer here is a split, not a single tool.
+
+**Code-extracted (cannot drift, regenerated every CI run):**
+
+- `cargo-depgraph` -> the 10-crate workspace dependency graph (SVG).
+- `cargo-modules` -> per-crate module structure and internal dependency graphs (SVG), plus
+  its `--acyclic` flag as a **CI gate** that fails on any new module cycle.
+- These are committed and guarded by the same regenerate-and-diff gate as WS1 (again via
+  `generated_file_fresh`).
+
+**Hand-modeled but CI-rendered (C4 intent):**
+
+- One Structurizr `workspace.dsl` (Apache-2.0) as the source of truth for C4 levels 1-3:
+  System Context (alint + developer/CI actors + linted repo + registries + alint.org),
+  Container (the CLI binary, the `alint-lsp` server, the alint.org site + docs-bundle
+  pipeline), and a Component view of the CLI (the crates as components). The ten crates are
+  components, not containers. Skip C4 level 4 (code) per C4's own guidance.
+- Export to Mermaid (renders natively in GitHub markdown and PRs) and to SVG (for alint.org),
+  in CI.
+- A small `xtask` consistency gate diffs the crate names declared in `workspace.dsl` against
+  `cargo metadata` workspace members and fails if a crate is added or removed without
+  updating the model. This is what keeps the hand-modeled layer honest.
+
+**Important currency caveat:** the standalone `structurizr/cli` repo was archived 2026-02-04
+and consolidated into a single `structurizr.war` tool (still Apache-2.0, data-compatible).
+Pin tooling to the consolidated artifact, not the archived install path. Confirm the exact
+invocation at implementation time.
+
+**arc42:** cherry-pick, do not adopt wholesale. Fold the high-value, low-churn sections
+(Introduction/Goals, Constraints, Context/Scope, Building Block View, Crosscutting Concepts,
+and Architecture Decisions -> links to `docs/adr/`) into ARCHITECTURE.md. The full 12-section
+template would itself become drift-prone.
+
+---
+
+### WS4 - Formal specification and verification (the pragmatic tier)
+
+The honest framing: most of alint is a deterministic batch pipeline, not a concurrent
+protocol, so the ROI of heavy formal methods is low and concentrated. Adopt in this order.
+
+**Adopt now (high value, low cost):**
+
+- **Grammar/schema as the syntax spec** - WS1's generated schema already is the config
+  contract. (A formal PEG/EBNF grammar via `pest`/`lalrpop` is optional and only relevant if
+  the DSL ever grows beyond YAML; not recommended now.)
+- **`insta` snapshots + `proptest` properties** as the behavior spec (proptest is already a
+  dependency; lean in harder). Properties are drift-proof partial specs that run in CI.
+- **Kani** (AWS bounded model checker) as a separate CI job, proving panic-freedom, no
+  arithmetic overflow, no out-of-bounds, and no unexpected `unwrap` on the **pure, bounded**
+  core: config merge/precedence, glob/path normalization, the dispatch-ordering helpers,
+  count arithmetic. No code annotations; harnesses look like proptest harnesses. Run nightly
+  to manage model-checking time.
+- **Miri** on the existing test suite (nightly job) to catch undefined behavior if any
+  `unsafe` exists. Near-zero effort.
+
+**Adopt selectively (medium):**
+
+- **`contracts` crate** (`#[requires]`/`#[ensures]`) on a few load-bearing invariants
+  (config merge, cross-file dispatch ordering, the read cap) as runtime/test assertions and
+  living documentation. Migrate toward the native compiler contracts (MCP-759) as they
+  stabilize, since those are designed to feed verifiers later.
+- **One Stateright model** (Rust-native model checker; spec and impl in one language, runs in
+  `cargo test`) for the single genuinely subtle invariant: that cross-file dispatch produces
+  the same result set regardless of file-visit order, and/or that the LSP's incremental
+  cache never serves a stale cross-file result. Prefer Stateright over TLA+/Quint precisely
+  because it avoids a second language and toolchain. Drive conformance by generated tests, not
+  by post-hoc trace validation (the field shows trace-validation is the expensive, brittle
+  end of anti-drift).
+
+**Explicitly skip (low ROI / research-grade):** Verus, Creusot, Prusti, Aeneas, hax (built
+for systems/crypto at ~5:1 proof-to-code; the Rust std-lib effort reached under 4 percent
+coverage with experts). TLA+/Alloy/P as maintained dependencies. Loom/Shuttle unless alint
+grows hand-rolled lock-free concurrency. These are "watch," not "adopt."
+
+---
+
+### WS5 - Close the alint.org drift loop
+
+The website is just another consumer of the `facts.json` contract from WS1e.
+
+- **Repo side:** ship `facts.json` as a release artifact (and at a stable URL via the
+  docs-bundle pipeline that alint.org already pulls).
+- **Site side:** render counts, version, supported-language lists, and comparison tables from
+  the synced `facts.json` at build time (Astro fetches build-time data and ingests JSON as a
+  typed source), instead of hardcoding them in prose. Live README/site badges can use the
+  shields.io endpoint contract pointed at `facts.json`.
+- **A content test in the site repo** fetches the product's published metadata (crates/npm
+  version, shipped `facts.json`) and fails the site build if the rendered claims disagree.
+- **Version-pin parity:** extend the release checklist (and ideally a cross-repo CI check) so
+  alint.org's version surfaces cannot lag a release undetected.
+
+The narrative bonus: "alint's own marketing claims are enforced by alint" is a credible,
+on-brand story for an anti-drift linter, and worth saying out loud on the site.
+
+---
+
+### WS0 (cross-cutting) - lightweight governance
+
+Two small, prose-rung artifacts that formalize tribal knowledge without creating regen risk:
+
+- **`docs/design/constitution.md`** - alint's immutable invariants, stated once and reviewed
+  on every change: every spawning rule kind must be in `SPAWNING_RULE_KINDS`; every rule kind
+  needs a firing and a silent e2e scenario; all whole-file analysis reads go through
+  `read_capped`; output is deterministic; cross-file kinds declare `requires_full_index()`
+  and no path scope. The project currently re-learns these each cycle; a constitution makes
+  them explicit. Several are already machine-enforced by `coverage_audit_*` and should link to
+  their enforcing test.
+- **A fixed design-doc template** (`docs/design/TEMPLATE.md`) codifying the existing
+  seven-section convention so it stops being informal, plus a one-line "which ADR(s) does this
+  touch" pointer.
+
+---
+
+## 4. Drift surface to fix map
+
+Consolidated from the drift-surface analysis. "Today" is the current control; "Proposal" is
+the target rung.
+
+| Fact / artifact | Today | Risk | Proposal |
+| --- | --- | --- | --- |
+| Schema vs parser (option keys) | hand-written JSON + byte-copy; no field-level audit | High (undetected) | WS1a generate from types (`schemars`) |
+| alint.org version + claims | manual, cross-repo, unaudited | High | WS5 `facts.json` + site content test |
+| Per-kind reference prose | hand-written `docs/rules.md`, `docs/site/reference/` | High | WS1b generate from metadata |
+| `CLI_REFERENCE_SUBCMDS` two-list | partial test (count only) | Medium | WS1c generate from clap |
+| In-crate schema byte-copy | manual copy | Medium | WS1a single generated emit |
+| Ruleset doc cell values | count audited, cells not | Medium | WS1b generate ruleset pages from YAML |
+| Rule-kind / family / ruleset counts | `coverage_audit_readme_claims` | Low (audited) | WS1e fold into `facts.json`; keep audit |
+| Version pins (install snippets) | `check-version-pins.sh` | Low | keep; surface via `facts.json` |
+| Architecture intent | prose only | Medium (no record) | WS2 ADRs + WS3 C4 model |
+| Crate/module structure | undocumented | Low | WS3 code-extracted graphs + acyclic gate |
+| Invariants (spawning, read cap, determinism) | scattered, partly tested | Medium | WS0 constitution linking to tests; WS4 Kani/contracts |
+
+Principle applied throughout: promote each row from "manual + hope" to "duplicate + CI
+audit," and from "audit" to "single source + generate," as far up as is practical. The
+`coverage_audit_*` counters stay as a safety net but are explicitly treated as a way-station,
+not a destination.
+
+---
+
+## 5. Dogfooding: alint enforces alint
+
+A short section because it is the multiplier that makes the rest "maximally automated," and
+because it is a differentiator worth being deliberate about.
+
+Wherever this proposal needs a CI gate, prefer expressing it as an alint rule in `.alint.yml`:
+
+- Generated-artifact freshness (schema, rule reference, CLI reference, `facts.json`,
+  diagrams) -> `generated_file_fresh`.
+- ADR hygiene in `docs/adr/` -> the shipped `docs/adr@v1` ruleset.
+- Cross-file consistency (for example, `facts.json` count vs the live registry) ->
+  `cross_file_value_equals` / `file_graph` / `registry_paths_resolve`.
+- The constitution's structural invariants -> existing `coverage_audit_*` tests, referenced
+  from the constitution.
+
+Every such use is simultaneously: more automated than a bespoke script, self-documenting, a
+real-world test of alint on a polyglot repo, and a true marketing claim ("alint's own
+spec/docs/marketing drift is prevented by alint"). This is the cleanest possible alignment of
+the four user goals.
+
+---
+
+## 6. Phased rollout
+
+Sequenced by dependency and ROI, using the project's established one-commit-per-phase
+convention (each phase: design note or ADR, then atomic implementation; forward
+`Next: Phase N` pointer). Phases 1-3 deliver most of the anti-drift value.
+
+**Phase 0 - Governance scaffolding (cheap, no code).**
+Constitution, design-doc template, MADR template into `docs/adr/`, and the first few backfill
+ADRs. Wire alint's `docs/adr@v1` ruleset into `.alint.yml`. ADR-0001 records "adopt
+spec-driven development" (this document, distilled).
+
+**Phase 1 - The keystone: schema from types.**
+WS1a. Spike fidelity, add `schemars` derives, add `xtask gen-schema`, retire the hand-written
+schema and the byte-copy, guard with `generated_file_fresh`. Keep `coverage_audit_schema_drift`
+as the net. Add the schema-validate-all-examples gate (WS1d, partial).
+
+**Phase 2 - Generate the reference + executable docs.**
+WS1b/1c/1d: rule reference and CLI reference generated and gated; `insta` snapshots for
+`--help` and the rules table; `trycmd` over documented invocations and README examples.
+
+**Phase 3 - The facts contract + alint.org loop.**
+WS1e `facts.json`; WS5 site renders from it with a content test and version-pin parity.
+Closes the highest-remaining-risk external drift.
+
+**Phase 4 - Architecture as code.**
+WS3: `cargo-depgraph` / `cargo-modules` extracted graphs + acyclic gate; the Structurizr
+`workspace.dsl` with Mermaid/SVG export and the crate-name consistency gate; arc42
+cherry-pick into ARCHITECTURE.md.
+
+**Phase 5 - Pragmatic formal methods.**
+WS4: Kani job on the pure core; Miri nightly; `contracts` on a few invariants; evaluate a
+single Stateright model for cross-file dispatch determinism / LSP cache. This phase is
+genuinely optional and can trail the rest.
+
+Each phase is independently shippable and leaves the tree green. The whole program is mostly
+non-user-facing (engine internals, CI, docs pipeline), so it can interleave with feature work
+rather than blocking a release; the natural home is an engineering-foundations track
+(candidate: v0.13) rather than a user-facing minor.
+
+---
+
+## 7. What we will deliberately NOT do
+
+Stated explicitly so the proposal cannot be read as "adopt everything."
+
+- **No heavyweight deductive verification** (Verus/Creusot/Prusti/Aeneas/hax). Real and
+  active, but built for systems/crypto with prohibitive proof-to-code ratios. Not maintainable
+  for linter business logic by a small team.
+- **No prose-as-regenerable-source.** Design docs, ADRs, and narrative docs stay
+  point-in-time. We do not try to regenerate English from a model; that repeats Model-Driven
+  Development's failures and stale prose specs mislead confidently.
+- **No second spec language as a dependency** (TLA+/Alloy/Quint/P) unless a specific subtle
+  invariant demands it, and even then Stateright (Rust-native) is preferred.
+- **No archived or fragile tooling.** `clap-markdown` (archived) -> use `clap_mangen`. Avoid
+  mtime-based staleness checks (unreliable on fresh CI clones) -> use content-diff. Pin
+  Structurizr to the consolidated `structurizr.war`, not the archived CLI.
+- **No big-bang rewrite of the existing drift system.** The `coverage_audit_*` tests stay and
+  are extended; they are the proof of concept, not technical debt.
+
+---
+
+## 8. Decisions needed from you
+
+1. **Deliverable shape:** is a single living design doc here (this file, evolving) the right
+   home, or do you want this split into per-workstream design docs under
+   `docs/design/spec-driven/` plus ADRs? (This draft assumes the former until Phase 0.)
+2. **ADR home:** `docs/adr/` (zero-friction dogfooding of the shipped ruleset, recommended) vs
+   MADR's canonical `docs/decisions/` (needs a three-line path override in `.alint.yml`).
+3. **Scope and sequencing:** approve the full program, or start with Phases 0-3 (the
+   anti-drift core) and defer WS3/WS4? My recommendation: commit to 0-3, treat 4-5 as
+   opt-in.
+4. **`facts.json` cross-repo wiring:** are you willing to add a CI step in the (separate,
+   private) alint.org repo that consumes `facts.json` and fails on drift? WS5's strongest
+   guarantee depends on a check living on the site side.
+5. **Formal-methods appetite:** is the single Stateright model (Phase 5) worth a spike, or
+   should WS4 stop at Kani + Miri + `contracts`?
+
+---
+
+## Appendix A - Tool inventory
+
+| Tool | Role | License | Maturity (as researched 2026) | Notes |
+| --- | --- | --- | --- | --- |
+| `schemars` | JSON Schema from Rust types | MIT | v1.x, active (latest early 2026) | Keystone; honors serde attributes |
+| `clap_mangen` | CLI man/reference from clap | MIT/Apache | v0.3.x, maintained in clap project | Recommends xtask pattern |
+| `insta` | Snapshot testing | Apache-2.0 | v1.4x, very active | Pin generated output |
+| `trycmd` | CLI/README conformance | MIT/Apache | maintained | Runs docs as tests |
+| `proptest` | Property testing | MIT/Apache | already a dependency | Lean in harder |
+| Kani | Bounded model checking | MIT/Apache (AWS) | v0.6x, active; GitHub Action | Pure-core panic/overflow proofs |
+| Miri | UB detection | MIT/Apache | mainstream, very active | Run on existing tests |
+| `contracts` | Runtime pre/postconditions | MPL-2.0 | maintained | Bridge to native MCP-759 contracts |
+| Stateright | Rust-native model checker | MIT | active; liveness experimental | One model, if any |
+| MADR 4.0.0 | ADR template | MIT/CC0 | released 2024-09-17 | Dogfood `docs/adr@v1` |
+| log4brains | ADR site (optional) | Apache-2.0 | v1.1.0 (2024-12) | Defer unless wanted |
+| Structurizr | C4 model + export | Apache-2.0 | CLI archived 2026-02-04 -> `structurizr.war` | Pin consolidated artifact |
+| `cargo-modules` | Module graphs + acyclic gate | MPL-2.0 | maintained | Code-extracted, CI gate |
+| `cargo-depgraph` | Workspace crate graph | MIT/Apache | maintained | Code-extracted |
+
+All licenses above are compatible with alint's Apache-2.0/MIT posture; run them through
+`cargo-deny` as usual before adoption.
+
+## Appendix B - Key sources
+
+Spec-driven development and anti-drift:
+- Martin Fowler, "Understanding SDD: Kiro, spec-kit, and Tessl" (the three-rung ladder).
+- GitHub Spec Kit; AWS Kiro (requirements/design/tasks).
+- Tom Preston-Werner, "Readme Driven Development" (2010).
+- "Design Docs at Google" (humans do not keep docs current).
+- Isoform, "The Limits of Spec-Driven Development"; Augment, "What SDD gets wrong."
+- Ruff contributing docs (`generate-all`: schema + docs + rules from metadata).
+- rust-analyzer PR #19315 (fail CI if codegen modifies tracked files); `cargo-xtask`.
+- `schemars`, `clap_mangen`, `insta`, `trycmd`, Astro build-time data, shields.io endpoint.
+
+ADRs and architecture diagrams:
+- MADR (adr.github.io/madr, v4.0.0); log4brains; joelparkerhenderson/architecture-decision-record.
+- C4 model (c4model.com): containers are deployables, not libraries; auto-generate the code level.
+- Structurizr DSL + export + EOL/consolidation notice; structurizr-site-generatr.
+- GitHub Mermaid rendering; D2/PlantUML/Graphviz trade-offs.
+- `cargo-modules` (`--acyclic`), `cargo-depgraph`; arc42 (cherry-pick, esp. Section 9 -> ADRs).
+
+Formal methods for Rust:
+- Kani (model-checking; Firecracker, verify-rust-std); Miri (POPL 2026, 100k+ crates).
+- Stateright (Rust-native model checker); Quint (modern TLA+) as the alternative if needed.
+- Verus/Creusot/Prusti/Flux surveys; std-lib verification coverage reality check.
+- MongoDB conformance-checking blog (trace-validation cost vs test-generation).
+
+(Full URLs are retained in the research notes that produced this proposal and can be inlined
+into the relevant ADRs as those decisions are recorded.)

--- a/docs/development/rule-authoring.md
+++ b/docs/development/rule-authoring.md
@@ -36,6 +36,17 @@ at test time.
    `coverage_audit_*` should pass.
 ```
 
+If the kind carries options, derive its schema branch from the Rust `Options`
+struct rather than hand-editing `schemas/v1/config.json`: add
+`#[derive(schemars::JsonSchema)]` to the struct (with `///` field docs and any
+`#[schemars(range/length/regex)]` constraints), register it in
+`alint-rules/src/lib.rs::migrated_option_schemas()`, then run
+`cargo run -p xtask -- gen-schema` to regenerate the schema (root + the in-crate
+copy). CI and preflight run `gen-schema --check`, which fails if the committed
+schema drifts from the Rust types. See ADR-0001 and
+`docs/design/spec-driven-development.md`. Kinds with deeply nested option shapes
+stay hand-written in the schema (omit them from `migrated_option_schemas`).
+
 ### Family-directory conventions
 
 The family directory is chosen by what the rule *does*:

--- a/schemas/v1/config.json
+++ b/schemas/v1/config.json
@@ -1,5 +1,94 @@
 {
   "$defs": {
+    "Algorithm": {
+      "enum": [
+        "sha256",
+        "sha512"
+      ],
+      "type": "string"
+    },
+    "Comparator": {
+      "oneOf": [
+        {
+          "const": "lexical",
+          "description": "Rust `str` `Ord` — byte-wise over the UTF-8.",
+          "type": "string"
+        },
+        {
+          "const": "lexical-ci",
+          "description": "ASCII-case-insensitive lexical.",
+          "type": "string"
+        },
+        {
+          "const": "numeric",
+          "description": "Leading-integer order; entries without a leading integer\nfall back to `lexical` so a mixed block degrades\npredictably rather than panicking.",
+          "type": "string"
+        }
+      ]
+    },
+    "FilesFrom": {
+      "oneOf": [
+        {
+          "const": "none",
+          "description": "One violation for the whole invocation (default).",
+          "type": "string"
+        },
+        {
+          "const": "stdout",
+          "description": "Parse the checker's stdout for the offender list.",
+          "type": "string"
+        },
+        {
+          "const": "stderr",
+          "description": "Parse the checker's stderr for the offender list.",
+          "type": "string"
+        }
+      ]
+    },
+    "Format": {
+      "oneOf": [
+        {
+          "const": "contains",
+          "description": "The digest must appear as a substring anywhere in `target`.",
+          "type": "string"
+        },
+        {
+          "const": "sums-line",
+          "description": "`target` must carry a `sha256sum`-style `<hex> [*]<path>`\nline whose path token is the source's path.",
+          "type": "string"
+        }
+      ]
+    },
+    "Language": {
+      "enum": [
+        "auto",
+        "rust",
+        "typescript",
+        "javascript",
+        "python",
+        "go",
+        "java",
+        "c",
+        "cpp",
+        "ruby",
+        "shell"
+      ],
+      "type": "string"
+    },
+    "StyleName": {
+      "enum": [
+        "tabs",
+        "spaces"
+      ],
+      "type": "string"
+    },
+    "TargetName": {
+      "enum": [
+        "lf",
+        "crlf"
+      ],
+      "type": "string"
+    },
     "case_convention": {
       "description": "Case convention. Aliases like PascalCase / pascal / pascal-case / UpperCamelCase all resolve to the same canonical form.",
       "enum": [
@@ -597,7 +686,7 @@
       "description": "Shell out to an external CLI per matched file. argv[0] is the program; remaining tokens support path-template substitution (`{path}`, `{dir}`, `{stem}`, `{ext}`, `{basename}`, `{parent_name}`). Working dir = repo root; stdin = /dev/null. Env: ALINT_PATH, ALINT_ROOT, ALINT_RULE_ID, ALINT_LEVEL, plus ALINT_VAR_<NAME> per `vars:` and ALINT_FACT_<NAME> per resolved fact. Verdict: exit 0 = pass; non-zero = one violation whose message is the (truncated) stdout+stderr. Trust-gated: only allowed in the user's top-level config (rejected at load-time when introduced via `extends:` or a bundled ruleset).",
       "properties": {
         "command": {
-          "description": "Argv tokens. The first token is the program (looked up via PATH if it's a bare name); remaining tokens accept `{path}` and friends.",
+          "description": "Argv tokens. The first token is the program (looked up via PATH if it's\na bare name); remaining tokens accept `{path}` and friends.",
           "items": {
             "type": "string"
           },
@@ -611,9 +700,14 @@
           "$ref": "#/$defs/paths_spec"
         },
         "timeout": {
-          "description": "Per-file timeout in seconds. Default 30. Past this, the child is killed and a violation reports the timeout.",
+          "default": null,
+          "description": "Per-file timeout in seconds. Default 30. Past this, the child is killed\nand a violation reports the timeout.",
+          "format": "uint64",
           "minimum": 1,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
       "required": [
@@ -626,7 +720,7 @@
       "description": "Run a user-declared formatter/checker in its --check (idempotence) mode once: exit 0 = the tree is formatter-clean (silent), non-zero = violation(s). alint never runs a mutating formatter and never writes the tree (the sibling of generated_file_fresh; same trust tier as the command rule — trust-gated to the user's own top-level config). With `files_from` (+ optional `files_pattern`) the tool's offender list is parsed into one violation per file. Single-shot, opt-in.",
       "properties": {
         "command": {
-          "description": "Checker argv (no shell), run in its --check / idempotence mode; exit 0 = clean.",
+          "description": "Checker argv (no shell), run in its --check / idempotence mode; exit\n0 = clean.",
           "items": {
             "type": "string"
           },
@@ -634,28 +728,37 @@
           "type": "array"
         },
         "files_from": {
-          "description": "On failure, parse this stream into per-file violations (default: none = one violation for the whole invocation).",
-          "enum": [
-            "none",
-            "stdout",
-            "stderr"
-          ]
+          "$ref": "#/$defs/FilesFrom",
+          "description": "On failure, parse this stream into per-file violations (default: none =\none violation for the whole invocation)."
         },
         "files_pattern": {
-          "description": "Regex whose capture group 1 is a file path, applied per output line (requires `files_from`; omit for bare-path listers).",
-          "type": "string"
+          "default": null,
+          "description": "Regex whose capture group 1 is a file path, applied per output line\n(requires `files_from`; omit for bare-path listers).",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "kind": {
           "const": "command_idempotent"
         },
         "timeout": {
-          "description": "Checker timeout in seconds (default 120). On timeout the child is killed and one violation is emitted.",
+          "default": null,
+          "description": "Checker timeout in seconds (default 120). On timeout the child is killed\nand one violation is emitted.",
+          "format": "uint64",
           "minimum": 1,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "workdir": {
+          "default": null,
           "description": "Checker cwd, relative to the lint root (default: lint root).",
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -670,26 +773,13 @@
           "const": "commented_out_code"
         },
         "language": {
-          "default": "auto",
-          "description": "Comment-marker set to use. `auto` (default) infers from each file's extension. Files with extensions the resolver doesn't recognise are silently skipped.",
-          "enum": [
-            "auto",
-            "rust",
-            "typescript",
-            "javascript",
-            "python",
-            "go",
-            "java",
-            "c",
-            "cpp",
-            "ruby",
-            "shell"
-          ],
-          "type": "string"
+          "$ref": "#/$defs/Language",
+          "description": "`auto` (default) infers the comment-marker set from\neach file's extension. Explicit override useful for\nembedded DSLs or cases where the extension lies."
         },
         "min_lines": {
           "default": 3,
-          "description": "Minimum consecutive comment-line count for a block to be considered. Default 3 — 1-2 line comments are almost always prose.",
+          "description": "Minimum consecutive comment-line count for a block to\nbe considered. 1-2 line comments are almost always\nprose; 3+ starts looking like dead code. Default 3.",
+          "format": "uint",
           "minimum": 2,
           "type": "integer"
         },
@@ -698,13 +788,15 @@
         },
         "skip_leading_lines": {
           "default": 30,
-          "description": "Skip blocks whose first line is at or before this line number. Default 30 — covers typical license headers without false-positive flagging them as commented-out code.",
+          "description": "Skip the first N lines of any file. Defaults to 30 to\npass over license headers without false-positive\nflagging them as commented-out code.",
+          "format": "uint",
           "minimum": 0,
           "type": "integer"
         },
         "threshold": {
           "default": 0.5,
-          "description": "Density floor for code-shapedness. Higher = stricter. Default 0.5 sits at the midpoint between obvious-prose (0.0) and obvious-code (1.0); lower it to widen the catch (more FPs), raise it to narrow.",
+          "description": "Token-density floor (0.0-1.0). Higher = stricter (only\nthe most code-shaped blocks fire). Default 0.5.",
+          "format": "double",
           "maximum": 1.0,
           "minimum": 0.0,
           "type": "number"
@@ -1360,6 +1452,7 @@
           "$ref": "#/$defs/paths_spec"
         },
         "sha256": {
+          "description": "Expected SHA-256 in lowercase hex (64 chars). Accepting\nuppercase and the `sha256:` prefix keeps the field forgiving.",
           "pattern": "^(sha256:)?[0-9a-fA-F]{64}$",
           "type": "string"
         }
@@ -1403,7 +1496,8 @@
       "description": "Every byte in every file in scope must be < 0x80 (pure ASCII), except codepoints listed in `allow:`. Stricter than file_is_text; check-only — auto-replacement for non-ASCII bytes would silently lose meaning. With `allow:` the file is decoded as UTF-8 and checked per character; without it, the strict byte-level fast path is used.",
       "properties": {
         "allow": {
-          "description": "Permitted non-ASCII codepoints — each entry a single character (e.g. \"ö\"), a `U+XXXX` codepoint, or a `U+XXXX-U+YYYY` inclusive range.",
+          "default": [],
+          "description": "Permitted non-ASCII codepoints - each a single character\n(e.g. \"o-umlaut\"), a `U+XXXX` codepoint, or a `U+XXXX-U+YYYY`\ninclusive range.",
           "items": {
             "type": "string"
           },
@@ -2163,16 +2257,18 @@
           "$ref": "#/$defs/paths_spec"
         },
         "style": {
-          "enum": [
-            "tabs",
-            "spaces"
-          ],
-          "type": "string"
+          "$ref": "#/$defs/StyleName",
+          "description": "Required indentation style: `tabs` rejects any leading space; `spaces`\nrejects any leading tab."
         },
         "width": {
-          "description": "When `style: spaces`, the leading-space count on every non-blank line must be a multiple of this. Ignored for `style: tabs`.",
+          "default": null,
+          "description": "When `style: spaces`, the leading-space count on every non-blank line\nmust be a multiple of this. Ignored for `style: tabs`.",
+          "format": "uint32",
           "minimum": 1,
-          "type": "integer"
+          "type": [
+            "integer",
+            "null"
+          ]
         }
       },
       "required": [
@@ -2514,11 +2610,8 @@
           "$ref": "#/$defs/paths_spec"
         },
         "target": {
-          "enum": [
-            "lf",
-            "crlf"
-          ],
-          "type": "string"
+          "$ref": "#/$defs/TargetName",
+          "description": "Required line ending style: `lf` or `crlf`. Mixed endings within a\nfile also fail."
         }
       },
       "required": [
@@ -2800,15 +2893,16 @@
       "description": "The lines between a `start` / `end` marker pair must stay sorted (and, with `unique`, free of duplicates) under `comparator`. Both markers are optional: omit `end` to sort from `start` to EOF, omit both to sort the whole file (the markerless 'this file is one sorted list' form). The generic form of per-project keep-sorted scripts. Per-file: markers match the trimmed line; blank lines inside a block are ignored.",
       "properties": {
         "comparator": {
-          "enum": [
-            "lexical",
-            "lexical-ci",
-            "numeric"
-          ]
+          "$ref": "#/$defs/Comparator",
+          "description": "Comparator used to order entries: lexical (default), lexical-ci, or\nnumeric."
         },
         "end": {
-          "description": "Marker line closing a block. Optional — omit to run the block to EOF.",
-          "type": "string"
+          "default": null,
+          "description": "Marker line closing a block. Optional - omit to run the block to EOF.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "kind": {
           "const": "ordered_block"
@@ -2817,14 +2911,24 @@
           "$ref": "#/$defs/paths_spec"
         },
         "select": {
-          "description": "Regex; when set, only lines inside a block matching it are sortable entries (others — comments, group headers — pass through). The sectioned / keep-sorted-subset shape.",
-          "type": "string"
+          "default": null,
+          "description": "Regex; when set, only lines inside a block matching it are sortable\nentries (others, such as comments or group headers, pass through).",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "start": {
-          "description": "Marker line opening a block (matched on the trimmed line). Optional — omit to anchor the block at the start of the file.",
-          "type": "string"
+          "default": null,
+          "description": "Marker line opening a block (matched on the trimmed line). Optional -\nomit to anchor the block at the start of the file.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "unique": {
+          "default": false,
+          "description": "When true, also forbid duplicate (equal) entries within a block.",
           "type": "boolean"
         }
       },
@@ -2881,28 +2985,22 @@
       "description": "Cross-file: the `algorithm` digest of every file matching `source` must appear in the single `target` file — either as an embedded hex substring (`format: contains`, the default) or a coreutils / go-`.sum`-style `<hex>  <path>` manifest line (`format: sums-line`). Detection-only (alint never rewrites the manifest). A missing `target` is one violation; one violation per source whose digest is absent or mismatched. golang/go FIPS `fips140.sum` is the canonical use.",
       "properties": {
         "algorithm": {
-          "description": "Digest algorithm (default: sha256).",
-          "enum": [
-            "sha256",
-            "sha512"
-          ]
+          "$ref": "#/$defs/Algorithm",
+          "description": "Digest algorithm (default: sha256)."
         },
         "format": {
-          "description": "How the digest must appear in `target`: `contains` = hex substring anywhere (default); `sums-line` = a `<hex> [*]<path>` line whose path token is the source's path.",
-          "enum": [
-            "contains",
-            "sums-line"
-          ]
+          "$ref": "#/$defs/Format",
+          "description": "How the digest must appear in `target`: `contains` = hex\nsubstring anywhere (default); `sums-line` = a `<hex> [*]<path>`\nline whose path token is the source's path."
         },
         "kind": {
           "const": "pair_hash"
         },
         "source": {
-          "description": "Literal path or glob selecting the file(s) whose content is hashed (one check per match).",
+          "description": "Literal path or glob selecting the file(s) whose content is\nhashed (one check per match).",
           "type": "string"
         },
         "target": {
-          "description": "The single file that must carry the digest (a `.sum` / `SHA256SUMS` / file with an embedded hash).",
+          "description": "The single file that must carry the digest (a `.sum` /\n`SHA256SUMS` / a file with an embedded hash).",
           "type": "string"
         }
       },

--- a/schemas/v1/config.json
+++ b/schemas/v1/config.json
@@ -21,7 +21,7 @@
         },
         {
           "const": "numeric",
-          "description": "Leading-integer order; entries without a leading integer\nfall back to `lexical` so a mixed block degrades\npredictably rather than panicking.",
+          "description": "Leading-integer order; entries without a leading integer fall back to `lexical` so a mixed block degrades predictably rather than panicking.",
           "type": "string"
         }
       ]
@@ -54,7 +54,7 @@
         },
         {
           "const": "sums-line",
-          "description": "`target` must carry a `sha256sum`-style `<hex> [*]<path>`\nline whose path token is the source's path.",
+          "description": "`target` must carry a `sha256sum`-style `<hex> [*]<path>` line whose path token is the source's path.",
           "type": "string"
         }
       ]
@@ -664,12 +664,12 @@
           "const": "changeset_requires_path"
         },
         "since": {
-          "description": "Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}`\ninterpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
+          "description": "Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}` interpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
           "type": "string"
         },
         "when_changed": {
           "default": null,
-          "description": "Optional gate: only require the add when some path matching this glob\nchanged (any status). Omit to require it on any non-empty changeset.",
+          "description": "Optional gate: only require the add when some path matching this glob changed (any status). Omit to require it on any non-empty changeset.",
           "type": [
             "string",
             "null"
@@ -686,7 +686,7 @@
       "description": "Shell out to an external CLI per matched file. argv[0] is the program; remaining tokens support path-template substitution (`{path}`, `{dir}`, `{stem}`, `{ext}`, `{basename}`, `{parent_name}`). Working dir = repo root; stdin = /dev/null. Env: ALINT_PATH, ALINT_ROOT, ALINT_RULE_ID, ALINT_LEVEL, plus ALINT_VAR_<NAME> per `vars:` and ALINT_FACT_<NAME> per resolved fact. Verdict: exit 0 = pass; non-zero = one violation whose message is the (truncated) stdout+stderr. Trust-gated: only allowed in the user's top-level config (rejected at load-time when introduced via `extends:` or a bundled ruleset).",
       "properties": {
         "command": {
-          "description": "Argv tokens. The first token is the program (looked up via PATH if it's\na bare name); remaining tokens accept `{path}` and friends.",
+          "description": "Argv tokens. The first token is the program (looked up via PATH if it's a bare name); remaining tokens accept `{path}` and friends.",
           "items": {
             "type": "string"
           },
@@ -701,7 +701,7 @@
         },
         "timeout": {
           "default": null,
-          "description": "Per-file timeout in seconds. Default 30. Past this, the child is killed\nand a violation reports the timeout.",
+          "description": "Per-file timeout in seconds. Default 30. Past this, the child is killed and a violation reports the timeout.",
           "format": "uint64",
           "minimum": 1,
           "type": [
@@ -720,7 +720,7 @@
       "description": "Run a user-declared formatter/checker in its --check (idempotence) mode once: exit 0 = the tree is formatter-clean (silent), non-zero = violation(s). alint never runs a mutating formatter and never writes the tree (the sibling of generated_file_fresh; same trust tier as the command rule — trust-gated to the user's own top-level config). With `files_from` (+ optional `files_pattern`) the tool's offender list is parsed into one violation per file. Single-shot, opt-in.",
       "properties": {
         "command": {
-          "description": "Checker argv (no shell), run in its --check / idempotence mode; exit\n0 = clean.",
+          "description": "Checker argv (no shell), run in its --check / idempotence mode; exit 0 = clean.",
           "items": {
             "type": "string"
           },
@@ -729,11 +729,11 @@
         },
         "files_from": {
           "$ref": "#/$defs/FilesFrom",
-          "description": "On failure, parse this stream into per-file violations (default: none =\none violation for the whole invocation)."
+          "description": "On failure, parse this stream into per-file violations (default: none = one violation for the whole invocation)."
         },
         "files_pattern": {
           "default": null,
-          "description": "Regex whose capture group 1 is a file path, applied per output line\n(requires `files_from`; omit for bare-path listers).",
+          "description": "Regex whose capture group 1 is a file path, applied per output line (requires `files_from`; omit for bare-path listers).",
           "type": [
             "string",
             "null"
@@ -744,7 +744,7 @@
         },
         "timeout": {
           "default": null,
-          "description": "Checker timeout in seconds (default 120). On timeout the child is killed\nand one violation is emitted.",
+          "description": "Checker timeout in seconds (default 120). On timeout the child is killed and one violation is emitted.",
           "format": "uint64",
           "minimum": 1,
           "type": [
@@ -774,11 +774,12 @@
         },
         "language": {
           "$ref": "#/$defs/Language",
-          "description": "`auto` (default) infers the comment-marker set from\neach file's extension. Explicit override useful for\nembedded DSLs or cases where the extension lies."
+          "default": "auto",
+          "description": "`auto` (default) infers the comment-marker set from each file's extension. Explicit override useful for embedded DSLs or cases where the extension lies."
         },
         "min_lines": {
           "default": 3,
-          "description": "Minimum consecutive comment-line count for a block to\nbe considered. 1-2 line comments are almost always\nprose; 3+ starts looking like dead code. Default 3.",
+          "description": "Minimum consecutive comment-line count for a block to be considered. 1-2 line comments are almost always prose; 3+ starts looking like dead code. Default 3.",
           "format": "uint",
           "minimum": 2,
           "type": "integer"
@@ -788,14 +789,14 @@
         },
         "skip_leading_lines": {
           "default": 30,
-          "description": "Skip the first N lines of any file. Defaults to 30 to\npass over license headers without false-positive\nflagging them as commented-out code.",
+          "description": "Skip blocks whose first line is at or before this line number. Default 30 - covers typical license headers without false-positive flagging them as commented-out code.",
           "format": "uint",
           "minimum": 0,
           "type": "integer"
         },
         "threshold": {
           "default": 0.5,
-          "description": "Token-density floor (0.0-1.0). Higher = stricter (only\nthe most code-shaped blocks fire). Default 0.5.",
+          "description": "Density floor for code-shapedness. Higher = stricter. Default 0.5 sits at the midpoint between obvious-prose (0.0) and obvious-code (1.0); lower it to widen the catch (more FPs), raise it to narrow.",
           "format": "double",
           "maximum": 1.0,
           "minimum": 0.0,
@@ -1452,7 +1453,7 @@
           "$ref": "#/$defs/paths_spec"
         },
         "sha256": {
-          "description": "Expected SHA-256 in lowercase hex (64 chars). Accepting\nuppercase and the `sha256:` prefix keeps the field forgiving.",
+          "description": "Expected SHA-256 in lowercase hex (64 chars). Accepting uppercase and the `sha256:` prefix keeps the field forgiving.",
           "pattern": "^(sha256:)?[0-9a-fA-F]{64}$",
           "type": "string"
         }
@@ -1497,7 +1498,7 @@
       "properties": {
         "allow": {
           "default": [],
-          "description": "Permitted non-ASCII codepoints - each a single character\n(e.g. \"o-umlaut\"), a `U+XXXX` codepoint, or a `U+XXXX-U+YYYY`\ninclusive range.",
+          "description": "Permitted non-ASCII codepoints - each a single character (e.g. \"o-umlaut\"), a `U+XXXX` codepoint, or a `U+XXXX-U+YYYY` inclusive range.",
           "items": {
             "type": "string"
           },
@@ -1645,7 +1646,7 @@
         },
         "shebang": {
           "default": "^#!",
-          "description": "Rust regex; the first line of every matched file must match. Default\n`^#!` only enforces shebang presence.",
+          "description": "Rust regex; the first line of every matched file must match. Default `^#!` only enforces shebang presence.",
           "type": "string"
         }
       },
@@ -1936,7 +1937,7 @@
           "const": "git_blame_age"
         },
         "max_age_days": {
-          "description": "Minimum line age (in days) for a matching line to fire as a violation.\nLines younger than this pass silently.",
+          "description": "Minimum line age (in days) for a matching line to fire as a violation. Lines younger than this pass silently. Common values: 90 (one quarter), 180 (half a year), 365 (a full year of debt).",
           "format": "uint64",
           "minimum": 1,
           "type": "integer"
@@ -1945,7 +1946,7 @@
           "$ref": "#/$defs/paths_spec"
         },
         "pattern": {
-          "description": "Rust-regex pattern applied to each blame line's content. Capture group 1\n(when present) is exposed as `{{ctx.match}}` in the message template;\nwithout a capture group, `{{ctx.match}}` substitutes the full match.",
+          "description": "Rust-regex pattern applied to each blame line's content. Capture group 1 (when present) is exposed as `{{ctx.match}}` in the message template; without a capture group, `{{ctx.match}}` substitutes the full match.",
           "type": "string"
         }
       },
@@ -1973,7 +1974,7 @@
       "properties": {
         "email_pattern": {
           "default": null,
-          "description": "Rust-regex the author email (`git log %ae`) must match, e.g.\n`^.+@example\\.com$`.",
+          "description": "Rust-regex the author email (`git log %ae`) must match, e.g. `^.+@example\\.com$`.",
           "type": [
             "string",
             "null"
@@ -1981,7 +1982,7 @@
         },
         "include_merges": {
           "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error.",
           "type": "boolean"
         },
         "kind": {
@@ -1997,7 +1998,7 @@
         },
         "since": {
           "default": null,
-          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does.",
+          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
           "type": [
             "string",
             "null"
@@ -2011,7 +2012,7 @@
       "properties": {
         "include_merges": {
           "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error.",
           "type": "boolean"
         },
         "kind": {
@@ -2019,7 +2020,7 @@
         },
         "since": {
           "default": null,
-          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does.",
+          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
           "type": [
             "string",
             "null"
@@ -2050,7 +2051,7 @@
       "properties": {
         "include_merges": {
           "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset; combining `include_merges: true` with no\n`since:` is a load-time error.",
+          "description": "When validating a range (`since:` set), include merge commits. Defaults to `false` because merge commits in PR contexts are typically the synthetic merge `actions/checkout` produces (with an auto-generated subject the rule would always flag) or maintainer-resolved merges from the base branch. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error.",
           "type": "boolean"
         },
         "kind": {
@@ -2058,7 +2059,7 @@
         },
         "pattern": {
           "default": null,
-          "description": "Rust-regex pattern the full message (subject + body, joined with\nnewlines) must match. Use `(?s)` to make `.` match newlines.",
+          "description": "Rust-regex pattern the full message (subject + body, joined with newlines) must match. Use `(?s)` to make `.` match newlines.",
           "type": [
             "string",
             "null"
@@ -2066,12 +2067,12 @@
         },
         "requires_body": {
           "default": false,
-          "description": "When true, the message must have a non-empty body, that is, at least\none line of content after the subject's blank-line separator.",
+          "description": "When true, the message must have a non-empty body, that is, at least one line of content after the subject's blank-line separator.",
           "type": "boolean"
         },
         "since": {
           "default": null,
-          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does: SHA (full or abbreviated), branch (`origin/main`),\ntag (`v1.2.3`), or relative ref (`HEAD~5`).",
+          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does: SHA (full or abbreviated), branch (`origin/main`), tag (`v1.2.3`), or relative ref (`HEAD~5`). Supports POSIX `${VAR}` and `${VAR:-default}` env-var interpolation so CI can pass a SHA via an env var (e.g. `since: ${ALINT_BASE_SHA:-origin/main}` with `ALINT_BASE_SHA` exported in a workflow step from `github.event.pull_request.base.sha`). The GitHub Actions double-brace template syntax `${{ ... }}` is NOT interpolated by alint.",
           "type": [
             "string",
             "null"
@@ -2079,7 +2080,7 @@
         },
         "subject_max_length": {
           "default": null,
-          "description": "Maximum number of characters allowed in the subject line. Common\nvalues: 50 (Tim Pope's recommendation), 72 (GitHub PR-title cutoff).",
+          "description": "Maximum number of characters allowed in the subject line. Common values: 50 (Tim Pope's recommendation), 72 (GitHub PR-title cutoff).",
           "format": "uint",
           "minimum": 1,
           "type": [
@@ -2095,7 +2096,7 @@
       "properties": {
         "include_merges": {
           "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error.",
           "type": "boolean"
         },
         "kind": {
@@ -2103,7 +2104,7 @@
         },
         "since": {
           "default": null,
-          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does.",
+          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
           "type": [
             "string",
             "null"
@@ -2117,7 +2118,7 @@
       "properties": {
         "include_merges": {
           "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error.",
           "type": "boolean"
         },
         "kind": {
@@ -2125,7 +2126,7 @@
         },
         "pattern": {
           "default": null,
-          "description": "Trailer pattern each commit message must contain. Defaults to the\ncanonical DCO sign-off shape. Override to enforce a stricter form\n(e.g. a corporate-domain email).",
+          "description": "Trailer pattern each commit message must contain. Defaults to the canonical DCO sign-off shape `(?m)^Signed-off-by: .+ <.+@.+>$`. Override to enforce a stricter form (e.g. a corporate-domain email).",
           "type": [
             "string",
             "null"
@@ -2133,7 +2134,7 @@
         },
         "since": {
           "default": null,
-          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does.",
+          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
           "type": [
             "string",
             "null"
@@ -2147,7 +2148,7 @@
       "properties": {
         "include_merges": {
           "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error.",
           "type": "boolean"
         },
         "kind": {
@@ -2159,7 +2160,7 @@
         },
         "since": {
           "default": null,
-          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD.",
+          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
           "type": [
             "string",
             "null"
@@ -2175,7 +2176,7 @@
       "description": "Fire when any tracked path matches a configured glob denylist. Companion of `git_tracked_only` for the absence axis: catches secrets, large binaries, or accidentally-tracked artifacts that would otherwise need a `file_absent` per pattern. With `since:` set, only paths changed in the `<since>...HEAD` diff are flagged (PR-scoped). Outside a git repo, silently no-ops; a `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
       "properties": {
         "denied": {
-          "description": "Globset patterns no tracked path may match. Both whole-path patterns\n(`secrets/**`) and basename-only patterns (`*.env`) work.",
+          "description": "Globset patterns no tracked path may match. Both whole-path patterns (`secrets/**`) and basename-only patterns (`*.env`) work.",
           "items": {
             "type": "string"
           },
@@ -2187,7 +2188,7 @@
         },
         "since": {
           "default": null,
-          "description": "Optional git ref. When set, only denied paths that changed in the\n`<since>...HEAD` diff are flagged, catches a secret added in a PR even if\nHEAD's tree still tracks an older one. Accepts the `{{env.X}}`\ninterpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
+          "description": "Optional git ref. When set, only denied paths that changed in the `<since>...HEAD` diff are flagged, catches a secret added in a PR even if HEAD's tree still tracks an older one. Accepts the `{{env.X}}` interpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
           "type": [
             "string",
             "null"
@@ -2258,11 +2259,11 @@
         },
         "style": {
           "$ref": "#/$defs/StyleName",
-          "description": "Required indentation style: `tabs` rejects any leading space; `spaces`\nrejects any leading tab."
+          "description": "Required indentation style: `tabs` rejects any leading space; `spaces` rejects any leading tab."
         },
         "width": {
           "default": null,
-          "description": "When `style: spaces`, the leading-space count on every non-blank line\nmust be a multiple of this. Ignored for `style: tabs`.",
+          "description": "When `style: spaces`, the leading-space count on every non-blank line must be a multiple of this. Ignored for `style: tabs`.",
           "format": "uint32",
           "minimum": 1,
           "type": [
@@ -2611,7 +2612,7 @@
         },
         "target": {
           "$ref": "#/$defs/TargetName",
-          "description": "Required line ending style: `lf` or `crlf`. Mixed endings within a\nfile also fail."
+          "description": "Required line ending style: `lf` or `crlf`. Mixed endings within a file also fail."
         }
       },
       "required": [
@@ -2647,7 +2648,7 @@
       "properties": {
         "ignore_template_vars": {
           "default": true,
-          "description": "Skip backticked tokens containing template-variable\nmarkers (`{{ }}`, `${ }`, `<…>`). Default true.",
+          "description": "When true (default), skip backticked tokens containing `{{ ... }}`, `${ ... }`, or `<...>` template-variable markers. These are placeholders, not real paths.",
           "type": "boolean"
         },
         "kind": {
@@ -2657,7 +2658,7 @@
           "$ref": "#/$defs/paths_spec"
         },
         "prefixes": {
-          "description": "Whitelist of path-shape prefixes to validate. A backticked\ntoken must start with one of these to be considered a path\ncandidate. No defaults — every project's layout differs and\nthe user must declare which prefixes mark a path.",
+          "description": "Whitelist of path-shape prefixes to validate. A backticked token must start with one of these to be considered a path candidate. No defaults — every project's layout differs and the user must declare which prefixes mark a path.",
           "items": {
             "type": "string"
           },
@@ -2678,7 +2679,7 @@
           "const": "max_consecutive_blank_lines"
         },
         "max": {
-          "description": "Maximum number of blank lines allowed in a row. `0` means\nno blank lines at all.",
+          "description": "Maximum number of blank lines allowed in a row. `0` means no blank lines at all.",
           "format": "uint32",
           "minimum": 0,
           "type": "integer"
@@ -2722,7 +2723,7 @@
           "const": "max_files_per_directory"
         },
         "max_files": {
-          "description": "Maximum number of in-scope files allowed as immediate children\nof any one directory (non-recursive).",
+          "description": "Maximum number of in-scope files allowed as immediate children of any one directory (non-recursive).",
           "format": "uint",
           "minimum": 1,
           "type": "integer"
@@ -2894,7 +2895,7 @@
       "properties": {
         "comparator": {
           "$ref": "#/$defs/Comparator",
-          "description": "Comparator used to order entries: lexical (default), lexical-ci, or\nnumeric."
+          "description": "Comparator used to order entries: lexical (default), lexical-ci, or numeric."
         },
         "end": {
           "default": null,
@@ -2912,7 +2913,7 @@
         },
         "select": {
           "default": null,
-          "description": "Regex; when set, only lines inside a block matching it are sortable\nentries (others, such as comments or group headers, pass through).",
+          "description": "Regex; when set, only lines inside a block matching it are sortable entries (others, such as comments or group headers, pass through). The sectioned / keep-sorted-subset shape.",
           "type": [
             "string",
             "null"
@@ -2920,7 +2921,7 @@
         },
         "start": {
           "default": null,
-          "description": "Marker line opening a block (matched on the trimmed line). Optional -\nomit to anchor the block at the start of the file.",
+          "description": "Marker line opening a block (matched on the trimmed line). Optional - omit to anchor the block at the start of the file.",
           "type": [
             "string",
             "null"
@@ -2959,18 +2960,18 @@
       "description": "If the `<since>...HEAD` diff changes any path matching `if_changed:`, at least one path matching `then_changed:` must change in the same range — the co-change gate (a FORMAT_VERSION must bump when the format struct changes; version.txt and the lockfile change together). Both globs and `since:` (the base ref) are required. Directional: a `then_changed`-only change never triggers it (add a second rule with the globs swapped for a bidirectional pact). Diff-scoped: silent no-op outside a git repo / when `if_changed` didn't change; a `since:` that fails to resolve hard-fails with a shallow-clone hint. Check-only.",
       "properties": {
         "if_changed": {
-          "description": "Glob; the trigger. When the diff changes a path matching this, a\n`then_changed` co-change is required.",
+          "description": "Glob; the trigger. When the diff changes a path matching this, a `then_changed` co-change is required.",
           "type": "string"
         },
         "kind": {
           "const": "pair_changed_together"
         },
         "since": {
-          "description": "Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}`\ninterpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
+          "description": "Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}` interpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
           "type": "string"
         },
         "then_changed": {
-          "description": "Glob; the obligation. At least one changed path must match it whenever\n`if_changed` fired.",
+          "description": "Glob; the obligation. At least one changed path must match it whenever `if_changed` fired.",
           "type": "string"
         }
       },
@@ -2982,7 +2983,7 @@
       "type": "object"
     },
     "rule_pair_hash": {
-      "description": "Cross-file: the `algorithm` digest of every file matching `source` must appear in the single `target` file — either as an embedded hex substring (`format: contains`, the default) or a coreutils / go-`.sum`-style `<hex>  <path>` manifest line (`format: sums-line`). Detection-only (alint never rewrites the manifest). A missing `target` is one violation; one violation per source whose digest is absent or mismatched. golang/go FIPS `fips140.sum` is the canonical use.",
+      "description": "Cross-file: the `algorithm` digest of every file matching `source` must appear in the single `target` file — either as an embedded hex substring (`format: contains`, the default) or a coreutils / go-`.sum`-style `<hex> <path>` manifest line (`format: sums-line`). Detection-only (alint never rewrites the manifest). A missing `target` is one violation; one violation per source whose digest is absent or mismatched. golang/go FIPS `fips140.sum` is the canonical use.",
       "properties": {
         "algorithm": {
           "$ref": "#/$defs/Algorithm",
@@ -2990,17 +2991,17 @@
         },
         "format": {
           "$ref": "#/$defs/Format",
-          "description": "How the digest must appear in `target`: `contains` = hex\nsubstring anywhere (default); `sums-line` = a `<hex> [*]<path>`\nline whose path token is the source's path."
+          "description": "How the digest must appear in `target`: `contains` = hex substring anywhere (default); `sums-line` = a `<hex> [*]<path>` line whose path token is the source's path."
         },
         "kind": {
           "const": "pair_hash"
         },
         "source": {
-          "description": "Literal path or glob selecting the file(s) whose content is\nhashed (one check per match).",
+          "description": "Literal path or glob selecting the file(s) whose content is hashed (one check per match).",
           "type": "string"
         },
         "target": {
-          "description": "The single file that must carry the digest (a `.sum` /\n`SHA256SUMS` / a file with an embedded hash).",
+          "description": "The single file that must carry the digest (a `.sum` / `SHA256SUMS` / a file with an embedded hash).",
           "type": "string"
         }
       },
@@ -3207,7 +3208,7 @@
       "properties": {
         "case_insensitive": {
           "default": false,
-          "description": "Fold the key to lowercase before grouping, so keys that\ncollide only under case-folding count as duplicates — the\ncase-insensitive-filesystem hazard (Windows / macOS).",
+          "description": "Fold the key to lowercase before grouping, so keys that collide only under case-folding count as duplicates — the case-insensitive-filesystem hazard (Windows / macOS).",
           "type": "boolean"
         },
         "key": {
@@ -3430,7 +3431,7 @@
       ]
     },
     "extends": {
-      "description": "Configs to inherit from. Each entry is either a bare string (local path, `https://` URL with SRI, or `alint://bundled/<name>@<rev>`) or a mapping `{url, only?, except?}` that filters the inherited rule set before merging.\n\nEntries resolved left-to-right; later entries override earlier ones, and the current file's own definitions override everything it extends.\n\n**Rule merging is field-level by `id`.** A child can override just the fields it wants to change — `rules: [{id: inherited, level: warning}]` keeps the parent's `kind`/`paths`/etc. and only downgrades severity. `{id: inherited, level: off}` disables a rule without redeclaring it.\n\n**Selective adoption** via `only:` (keep these ids, drop everything else) or `except:` (drop these ids). The two are mutually exclusive on a single entry. Unknown ids are a load-time error so typos surface immediately.\n\nRemote and bundled configs cannot themselves declare `extends:` (no principled base for relative resolution in a fetched body); nest extends locally instead.",
+      "description": "Configs to inherit from. Each entry is either a bare string (local path, `https://` URL with SRI, or `alint://bundled/<name>@<rev>`) or a mapping `{url, only?, except?}` that filters the inherited rule set before merging. Entries resolved left-to-right; later entries override earlier ones, and the current file's own definitions override everything it extends. **Rule merging is field-level by `id`.** A child can override just the fields it wants to change — `rules: [{id: inherited, level: warning}]` keeps the parent's `kind`/`paths`/etc. and only downgrades severity. `{id: inherited, level: off}` disables a rule without redeclaring it. **Selective adoption** via `only:` (keep these ids, drop everything else) or `except:` (drop these ids). The two are mutually exclusive on a single entry. Unknown ids are a load-time error so typos surface immediately. Remote and bundled configs cannot themselves declare `extends:` (no principled base for relative resolution in a fetched body); nest extends locally instead.",
       "items": {
         "$ref": "#/$defs/extends_entry"
       },

--- a/schemas/v1/config.json
+++ b/schemas/v1/config.json
@@ -1,922 +1,677 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/asamarts/alint/main/schemas/v1/config.json",
-  "title": "alint configuration (v1)",
-  "description": "Schema for .alint.yml configuration files. Authoritative reference: docs/design/ARCHITECTURE.md in the alint repository.",
-  "type": "object",
-  "required": ["version"],
-  "additionalProperties": false,
-  "properties": {
-    "version": {
-      "const": 1,
-      "description": "Config schema version. Always 1 for this schema."
-    },
-    "extends": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/extends_entry" },
-      "description": "Configs to inherit from. Each entry is either a bare string (local path, `https://` URL with SRI, or `alint://bundled/<name>@<rev>`) or a mapping `{url, only?, except?}` that filters the inherited rule set before merging.\n\nEntries resolved left-to-right; later entries override earlier ones, and the current file's own definitions override everything it extends.\n\n**Rule merging is field-level by `id`.** A child can override just the fields it wants to change — `rules: [{id: inherited, level: warning}]` keeps the parent's `kind`/`paths`/etc. and only downgrades severity. `{id: inherited, level: off}` disables a rule without redeclaring it.\n\n**Selective adoption** via `only:` (keep these ids, drop everything else) or `except:` (drop these ids). The two are mutually exclusive on a single entry. Unknown ids are a load-time error so typos surface immediately.\n\nRemote and bundled configs cannot themselves declare `extends:` (no principled base for relative resolution in a fetched body); nest extends locally instead."
-    },
-    "ignore": {
-      "type": "array",
-      "items": { "type": "string" },
-      "description": "Additional glob patterns excluded on top of .gitignore."
-    },
-    "respect_gitignore": {
-      "type": "boolean",
-      "default": true,
-      "description": "Whether to honor .gitignore files during the walk."
-    },
-    "vars": {
-      "type": "object",
-      "additionalProperties": { "type": "string" },
-      "description": "Free-form string variables referenced from rule messages as {{vars.<name>}} and from `when` clauses as vars.<name>."
-    },
-    "facts": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/fact" },
-      "description": "Properties of the repository evaluated once per run; referenced from `when` clauses as facts.<id>."
-    },
-    "rules": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/rule" },
-      "description": "Rules evaluated against the repository tree."
-    },
-    "templates": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/template" },
-      "description": "Reusable rule shapes referenced by `extends_template:` in `rules:` entries. Each template carries an `id:` and any other rule-spec fields; `{{vars.<name>}}` placeholders in those fields substitute from each instance's `vars:` map at expansion time. Templates are leaf-only — a template may not itself `extends_template:` another. Templates merge through the `extends:` chain by id, so a downstream config can override an upstream template's body."
-    },
-    "fix_size_limit": {
-      "type": ["integer", "null"],
-      "minimum": 0,
-      "default": 1048576,
-      "description": "Max bytes a content-editing fix will touch. Files over this limit are reported as Skipped with a stderr warning. Default: 1 MiB. Explicit null disables the cap. Path-only fixes (file_create, file_remove, file_rename) ignore this setting."
-    },
-    "nested_configs": {
-      "type": "boolean",
-      "default": false,
-      "description": "Opt in to discovery of nested `.alint.yml` / `.alint.yaml` files in subdirectories. When true, the loader walks the tree from this config's directory (honoring `.gitignore` + `ignore`) and finds any nested config files. Each nested rule's path-like scope fields (`paths`, `select`, `primary`) are automatically prefixed with the nested config's relative directory, so rules declared in `packages/frontend/.alint.yml` apply only under `packages/frontend/**`. Id collisions across configs are rejected with a clear error — per-subtree overrides aren't supported in this release (use `when:` on the root rule for that). Only the root config sets this; nested configs can't spawn further nested discovery."
-    },
-    "allow_out_of_root": {
-      "description": "Top-level-only escape hatch for path confinement: permit rules to read a config-declared path that escapes the repo root. `true` allows every rule; a map `{ kinds: [...], rules: [...] }` allows only the listed rule kinds / ids. Absent or `false` keeps the secure default (every config-derived path read is confined). REJECTED from `extends:`'d rulesets — only the user's own top-level config may set it. Applies to file reads (currently `registry_paths_resolve` source, `json_schema_passes` schema_path, `pair_hash` target); resolve/index checks stay confined. Permitted reads emit an informational note. See docs/design/v0.12/allow_out_of_root.md.",
-      "oneOf": [
-        { "type": "boolean" },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "kinds": {
-              "type": "array",
-              "items": { "type": "string" },
-              "description": "Rule kinds permitted to read out of the repo root."
-            },
-            "rules": {
-              "type": "array",
-              "items": { "type": "string" },
-              "description": "Rule ids permitted to read out of the repo root."
-            }
-          }
-        }
-      ]
-    }
-  },
-
   "$defs": {
-    "level": {
-      "type": "string",
-      "enum": ["error", "warning", "info", "off"],
-      "description": "Severity. `off` disables a rule (useful when overriding inherited rules)."
+    "case_convention": {
+      "description": "Case convention. Aliases like PascalCase / pascal / pascal-case / UpperCamelCase all resolve to the same canonical form.",
+      "enum": [
+        "lower",
+        "lowercase",
+        "upper",
+        "uppercase",
+        "pascal",
+        "pascalcase",
+        "PascalCase",
+        "UpperCamelCase",
+        "upper_camel",
+        "upper_camel_case",
+        "camel",
+        "camelcase",
+        "camelCase",
+        "lowerCamelCase",
+        "lower_camel",
+        "lower_camel_case",
+        "snake",
+        "snakecase",
+        "snake_case",
+        "kebab",
+        "kebabcase",
+        "kebab-case",
+        "dash",
+        "dashcase",
+        "dash-case",
+        "screaming-snake",
+        "screamingsnake",
+        "screamingsnakecase",
+        "SCREAMING_SNAKE_CASE",
+        "upper_snake",
+        "upper_snake_case",
+        "flat",
+        "flatcase"
+      ],
+      "type": "string"
     },
-
-    "rule_id": {
-      "type": "string",
-      "pattern": "^[a-z][a-z0-9_-]*$",
-      "description": "Unique kebab-case identifier for the rule."
-    },
-
-    "string_or_string_array": {
-      "oneOf": [
-        { "type": "string" },
-        { "type": "array", "items": { "type": "string" } }
-      ]
-    },
-
     "extends_entry": {
       "description": "One extends entry. Bare string = classic form (url-only). Mapping form lets you filter with `only:` / `except:` (mutually exclusive).",
       "oneOf": [
-        { "type": "string" },
         {
-          "type": "object",
-          "required": ["url"],
+          "type": "string"
+        },
+        {
           "additionalProperties": false,
           "properties": {
-            "url": {
-              "type": "string",
-              "description": "Local path, `https://...#sha256-<hex>`, or `alint://bundled/<name>@<rev>`."
+            "except": {
+              "description": "Drop these rule ids from the extended config.",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
             },
             "only": {
-              "type": "array",
-              "items": { "type": "string" },
+              "description": "Keep only these rule ids from the extended config; drop everything else.",
+              "items": {
+                "type": "string"
+              },
               "minItems": 1,
-              "description": "Keep only these rule ids from the extended config; drop everything else."
+              "type": "array"
             },
-            "except": {
-              "type": "array",
-              "items": { "type": "string" },
-              "minItems": 1,
-              "description": "Drop these rule ids from the extended config."
+            "url": {
+              "description": "Local path, `https://...#sha256-<hex>`, or `alint://bundled/<name>@<rev>`.",
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "url"
+          ],
+          "type": "object"
         }
       ]
     },
-
-    "paths_spec": {
-      "description": "A single glob, an array of globs (with optional `!negation`), or an explicit include/exclude pair.",
-      "oneOf": [
-        { "type": "string" },
-        {
-          "type": "array",
-          "items": { "type": "string" }
+    "extract_spec": {
+      "additionalProperties": false,
+      "description": "Exactly one of: toml/json/yaml (RFC 9535 JSONPath string), lines (object; optional `comment` prefix, default `#`), regex (string; capture group 1 is the value), whole_file (object `{}`; the entire file content as one value — for byte-level cross_file comparison; the non-literal skip does not apply).",
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "json": {
+          "type": "string"
         },
-        {
-          "type": "object",
+        "lines": {
           "additionalProperties": false,
           "properties": {
-            "include": { "$ref": "#/$defs/string_or_string_array" },
-            "exclude": { "$ref": "#/$defs/string_or_string_array" }
-          }
+            "comment": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "regex": {
+          "type": "string"
+        },
+        "toml": {
+          "type": "string"
+        },
+        "whole_file": {
+          "additionalProperties": false,
+          "type": "object"
+        },
+        "yaml": {
+          "type": "string"
         }
-      ]
+      },
+      "type": "object"
     },
-
-    "case_convention": {
-      "type": "string",
-      "description": "Case convention. Aliases like PascalCase / pascal / pascal-case / UpperCamelCase all resolve to the same canonical form.",
-      "enum": [
-        "lower", "lowercase",
-        "upper", "uppercase",
-        "pascal", "pascalcase", "PascalCase", "UpperCamelCase", "upper_camel", "upper_camel_case",
-        "camel", "camelcase", "camelCase", "lowerCamelCase", "lower_camel", "lower_camel_case",
-        "snake", "snakecase", "snake_case",
-        "kebab", "kebabcase", "kebab-case", "dash", "dashcase", "dash-case",
-        "screaming-snake", "screamingsnake", "screamingsnakecase", "SCREAMING_SNAKE_CASE", "upper_snake", "upper_snake_case",
-        "flat", "flatcase"
-      ]
-    },
-
-    "rule_common": {
-      "type": "object",
-      "required": ["id", "kind", "level"],
-      "properties": {
-        "id": { "$ref": "#/$defs/rule_id" },
-        "kind": {
-          "type": "string",
-          "description": "The primitive rule kind. See docs/design/ARCHITECTURE.md §4.4 for the full catalog."
-        },
-        "level": { "$ref": "#/$defs/level" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "message": {
-          "type": "string",
-          "description": "Override the default failure message. Supports `{{vars.*}}` and `{{ctx.*}}` substitution."
-        },
-        "policy_url": {
-          "type": "string",
-          "format": "uri",
-          "description": "Link to a human-readable policy justification."
-        },
-        "when": {
-          "type": "string",
-          "description": "Gate the rule on a fact-based expression (available from v0.2)."
-        },
-        "scope_filter": { "$ref": "#/$defs/scope_filter" },
-        "fix": { "$ref": "#/$defs/fix" }
-      }
-    },
-
-    "fix": {
-      "description": "Automatic-fix strategy applied by `alint fix`. Each rule kind accepts a specific op — alint errors at load time when the op and kind are incompatible.",
-      "type": "object",
+    "fact": {
+      "description": "A single fact declaration. Each fact has an `id` plus exactly one kind-specific field.",
       "oneOf": [
         {
-          "type": "object",
-          "required": ["file_create"],
+          "properties": {
+            "any_file_exists": {
+              "$ref": "#/$defs/string_or_string_array"
+            }
+          },
+          "required": [
+            "any_file_exists"
+          ]
+        },
+        {
+          "properties": {
+            "all_files_exist": {
+              "$ref": "#/$defs/string_or_string_array"
+            }
+          },
+          "required": [
+            "all_files_exist"
+          ]
+        },
+        {
+          "properties": {
+            "count_files": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "count_files"
+          ]
+        },
+        {
+          "properties": {
+            "file_content_matches": {
+              "additionalProperties": false,
+              "properties": {
+                "paths": {
+                  "$ref": "#/$defs/string_or_string_array"
+                },
+                "pattern": {
+                  "description": "Rust-regex pattern matched against the content of every file in `paths`. The fact is true iff at least one file contains a match. Non-UTF-8 files are skipped.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "paths",
+                "pattern"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "file_content_matches"
+          ]
+        },
+        {
+          "properties": {
+            "git_branch": {
+              "additionalProperties": false,
+              "description": "Read `<repo>/.git/HEAD` and return the current branch name (string). Detached HEAD, no `.git/` directory, or any unrecognized layout resolves to an empty string (falsy under `when:`).",
+              "properties": {},
+              "type": "object"
+            }
+          },
+          "required": [
+            "git_branch"
+          ]
+        },
+        {
+          "properties": {
+            "custom": {
+              "additionalProperties": false,
+              "properties": {
+                "argv": {
+                  "description": "Program + arguments, passed verbatim to the OS (no shell). Fact value is the process's stdout (trimmed). Non-zero exit, spawn failure, or non-UTF-8 output all resolve to an empty string. SECURITY: `custom:` is only valid in the user's top-level config — alint refuses to load an extended config that declares one.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "required": [
+                "argv"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "custom"
+          ]
+        }
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/rule_id"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object",
+      "unevaluatedProperties": false
+    },
+    "fix": {
+      "description": "Automatic-fix strategy applied by `alint fix`. Each rule kind accepts a specific op — alint errors at load time when the op and kind are incompatible.",
+      "oneOf": [
+        {
           "additionalProperties": false,
           "properties": {
             "file_create": {
-              "type": "object",
               "additionalProperties": false,
               "oneOf": [
-                { "required": ["content"] },
-                { "required": ["content_from"] }
+                {
+                  "required": [
+                    "content"
+                  ]
+                },
+                {
+                  "required": [
+                    "content_from"
+                  ]
+                }
               ],
               "properties": {
                 "content": {
-                  "type": "string",
-                  "description": "Literal bytes to write. Mutually exclusive with `content_from`. Pass \"\" for an empty file."
+                  "description": "Literal bytes to write. Mutually exclusive with `content_from`. Pass \"\" for an empty file.",
+                  "type": "string"
                 },
                 "content_from": {
-                  "type": "string",
-                  "description": "Path to a file whose bytes will be the content, relative to the lint root. Mutually exclusive with `content`. Read at fix-apply time; missing source produces a `Skipped` outcome rather than an error. Useful for LICENSE / NOTICE / boilerplate too long to inline."
-                },
-                "path": {
-                  "type": "string",
-                  "description": "Target path, relative to the repo root. When omitted, the first literal entry from the rule's `paths:` list is used."
+                  "description": "Path to a file whose bytes will be the content, relative to the lint root. Mutually exclusive with `content`. Read at fix-apply time; missing source produces a `Skipped` outcome rather than an error. Useful for LICENSE / NOTICE / boilerplate too long to inline.",
+                  "type": "string"
                 },
                 "create_parents": {
-                  "type": "boolean",
                   "default": true,
-                  "description": "Create intermediate directories if missing."
+                  "description": "Create intermediate directories if missing.",
+                  "type": "boolean"
+                },
+                "path": {
+                  "description": "Target path, relative to the repo root. When omitted, the first literal entry from the rule's `paths:` list is used.",
+                  "type": "string"
                 }
-              }
+              },
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_create"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_remove"],
           "additionalProperties": false,
           "properties": {
             "file_remove": {
-              "type": "object",
               "additionalProperties": false,
-              "properties": {}
+              "properties": {},
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_remove"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_prepend"],
           "additionalProperties": false,
           "properties": {
             "file_prepend": {
-              "type": "object",
               "additionalProperties": false,
               "oneOf": [
-                { "required": ["content"] },
-                { "required": ["content_from"] }
+                {
+                  "required": [
+                    "content"
+                  ]
+                },
+                {
+                  "required": [
+                    "content_from"
+                  ]
+                }
               ],
               "properties": {
                 "content": {
-                  "type": "string",
-                  "description": "Bytes to insert at the start of each violating file. Mutually exclusive with `content_from`. A trailing newline is the caller's responsibility."
+                  "description": "Bytes to insert at the start of each violating file. Mutually exclusive with `content_from`. A trailing newline is the caller's responsibility.",
+                  "type": "string"
                 },
                 "content_from": {
-                  "type": "string",
-                  "description": "Path to a file whose bytes will be prepended, relative to the lint root. Mutually exclusive with `content`. Read at fix-apply time."
+                  "description": "Path to a file whose bytes will be prepended, relative to the lint root. Mutually exclusive with `content`. Read at fix-apply time.",
+                  "type": "string"
                 }
-              }
+              },
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_prepend"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_append"],
           "additionalProperties": false,
           "properties": {
             "file_append": {
-              "type": "object",
               "additionalProperties": false,
               "oneOf": [
-                { "required": ["content"] },
-                { "required": ["content_from"] }
+                {
+                  "required": [
+                    "content"
+                  ]
+                },
+                {
+                  "required": [
+                    "content_from"
+                  ]
+                }
               ],
               "properties": {
                 "content": {
-                  "type": "string",
-                  "description": "Bytes to append to each violating file. Mutually exclusive with `content_from`. A leading newline is the caller's responsibility."
+                  "description": "Bytes to append to each violating file. Mutually exclusive with `content_from`. A leading newline is the caller's responsibility.",
+                  "type": "string"
                 },
                 "content_from": {
-                  "type": "string",
-                  "description": "Path to a file whose bytes will be appended, relative to the lint root. Mutually exclusive with `content`. Read at fix-apply time."
+                  "description": "Path to a file whose bytes will be appended, relative to the lint root. Mutually exclusive with `content`. Read at fix-apply time.",
+                  "type": "string"
                 }
-              }
+              },
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_append"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_rename"],
           "additionalProperties": false,
           "properties": {
             "file_rename": {
-              "type": "object",
               "additionalProperties": false,
+              "description": "Rename the violating file's stem to the parent rule's target convention (e.g. filename_case's `case:`). Extension is preserved; the file stays in the same directory. No parameters.",
               "properties": {},
-              "description": "Rename the violating file's stem to the parent rule's target convention (e.g. filename_case's `case:`). Extension is preserved; the file stays in the same directory. No parameters."
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_rename"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_trim_trailing_whitespace"],
           "additionalProperties": false,
           "properties": {
             "file_trim_trailing_whitespace": {
-              "type": "object",
               "additionalProperties": false,
+              "description": "Read the violating file, strip trailing space/tab on every line, write back. Preserves LF or CRLF endings. Skipped on files larger than `fix_size_limit`.",
               "properties": {},
-              "description": "Read the violating file, strip trailing space/tab on every line, write back. Preserves LF or CRLF endings. Skipped on files larger than `fix_size_limit`."
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_trim_trailing_whitespace"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_append_final_newline"],
           "additionalProperties": false,
           "properties": {
             "file_append_final_newline": {
-              "type": "object",
               "additionalProperties": false,
+              "description": "Append a single `\\n` byte when the file has content but doesn't end with one. No-op on empty files.",
               "properties": {},
-              "description": "Append a single `\\n` byte when the file has content but doesn't end with one. No-op on empty files."
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_append_final_newline"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_normalize_line_endings"],
           "additionalProperties": false,
           "properties": {
             "file_normalize_line_endings": {
-              "type": "object",
               "additionalProperties": false,
+              "description": "Rewrite every line ending in the file to the parent rule's `target` (lf or crlf). Skipped on files larger than `fix_size_limit`.",
               "properties": {},
-              "description": "Rewrite every line ending in the file to the parent rule's `target` (lf or crlf). Skipped on files larger than `fix_size_limit`."
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_normalize_line_endings"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_strip_bidi"],
           "additionalProperties": false,
           "properties": {
             "file_strip_bidi": {
-              "type": "object",
               "additionalProperties": false,
+              "description": "Remove every Unicode bidi control character (U+202A–202E, U+2066–2069). Skipped on files larger than `fix_size_limit` or on non-UTF-8 content.",
               "properties": {},
-              "description": "Remove every Unicode bidi control character (U+202A–202E, U+2066–2069). Skipped on files larger than `fix_size_limit` or on non-UTF-8 content."
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_strip_bidi"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_strip_zero_width"],
           "additionalProperties": false,
           "properties": {
             "file_strip_zero_width": {
-              "type": "object",
               "additionalProperties": false,
+              "description": "Remove every zero-width character (U+200B/C/D, body-internal U+FEFF). A leading BOM is preserved — use `no_bom` to strip that.",
               "properties": {},
-              "description": "Remove every zero-width character (U+200B/C/D, body-internal U+FEFF). A leading BOM is preserved — use `no_bom` to strip that."
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_strip_zero_width"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_strip_bom"],
           "additionalProperties": false,
           "properties": {
             "file_strip_bom": {
-              "type": "object",
               "additionalProperties": false,
+              "description": "Remove a leading UTF-8 / UTF-16 / UTF-32 BOM from the file. No-op when no BOM is present.",
               "properties": {},
-              "description": "Remove a leading UTF-8 / UTF-16 / UTF-32 BOM from the file. No-op when no BOM is present."
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_strip_bom"
+          ],
+          "type": "object"
         },
         {
-          "type": "object",
-          "required": ["file_collapse_blank_lines"],
           "additionalProperties": false,
           "properties": {
             "file_collapse_blank_lines": {
-              "type": "object",
               "additionalProperties": false,
+              "description": "Collapse runs of blank lines longer than the parent rule's `max` down to exactly `max` blank lines. Preserves the file's line endings (LF vs CRLF). Skipped on files larger than `fix_size_limit` or on non-UTF-8 content.",
               "properties": {},
-              "description": "Collapse runs of blank lines longer than the parent rule's `max` down to exactly `max` blank lines. Preserves the file's line endings (LF vs CRLF). Skipped on files larger than `fix_size_limit` or on non-UTF-8 content."
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "file_collapse_blank_lines"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "git_tracked_only": {
+      "default": false,
+      "description": "When true, restrict the rule to files / directories tracked in git's index. Outside a git repo the rule becomes a silent no-op for absence-style checks. Currently supported on `file_exists`, `file_absent`, `dir_exists`, `dir_absent`; other rule kinds ignore the field. See https://alint.org/docs/concepts/walker-and-gitignore/ for the full semantics.",
+      "type": "boolean"
+    },
+    "if_present": {
+      "default": false,
+      "description": "When true, a JSONPath query returning zero matches is silently OK — only real matches that fail the op produce violations. Use for predicates conditional on a field's presence (e.g. \"every `uses:` must be SHA-pinned\" where a workflow without `uses:` steps shouldn't be flagged).",
+      "type": "boolean"
+    },
+    "level": {
+      "description": "Severity. `off` disables a rule (useful when overriding inherited rules).",
+      "enum": [
+        "error",
+        "warning",
+        "info",
+        "off"
+      ],
+      "type": "string"
+    },
+    "nested_rule": {
+      "description": "A nested rule inside `require:`. Unlike top-level rules, `id` and `level` are synthesized from the parent; the user supplies only `kind` plus kind-specific options.",
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "policy_url": {
+          "format": "uri",
+          "type": "string"
+        },
+        "when": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    "paths_spec": {
+      "description": "A single glob, an array of globs (with optional `!negation`), or an explicit include/exclude pair.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "exclude": {
+              "$ref": "#/$defs/string_or_string_array"
+            },
+            "include": {
+              "$ref": "#/$defs/string_or_string_array"
+            }
+          },
+          "type": "object"
         }
       ]
     },
-
+    "per_rule_respect_gitignore": {
+      "description": "Per-rule override for the workspace-level `respect_gitignore:` setting. When `false`, this rule treats `.gitignore`-listed files as if they were untracked-but-on-disk: the rule sees them. The canonical use case is the bazel-style \"tracked AND gitignored\" pattern (a file like `.bazelversion` ships a default upstream and contributors override it locally without committing the override) — the workspace walker honours the gitignore, so `file_exists` reports \"no match\" against a file that's both on disk AND in `git ls-files`. This per-rule knob lets that single rule see the file without flipping the workspace-wide setting. Currently honoured by `file_exists` for literal-path patterns; other rule kinds + glob patterns fall through to the workspace setting. Default: inherit the workspace `respect_gitignore`. See `docs/development/CONFIG-AUTHORING.md` pitfall #18.",
+      "type": "boolean"
+    },
     "rule": {
       "description": "A rule entry — either a kind-driven rule (with `kind` and the kind-specific fields) or a template instance (with `extends_template` referencing a template id and optional `vars` overrides).",
       "oneOf": [
         {
           "allOf": [
-            { "$ref": "#/$defs/rule_common" },
-            { "$ref": "#/$defs/rule_kind_dispatch" }
+            {
+              "$ref": "#/$defs/rule_common"
+            },
+            {
+              "$ref": "#/$defs/rule_kind_dispatch"
+            }
           ],
           "unevaluatedProperties": false
         },
-        { "$ref": "#/$defs/rule_template_instance" }
+        {
+          "$ref": "#/$defs/rule_template_instance"
+        }
       ]
     },
-
-    "rule_template_instance": {
-      "description": "A rule entry that expands a `templates:` body. The instance's `id:` is required; `vars:` provides the substitutions for the template's `{{vars.<name>}}` placeholders. Any other field overrides the corresponding field in the expanded template.",
-      "type": "object",
-      "required": ["id", "extends_template"],
+    "rule_changeset_requires_path": {
+      "description": "The `<since>...HEAD` diff must ADD (git status A) at least one path matching `add_glob:` — the 'did you add a changelog entry?' gate (prettier `changelog_unreleased/`, cpython `Misc/NEWS.d/next/`, pnpm `.changeset/*.md`). `since:` (the base ref) is required. Optional `when_changed:` gates the requirement on some other glob having changed (don't demand a changelog for a docs-only PR); with no gate, any non-empty changeset triggers it. Diff-scoped: silent no-op outside a git repo / when nothing relevant changed; a `since:` that fails to resolve hard-fails with a shallow-clone hint. Check-only.",
       "properties": {
-        "id": { "$ref": "#/$defs/rule_id" },
-        "extends_template": {
-          "type": "string",
-          "description": "Id of an entry in the top-level `templates:` block to instantiate."
+        "add_glob": {
+          "description": "Glob; the diff must ADD at least one path matching it.",
+          "type": "string"
         },
-        "vars": {
-          "type": "object",
-          "additionalProperties": { "type": ["string", "number", "boolean"] },
-          "description": "Map of `name → value` to substitute into `{{vars.<name>}}` placeholders in the template body."
+        "kind": {
+          "const": "changeset_requires_path"
         },
-        "level": { "$ref": "#/$defs/level" },
-        "message": { "type": "string" },
-        "policy_url": { "type": "string", "format": "uri" },
-        "when": { "type": "string" }
-      }
-    },
-
-    "template": {
-      "description": "A reusable rule shape. Identical to a regular rule except `level` is optional (instances may add it) and the body is matched after `{{vars.<name>}}` substitution.",
-      "type": "object",
-      "required": ["id"],
-      "properties": {
-        "id": { "$ref": "#/$defs/rule_id" }
+        "since": {
+          "description": "Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}`\ninterpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
+          "type": "string"
+        },
+        "when_changed": {
+          "default": null,
+          "description": "Optional gate: only require the add when some path matching this glob\nchanged (any status). Omit to require it on any non-empty changeset.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
       },
-      "additionalProperties": true
-    },
-
-    "rule_kind_dispatch": {
-      "description": "Dispatch on the `kind` discriminator. Each branch sets the required kind-specific fields.",
-      "oneOf": [
-        { "$ref": "#/$defs/rule_file_exists" },
-        { "$ref": "#/$defs/rule_file_absent" },
-        { "$ref": "#/$defs/rule_dir_exists" },
-        { "$ref": "#/$defs/rule_dir_absent" },
-        { "$ref": "#/$defs/rule_file_content_matches" },
-        { "$ref": "#/$defs/rule_file_content_forbidden" },
-        { "$ref": "#/$defs/rule_file_header" },
-        { "$ref": "#/$defs/rule_file_max_size" },
-        { "$ref": "#/$defs/rule_file_min_size" },
-        { "$ref": "#/$defs/rule_file_min_lines" },
-        { "$ref": "#/$defs/rule_file_max_lines" },
-        { "$ref": "#/$defs/rule_file_footer" },
-        { "$ref": "#/$defs/rule_file_shebang" },
-        { "$ref": "#/$defs/rule_file_is_text" },
-        { "$ref": "#/$defs/rule_json_path_equals" },
-        { "$ref": "#/$defs/rule_json_path_matches" },
-        { "$ref": "#/$defs/rule_yaml_path_equals" },
-        { "$ref": "#/$defs/rule_yaml_path_matches" },
-        { "$ref": "#/$defs/rule_toml_path_equals" },
-        { "$ref": "#/$defs/rule_toml_path_matches" },
-        { "$ref": "#/$defs/rule_xml_path_equals" },
-        { "$ref": "#/$defs/rule_xml_path_matches" },
-        { "$ref": "#/$defs/rule_json_schema_passes" },
-        { "$ref": "#/$defs/rule_commented_out_code" },
-        { "$ref": "#/$defs/rule_markdown_paths_resolve" },
-        { "$ref": "#/$defs/rule_git_no_denied_paths" },
-        { "$ref": "#/$defs/rule_git_commit_message" },
-        { "$ref": "#/$defs/rule_git_commit_signed_off" },
-        { "$ref": "#/$defs/rule_git_commit_subject_matches" },
-        { "$ref": "#/$defs/rule_git_commit_no_fixup" },
-        { "$ref": "#/$defs/rule_git_commit_author_allowlist" },
-        { "$ref": "#/$defs/rule_git_commit_gpg_signed" },
-        { "$ref": "#/$defs/rule_git_blame_age" },
-        { "$ref": "#/$defs/rule_changeset_requires_path" },
-        { "$ref": "#/$defs/rule_pair_changed_together" },
-        { "$ref": "#/$defs/rule_filename_case" },
-        { "$ref": "#/$defs/rule_filename_regex" },
-        { "$ref": "#/$defs/rule_pair" },
-        { "$ref": "#/$defs/rule_pair_hash" },
-        { "$ref": "#/$defs/rule_registry_paths_resolve" },
-        { "$ref": "#/$defs/rule_cross_file" },
-        { "$ref": "#/$defs/rule_file_graph" },
-        { "$ref": "#/$defs/rule_ordered_block" },
-        { "$ref": "#/$defs/rule_for_each_match" },
-        { "$ref": "#/$defs/rule_generated_file_fresh" },
-        { "$ref": "#/$defs/rule_import_gate" },
-        { "$ref": "#/$defs/rule_command_idempotent" },
-        { "$ref": "#/$defs/rule_for_each_dir" },
-        { "$ref": "#/$defs/rule_for_each_file" },
-        { "$ref": "#/$defs/rule_dir_only_contains" },
-        { "$ref": "#/$defs/rule_unique_by" },
-        { "$ref": "#/$defs/rule_dir_contains" },
-        { "$ref": "#/$defs/rule_every_matching_has" },
-        { "$ref": "#/$defs/rule_no_trailing_whitespace" },
-        { "$ref": "#/$defs/rule_final_newline" },
-        { "$ref": "#/$defs/rule_line_endings" },
-        { "$ref": "#/$defs/rule_line_max_width" },
-        { "$ref": "#/$defs/rule_no_merge_conflict_markers" },
-        { "$ref": "#/$defs/rule_no_bidi_controls" },
-        { "$ref": "#/$defs/rule_no_zero_width_chars" },
-        { "$ref": "#/$defs/rule_file_is_ascii" },
-        { "$ref": "#/$defs/rule_no_bom" },
-        { "$ref": "#/$defs/rule_file_hash" },
-        { "$ref": "#/$defs/rule_max_directory_depth" },
-        { "$ref": "#/$defs/rule_max_files_per_directory" },
-        { "$ref": "#/$defs/rule_no_empty_files" },
-        { "$ref": "#/$defs/rule_no_case_conflicts" },
-        { "$ref": "#/$defs/rule_no_illegal_windows_names" },
-        { "$ref": "#/$defs/rule_no_symlinks" },
-        { "$ref": "#/$defs/rule_executable_bit" },
-        { "$ref": "#/$defs/rule_executable_has_shebang" },
-        { "$ref": "#/$defs/rule_shebang_has_executable" },
-        { "$ref": "#/$defs/rule_no_submodules" },
-        { "$ref": "#/$defs/rule_indent_style" },
-        { "$ref": "#/$defs/rule_max_consecutive_blank_lines" },
-        { "$ref": "#/$defs/rule_file_starts_with" },
-        { "$ref": "#/$defs/rule_file_ends_with" },
-        { "$ref": "#/$defs/rule_command" }
-      ]
-    },
-
-    "nested_rule": {
-      "description": "A nested rule inside `require:`. Unlike top-level rules, `id` and `level` are synthesized from the parent; the user supplies only `kind` plus kind-specific options.",
-      "type": "object",
-      "required": ["kind"],
-      "properties": {
-        "kind": { "type": "string" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "message": { "type": "string" },
-        "policy_url": { "type": "string", "format": "uri" },
-        "when": { "type": "string" }
-      }
-    },
-
-    "rule_file_exists": {
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "file_exists" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "root_only": {
-          "type": "boolean",
-          "default": false,
-          "description": "If true, only files directly at the repository root satisfy the rule."
-        },
-        "git_tracked_only": { "$ref": "#/$defs/git_tracked_only" },
-        "respect_gitignore": { "$ref": "#/$defs/per_rule_respect_gitignore" }
-      }
-    },
-
-    "rule_file_absent": {
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "file_absent" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "git_tracked_only": { "$ref": "#/$defs/git_tracked_only" }
-      }
-    },
-
-    "rule_dir_exists": {
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "dir_exists" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "git_tracked_only": { "$ref": "#/$defs/git_tracked_only" }
-      }
-    },
-
-    "rule_dir_absent": {
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "dir_absent" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "git_tracked_only": { "$ref": "#/$defs/git_tracked_only" }
-      }
-    },
-
-    "git_tracked_only": {
-      "type": "boolean",
-      "default": false,
-      "description": "When true, restrict the rule to files / directories tracked in git's index. Outside a git repo the rule becomes a silent no-op for absence-style checks. Currently supported on `file_exists`, `file_absent`, `dir_exists`, `dir_absent`; other rule kinds ignore the field. See https://alint.org/docs/concepts/walker-and-gitignore/ for the full semantics."
-    },
-
-    "per_rule_respect_gitignore": {
-      "type": "boolean",
-      "description": "Per-rule override for the workspace-level `respect_gitignore:` setting. When `false`, this rule treats `.gitignore`-listed files as if they were untracked-but-on-disk: the rule sees them. The canonical use case is the bazel-style \"tracked AND gitignored\" pattern (a file like `.bazelversion` ships a default upstream and contributors override it locally without committing the override) — the workspace walker honours the gitignore, so `file_exists` reports \"no match\" against a file that's both on disk AND in `git ls-files`. This per-rule knob lets that single rule see the file without flipping the workspace-wide setting. Currently honoured by `file_exists` for literal-path patterns; other rule kinds + glob patterns fall through to the workspace setting. Default: inherit the workspace `respect_gitignore`. See `docs/development/CONFIG-AUTHORING.md` pitfall #18."
-    },
-
-    "scope_filter": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "Per-file rule scoping. `has_ancestor` (v0.9.6+) admits files whose ancestor chain contains a named manifest; `changed_since` (v0.11+) admits files in a `<ref>...HEAD` git diff. At least one must be set; setting both is an AND. Supported on per-file rules and on `dir_absent` (since v0.9.18). Cross-file rules (`pair`, `for_each_dir`, `file_exists`, etc.) reject `scope_filter:` at build time. Combine with the rule's existing `paths:` glob — all gates must match for the rule to fire.",
-      "anyOf": [
-        { "required": ["has_ancestor"] },
-        { "required": ["changed_since"] }
+      "required": [
+        "add_glob",
+        "since"
       ],
+      "type": "object"
+    },
+    "rule_command": {
+      "description": "Shell out to an external CLI per matched file. argv[0] is the program; remaining tokens support path-template substitution (`{path}`, `{dir}`, `{stem}`, `{ext}`, `{basename}`, `{parent_name}`). Working dir = repo root; stdin = /dev/null. Env: ALINT_PATH, ALINT_ROOT, ALINT_RULE_ID, ALINT_LEVEL, plus ALINT_VAR_<NAME> per `vars:` and ALINT_FACT_<NAME> per resolved fact. Verdict: exit 0 = pass; non-zero = one violation whose message is the (truncated) stdout+stderr. Trust-gated: only allowed in the user's top-level config (rejected at load-time when introduced via `extends:` or a bundled ruleset).",
       "properties": {
-        "has_ancestor": {
-          "description": "Manifest filename (or list of filenames) whose presence in any ancestor directory of the linted file admits the rule. Each entry is a literal filename like `Cargo.toml` or `package.json` — no path separators, no glob metacharacters; the ancestor walk handles \"anywhere up the tree\" by traversing `Path::parent()` upward.",
-          "oneOf": [
-            { "type": "string", "minLength": 1 },
-            {
-              "type": "array",
-              "minItems": 1,
-              "items": { "type": "string", "minLength": 1 }
-            }
+        "command": {
+          "description": "Argv tokens. The first token is the program (looked up via PATH if it's a bare name); remaining tokens accept `{path}` and friends.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "kind": {
+          "const": "command"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "timeout": {
+          "description": "Per-file timeout in seconds. Default 30. Past this, the child is killed and a violation reports the timeout.",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "paths",
+        "command"
+      ],
+      "type": "object"
+    },
+    "rule_command_idempotent": {
+      "description": "Run a user-declared formatter/checker in its --check (idempotence) mode once: exit 0 = the tree is formatter-clean (silent), non-zero = violation(s). alint never runs a mutating formatter and never writes the tree (the sibling of generated_file_fresh; same trust tier as the command rule — trust-gated to the user's own top-level config). With `files_from` (+ optional `files_pattern`) the tool's offender list is parsed into one violation per file. Single-shot, opt-in.",
+      "properties": {
+        "command": {
+          "description": "Checker argv (no shell), run in its --check / idempotence mode; exit 0 = clean.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "files_from": {
+          "description": "On failure, parse this stream into per-file violations (default: none = one violation for the whole invocation).",
+          "enum": [
+            "none",
+            "stdout",
+            "stderr"
           ]
         },
-        "changed_since": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Git ref; the rule only fires on files in the `<ref>...HEAD` diff (the same merge-base diff as `alint check --changed`). Right shape for grandfathering pre-existing files in a PR — e.g. require an SPDX header only on files the PR touched. Accepts the `{{env.X}}` interpolation (e.g. `changed_since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`). Outside a git repo the predicate matches nothing (silent); an unresolvable ref inside a repo is a hard error with a shallow-clone hint."
-        }
-      }
-    },
-
-    "rule_file_content_matches": {
-      "type": "object",
-      "required": ["paths", "pattern"],
-      "properties": {
-        "kind": { "enum": ["file_content_matches", "content_matches"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "pattern": {
-          "type": "string",
-          "description": "Rust regex. File contents must match."
-        }
-      }
-    },
-
-    "rule_file_content_forbidden": {
-      "type": "object",
-      "required": ["paths", "pattern"],
-      "properties": {
-        "kind": { "enum": ["file_content_forbidden", "content_forbidden"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "pattern": {
-          "type": "string",
-          "description": "Rust regex. File contents must NOT match."
-        }
-      }
-    },
-
-    "rule_file_header": {
-      "type": "object",
-      "required": ["paths", "pattern"],
-      "properties": {
-        "kind": { "enum": ["file_header", "header"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "pattern": {
-          "type": "string",
-          "description": "Rust regex. The first `lines` lines of each file in scope must match."
+        "files_pattern": {
+          "description": "Regex whose capture group 1 is a file path, applied per output line (requires `files_from`; omit for bare-path listers).",
+          "type": "string"
         },
-        "lines": {
-          "type": "integer",
+        "kind": {
+          "const": "command_idempotent"
+        },
+        "timeout": {
+          "description": "Checker timeout in seconds (default 120). On timeout the child is killed and one violation is emitted.",
           "minimum": 1,
-          "default": 20,
-          "description": "Number of leading lines to consider."
-        }
-      }
-    },
-
-    "rule_file_max_size": {
-      "type": "object",
-      "required": ["paths", "max_bytes"],
-      "properties": {
-        "kind": { "enum": ["file_max_size", "max_size"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "max_bytes": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Maximum allowed file size in bytes."
-        }
-      }
-    },
-
-    "rule_file_min_size": {
-      "description": "Files in scope must be at least `min_bytes` bytes. Catches placeholder / stub files that pass existence checks but contain no useful content (e.g. a 20-byte README).",
-      "type": "object",
-      "required": ["paths", "min_bytes"],
-      "properties": {
-        "kind": { "enum": ["file_min_size", "min_size"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "min_bytes": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Minimum allowed file size in bytes."
-        }
-      }
-    },
-
-    "rule_file_min_lines": {
-      "description": "Files in scope must have at least `min_lines` lines (where a line is `\\n`-terminated, with an unterminated trailing segment counting as one more, matching `wc -l` semantics). Common use: require README / CHANGELOG / SECURITY.md to be more than a title plus one sentence.",
-      "type": "object",
-      "required": ["paths", "min_lines"],
-      "properties": {
-        "kind": { "enum": ["file_min_lines", "min_lines"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "min_lines": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Minimum allowed line count."
-        }
-      }
-    },
-
-    "rule_file_max_lines": {
-      "description": "Files in scope must have at most `max_lines` lines, with the same `wc -l`-style accounting as `file_min_lines`. Use to catch the everything-module anti-pattern.",
-      "type": "object",
-      "required": ["paths", "max_lines"],
-      "properties": {
-        "kind": { "enum": ["file_max_lines", "max_lines"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "max_lines": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Maximum allowed line count."
-        }
-      }
-    },
-
-    "rule_file_footer": {
-      "description": "Last `lines` lines of each file in scope must match `pattern` (Rust regex). Mirror of `file_header` anchored at the END of the file. Use for license footers, signed-off-by trailers, generated-file sentinels.",
-      "type": "object",
-      "required": ["paths", "pattern"],
-      "properties": {
-        "kind": { "enum": ["file_footer", "footer"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "pattern": {
-          "type": "string",
-          "description": "Rust regex. The last `lines` lines of each file must match."
+          "type": "integer"
         },
-        "lines": {
-          "type": "integer",
-          "minimum": 1,
-          "default": 20,
-          "description": "Number of trailing lines to consider."
+        "workdir": {
+          "description": "Checker cwd, relative to the lint root (default: lint root).",
+          "type": "string"
         }
-      }
+      },
+      "required": [
+        "command"
+      ],
+      "type": "object"
     },
-
-    "rule_file_shebang": {
-      "description": "First line of each file in scope must match the `shebang` regex. Pairs with `executable_has_shebang` (presence) and `shebang_has_executable` (the inverse) to enforce shebang shape, e.g. require `^#!/usr/bin/env bash$`.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "enum": ["file_shebang", "shebang"] },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "shebang": {
-          "type": "string",
-          "default": "^#!",
-          "description": "Rust regex; the first line of every matched file must match. Default `^#!` only enforces shebang presence."
-        }
-      }
-    },
-
-    "rule_file_is_text": {
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "enum": ["file_is_text", "is_text"] },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_json_path_equals": {
-      "description": "Value at a JSONPath (RFC 9535) expression in every JSON file in `paths` must deep-equal `equals`. Multiple matches all must match; zero matches is a violation (value missing) unless `if_present: true`. Typical use: `$.license == \"MIT\"` on every `packages/*/package.json`.",
-      "type": "object",
-      "required": ["paths", "path", "equals"],
-      "properties": {
-        "kind": { "const": "json_path_equals" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "path": {
-          "type": "string",
-          "description": "JSONPath expression rooted at `$`. Supports dot-access (`$.foo.bar`), array index (`$.deps[0]`), wildcards (`$.deps[*]`), filters, and every other RFC 9535 construct."
-        },
-        "equals": {
-          "description": "Expected value. Any JSON type (string, number, boolean, null, array, object)."
-        },
-        "if_present": { "$ref": "#/$defs/if_present" }
-      }
-    },
-
-    "rule_json_path_matches": {
-      "description": "Value at a JSONPath in every JSON file in `paths` must be a string and must match `matches` (a Rust regex). Non-string matches produce a clear 'not a string' violation.",
-      "type": "object",
-      "required": ["paths", "path", "matches"],
-      "properties": {
-        "kind": { "const": "json_path_matches" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "path": { "type": "string" },
-        "matches": {
-          "type": "string",
-          "description": "Rust-regex pattern to match against the value at `path`."
-        },
-        "if_present": { "$ref": "#/$defs/if_present" }
-      }
-    },
-
-    "rule_yaml_path_equals": {
-      "description": "YAML sibling of `json_path_equals`. Parses the file as YAML before applying the JSONPath query. Use this on GitHub Actions workflows, docker-compose.yml, kubernetes manifests, `.gitlab-ci.yml`, etc.",
-      "type": "object",
-      "required": ["paths", "path", "equals"],
-      "properties": {
-        "kind": { "const": "yaml_path_equals" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "path": { "type": "string" },
-        "equals": {},
-        "if_present": { "$ref": "#/$defs/if_present" }
-      }
-    },
-
-    "rule_yaml_path_matches": {
-      "description": "YAML sibling of `json_path_matches`.",
-      "type": "object",
-      "required": ["paths", "path", "matches"],
-      "properties": {
-        "kind": { "const": "yaml_path_matches" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "path": { "type": "string" },
-        "matches": { "type": "string" },
-        "if_present": { "$ref": "#/$defs/if_present" }
-      }
-    },
-
-    "rule_toml_path_equals": {
-      "description": "TOML sibling of `json_path_equals`. Typical use: enforce `[package].edition == \"2024\"` on every `Cargo.toml`.",
-      "type": "object",
-      "required": ["paths", "path", "equals"],
-      "properties": {
-        "kind": { "const": "toml_path_equals" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "path": { "type": "string" },
-        "equals": {},
-        "if_present": { "$ref": "#/$defs/if_present" }
-      }
-    },
-
-    "rule_toml_path_matches": {
-      "description": "TOML sibling of `json_path_matches`.",
-      "type": "object",
-      "required": ["paths", "path", "matches"],
-      "properties": {
-        "kind": { "const": "toml_path_matches" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "path": { "type": "string" },
-        "matches": { "type": "string" },
-        "if_present": { "$ref": "#/$defs/if_present" }
-      }
-    },
-
-    "rule_xml_path_equals": {
-      "description": "XML sibling of `json_path_equals`. XML maps to the same value tree via the xmltodict-style convention: attributes are `@name` keys, repeated child elements become an array, a leaf element collapses to its text string, namespaces flatten to local names, and every leaf value is a string (quote your `equals:`, e.g. `equals: \"4.0.0\"`). Typical use: enforce `$.Project.PropertyGroup.TargetFramework == \"net8.0\"` on every `.csproj`, or a Maven `$.project.parent.version` across `pom.xml`.",
-      "type": "object",
-      "required": ["paths", "path", "equals"],
-      "properties": {
-        "kind": { "const": "xml_path_equals" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "path": { "type": "string" },
-        "equals": {},
-        "if_present": { "$ref": "#/$defs/if_present" }
-      }
-    },
-
-    "rule_xml_path_matches": {
-      "description": "XML sibling of `json_path_matches` (same xmltodict-style mapping as `xml_path_equals`; all XML leaf values are strings). Typical use: `$.Project.ItemGroup.PackageReference[*]['@Version']` matches a version pattern across `.csproj`.",
-      "type": "object",
-      "required": ["paths", "path", "matches"],
-      "properties": {
-        "kind": { "const": "xml_path_matches" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "path": { "type": "string" },
-        "matches": { "type": "string" },
-        "if_present": { "$ref": "#/$defs/if_present" }
-      }
-    },
-
-    "rule_json_schema_passes": {
-      "description": "Validate every JSON / YAML / TOML file in `paths` against the JSON Schema at `schema_path`. Each schema-violation error becomes one violation; a target that fails to parse produces one parse-error violation. Format is detected from the target's extension; pass `format:` to override.",
-      "type": "object",
-      "required": ["paths", "schema_path"],
-      "properties": {
-        "kind": { "const": "json_schema_passes" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "schema_path": {
-          "type": "string",
-          "description": "Path to a JSON Schema file relative to the lint root. Schema must itself be JSON even when validating YAML / TOML targets."
-        },
-        "format": {
-          "type": "string",
-          "enum": ["json", "yaml", "yml", "toml"],
-          "description": "Override the auto-detected target format. When omitted, format is inferred from each target file's extension (.json / .yaml / .yml / .toml)."
-        }
-      }
-    },
-
     "rule_commented_out_code": {
       "description": "Heuristic detector for blocks of commented-out source code (as opposed to prose comments, license headers, doc comments, or ASCII banners). For each consecutive run of comment lines (≥ `min_lines`), counts the fraction of non-whitespace characters that are structural punctuation strongly biased toward code (`( ) { } [ ] ; = < > & | ^`). Scores ≥ `threshold` (after a runs-of-5+-identical-chars defang to drop ASCII banners) fire as violations. Doc-comment blocks (`/// `, `/** … */`) are excluded; the file's first `skip_leading_lines` lines are skipped to pass over license headers without false-positive flagging. Severity defaults to `warning`; the rule explicitly does not ship at `error` because heuristics have non-zero FP rate and shouldn't gate commits on first adoption. Check-only — auto-removing commented-out code is destructive.",
-      "type": "object",
-      "required": ["paths"],
       "properties": {
-        "kind": { "const": "commented_out_code" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
+        "kind": {
+          "const": "commented_out_code"
+        },
         "language": {
-          "type": "string",
+          "default": "auto",
+          "description": "Comment-marker set to use. `auto` (default) infers from each file's extension. Files with extensions the resolver doesn't recognise are silently skipped.",
           "enum": [
             "auto",
             "rust",
@@ -930,1251 +685,2721 @@
             "ruby",
             "shell"
           ],
-          "default": "auto",
-          "description": "Comment-marker set to use. `auto` (default) infers from each file's extension. Files with extensions the resolver doesn't recognise are silently skipped."
+          "type": "string"
         },
         "min_lines": {
-          "type": "integer",
-          "minimum": 2,
           "default": 3,
-          "description": "Minimum consecutive comment-line count for a block to be considered. Default 3 — 1-2 line comments are almost always prose."
+          "description": "Minimum consecutive comment-line count for a block to be considered. Default 3 — 1-2 line comments are almost always prose.",
+          "minimum": 2,
+          "type": "integer"
         },
-        "threshold": {
-          "type": "number",
-          "minimum": 0.0,
-          "maximum": 1.0,
-          "default": 0.5,
-          "description": "Density floor for code-shapedness. Higher = stricter. Default 0.5 sits at the midpoint between obvious-prose (0.0) and obvious-code (1.0); lower it to widen the catch (more FPs), raise it to narrow."
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
         },
         "skip_leading_lines": {
-          "type": "integer",
-          "minimum": 0,
           "default": 30,
-          "description": "Skip blocks whose first line is at or before this line number. Default 30 — covers typical license headers without false-positive flagging them as commented-out code."
-        }
-      }
-    },
-
-    "rule_markdown_paths_resolve": {
-      "description": "Validate that backticked workspace paths in markdown files resolve to real files or directories in the repo. Targets the AGENTS.md / CLAUDE.md / .cursorrules staleness problem: agent-context files reference paths in inline backticks, and those paths drift as the codebase evolves. Skips fenced and 4-space-indented code blocks (those contain code samples, not factual claims about the tree). Required `prefixes` field marks which path-shapes to validate (e.g. `[\"src/\", \"crates/\", \"docs/\"]`); backticked tokens not starting with a configured prefix are ignored, eliminating the FP class of `\\`npm\\`` / `\\`function\\`` / etc.",
-      "type": "object",
-      "required": ["paths", "prefixes"],
-      "properties": {
-        "kind": { "const": "markdown_paths_resolve" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "prefixes": {
-          "type": "array",
-          "items": { "type": "string" },
-          "minItems": 1,
-          "description": "Path-shape prefixes to validate. A backticked token must start with one of these to be considered a path candidate. No defaults — declare the prefixes that mark a path in your codebase."
+          "description": "Skip blocks whose first line is at or before this line number. Default 30 — covers typical license headers without false-positive flagging them as commented-out code.",
+          "minimum": 0,
+          "type": "integer"
         },
-        "ignore_template_vars": {
-          "type": "boolean",
-          "default": true,
-          "description": "When true (default), skip backticked tokens containing `{{ … }}`, `${ … }`, or `<…>` template-variable markers. These are placeholders, not real paths."
-        }
-      }
-    },
-
-    "rule_git_no_denied_paths": {
-      "description": "Fire when any tracked path matches a configured glob denylist. Companion of `git_tracked_only` for the absence axis: catches secrets, large binaries, or accidentally-tracked artifacts that would otherwise need a `file_absent` per pattern. With `since:` set, only paths changed in the `<since>...HEAD` diff are flagged (PR-scoped). Outside a git repo, silently no-ops; a `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
-      "type": "object",
-      "required": ["denied"],
-      "properties": {
-        "kind": { "const": "git_no_denied_paths" },
-        "denied": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "type": "string" },
-          "description": "Globset patterns no tracked path may match. Both whole-path patterns (`secrets/**`) and basename-only patterns (`*.env`) work."
-        },
-        "since": {
-          "type": "string",
-          "description": "Optional git ref. When set, only denied paths that changed in the `<since>...HEAD` diff are flagged — catches a secret added in a PR even if HEAD's tree still tracks an older one. Accepts the `{{env.X}}` interpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`."
-        }
-      }
-    },
-
-    "rule_git_commit_message": {
-      "description": "Validate one or more commit messages against shape rules: regex, max subject length, body required. With `since:` unset, only HEAD is checked. With `since:` set to a ref, every commit in `<since>..HEAD` is checked (oldest first, merge commits excluded by default); right shape for PR-trigger workflows where HEAD is a synthetic `actions/checkout` merge commit. At least one of `pattern:` / `subject_max_length:` / `requires_body: true` must be set. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
-      "type": "object",
-      "properties": {
-        "kind": { "const": "git_commit_message" },
-        "pattern": {
-          "type": "string",
-          "description": "Rust-regex pattern the full message (subject + body, joined with newlines) must match. Use `(?s)` to make `.` match newlines."
-        },
-        "subject_max_length": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Maximum number of characters allowed in the subject line. Common values: 50 (Tim Pope's recommendation), 72 (GitHub PR-title cutoff)."
-        },
-        "requires_body": {
-          "type": "boolean",
-          "default": false,
-          "description": "When true, the message must have a non-empty body, that is, at least one line of content after the subject's blank-line separator."
-        },
-        "since": {
-          "type": "string",
-          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does: SHA (full or abbreviated), branch (`origin/main`), tag (`v1.2.3`), or relative ref (`HEAD~5`). Supports POSIX `${VAR}` and `${VAR:-default}` env-var interpolation so CI can pass a SHA via an env var (e.g. `since: ${ALINT_BASE_SHA:-origin/main}` with `ALINT_BASE_SHA` exported in a workflow step from `github.event.pull_request.base.sha`). The GitHub Actions double-brace template syntax `${{ ... }}` is NOT interpolated by alint."
-        },
-        "include_merges": {
-          "type": "boolean",
-          "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Defaults to `false` because merge commits in PR contexts are typically the synthetic merge `actions/checkout` produces (with an auto-generated subject the rule would always flag) or maintainer-resolved merges from the base branch. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error."
+        "threshold": {
+          "default": 0.5,
+          "description": "Density floor for code-shapedness. Higher = stricter. Default 0.5 sits at the midpoint between obvious-prose (0.0) and obvious-code (1.0); lower it to widen the catch (more FPs), raise it to narrow.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "type": "number"
         }
       },
-      "anyOf": [
-        { "required": ["pattern"] },
-        { "required": ["subject_max_length"] },
-        { "required": ["requires_body"] }
-      ]
+      "required": [
+        "paths"
+      ],
+      "type": "object"
     },
-
-    "rule_git_commit_signed_off": {
-      "description": "Assert every commit in scope carries a DCO `Signed-off-by:` trailer. With `since:` unset, only HEAD is checked; with `since:` set to a ref, every commit in `<since>..HEAD` is checked (oldest first, merge commits excluded by default) — the right shape for PR-trigger workflows. Required by CNCF / Linux Foundation / kernel-style projects. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
-      "type": "object",
+    "rule_common": {
       "properties": {
-        "kind": { "const": "git_commit_signed_off" },
-        "pattern": {
-          "type": "string",
-          "description": "Trailer pattern each commit message must contain. Defaults to the canonical DCO sign-off shape `(?m)^Signed-off-by: .+ <.+@.+>$`. Override to enforce a stricter form (e.g. a corporate-domain email)."
+        "fix": {
+          "$ref": "#/$defs/fix"
         },
-        "since": {
-          "type": "string",
-          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`."
+        "id": {
+          "$ref": "#/$defs/rule_id"
         },
-        "include_merges": {
-          "type": "boolean",
-          "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error."
-        }
-      }
-    },
-
-    "rule_git_commit_subject_matches": {
-      "description": "Each commit's subject line (the first line of its message) must match the `matches:` regex — the subject-grammar member of the commit family (e.g. `pkg/path: lowercase summary`, conventional-commit types). Anchored to the subject alone, unlike `git_commit_message`'s whole-message `pattern:`; use `git_commit_message`'s `subject_max_length:` for a length cap. With `since:` unset, only HEAD is checked; with `since:` set, every commit in `<since>..HEAD`. Outside a git repo / with no commits / when git is unavailable, silently no-ops; a bad `since:` ref hard-fails with a shallow-clone hint.",
-      "type": "object",
-      "required": ["matches"],
-      "properties": {
-        "kind": { "const": "git_commit_subject_matches" },
-        "matches": {
-          "type": "string",
-          "description": "Rust-regex the commit subject (first line of the message) must match."
+        "kind": {
+          "description": "The primitive rule kind. See docs/design/ARCHITECTURE.md §4.4 for the full catalog.",
+          "type": "string"
         },
-        "since": {
-          "type": "string",
-          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`."
+        "level": {
+          "$ref": "#/$defs/level"
         },
-        "include_merges": {
-          "type": "boolean",
-          "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error."
-        }
-      }
-    },
-
-    "rule_git_commit_no_fixup": {
-      "description": "Fail on residual `fixup!` / `squash!` / `amend!` commits in scope — the ones `git commit --fixup`/`--squash` produce, meant to be collapsed by `git rebase --autosquash` before merging. With `since:` unset, only HEAD is checked; with `since:` set to a ref, every commit in `<since>..HEAD` is checked. No configuration knobs — the matched prefixes are exactly what `--autosquash` understands. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
-      "type": "object",
-      "properties": {
-        "kind": { "const": "git_commit_no_fixup" },
-        "since": {
-          "type": "string",
-          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`."
+        "message": {
+          "description": "Override the default failure message. Supports `{{vars.*}}` and `{{ctx.*}}` substitution.",
+          "type": "string"
         },
-        "include_merges": {
-          "type": "boolean",
-          "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error."
-        }
-      }
-    },
-
-    "rule_git_commit_author_allowlist": {
-      "description": "Assert every commit author in scope matches an allowed email and/or name pattern. At least one of `email_pattern:` / `name_pattern:` is required; specifying both means BOTH must match (AND). A commit whose author fails any specified pattern fires one violation. With `since:` unset, only HEAD is checked; with `since:` set to a ref, every commit in `<since>..HEAD` is checked. Demand: enterprise repos enforcing contributor identity against a corporate domain; OSS projects catching sock-puppet / compromised-account commits. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
-      "type": "object",
-      "properties": {
-        "kind": { "const": "git_commit_author_allowlist" },
-        "email_pattern": {
-          "type": "string",
-          "description": "Rust-regex the author email (`git log %ae`) must match, e.g. `^.+@example\\.com$`."
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
         },
-        "name_pattern": {
-          "type": "string",
-          "description": "Rust-regex the author name (`git log %an`) must match."
+        "policy_url": {
+          "description": "Link to a human-readable policy justification.",
+          "format": "uri",
+          "type": "string"
         },
-        "since": {
-          "type": "string",
-          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`."
+        "scope_filter": {
+          "$ref": "#/$defs/scope_filter"
         },
-        "include_merges": {
-          "type": "boolean",
-          "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error."
+        "when": {
+          "description": "Gate the rule on a fact-based expression (available from v0.2).",
+          "type": "string"
         }
       },
-      "anyOf": [
-        { "required": ["email_pattern"] },
-        { "required": ["name_pattern"] }
-      ]
+      "required": [
+        "id",
+        "kind",
+        "level"
+      ],
+      "type": "object"
     },
-
-    "rule_git_commit_gpg_signed": {
-      "description": "Assert every commit in scope has a verifying signature (`git verify-commit` exits 0). A commit that is unsigned, or signed with a key that doesn't verify against the local keyring, fires one violation. With `since:` unset, only HEAD is checked; with `since:` set to a ref, every commit in `<since>..HEAD` is checked. Demand: kernel maintainers, security-sensitive OSS, GitHub 'Require signed commits' branch protection. Reflects git's own verdict — does NOT distinguish 'unsigned' from 'signed with an untrusted key' (trust is git's GPG config / `.git/allowed_signers`). Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
-      "type": "object",
-      "properties": {
-        "kind": { "const": "git_commit_gpg_signed" },
-        "since": {
-          "type": "string",
-          "description": "Git ref to use as the base of the commit range. When set, validates every commit in `<since>..HEAD` instead of just HEAD. Accepts anything `git rev-parse` does. Use the canonical `{{env.X}}` interpolation to pass a SHA via an env var, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`."
-        },
-        "include_merges": {
-          "type": "boolean",
-          "default": false,
-          "description": "When validating a range (`since:` set), include merge commits. Has no effect when `since:` is unset; combining `include_merges: true` with no `since:` is a load-time error."
-        }
-      }
-    },
-
-    "rule_git_blame_age": {
-      "description": "Fire on lines matching a regex whose `git blame` author-time is older than `max_age_days`. Closes the gap between `level: warning` on every TODO (too noisy) and `level: off` (accepts unbounded debt accumulation). Use cases: stale TODO / FIXME / XXX / HACK markers, abandoned `@deprecated` JSDoc tags, model-attributed TODOs that nobody followed up on. Outside a git repo, on untracked files, or when blame fails for any other reason, the rule silently no-ops per file. Heuristic notes: formatting passes (cargo fmt, prettier) reset blame age unless the formatting commit is listed in `.git-blame-ignore-revs`; vendored / imported code carries the import commit's timestamp; squash-merged PRs collapse to a single date. Check-only — auto-removing matched lines is destructive.",
-      "type": "object",
-      "required": ["paths", "pattern", "max_age_days"],
-      "properties": {
-        "kind": { "const": "git_blame_age" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "pattern": {
-          "type": "string",
-          "description": "Rust-regex pattern applied to each blame line's content. Capture group 1 (when present) is exposed as `{{ctx.match}}` in the message template; without a capture group, `{{ctx.match}}` substitutes the full match."
-        },
-        "max_age_days": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Minimum line age (in days) for a matching line to fire as a violation. Lines younger than this pass silently. Common values: 90 (one quarter), 180 (half a year), 365 (a full year of debt)."
-        }
-      }
-    },
-
-    "rule_changeset_requires_path": {
-      "description": "The `<since>...HEAD` diff must ADD (git status A) at least one path matching `add_glob:` — the 'did you add a changelog entry?' gate (prettier `changelog_unreleased/`, cpython `Misc/NEWS.d/next/`, pnpm `.changeset/*.md`). `since:` (the base ref) is required. Optional `when_changed:` gates the requirement on some other glob having changed (don't demand a changelog for a docs-only PR); with no gate, any non-empty changeset triggers it. Diff-scoped: silent no-op outside a git repo / when nothing relevant changed; a `since:` that fails to resolve hard-fails with a shallow-clone hint. Check-only.",
-      "type": "object",
-      "required": ["add_glob", "since"],
-      "properties": {
-        "kind": { "const": "changeset_requires_path" },
-        "add_glob": {
-          "type": "string",
-          "description": "Glob; the diff must ADD at least one path matching it."
-        },
-        "when_changed": {
-          "type": "string",
-          "description": "Optional gate: only require the add when some path matching this glob changed (any status). Omit to require it on any non-empty changeset."
-        },
-        "since": {
-          "type": "string",
-          "description": "Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}` interpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`."
-        }
-      }
-    },
-
-    "rule_pair_changed_together": {
-      "description": "If the `<since>...HEAD` diff changes any path matching `if_changed:`, at least one path matching `then_changed:` must change in the same range — the co-change gate (a FORMAT_VERSION must bump when the format struct changes; version.txt and the lockfile change together). Both globs and `since:` (the base ref) are required. Directional: a `then_changed`-only change never triggers it (add a second rule with the globs swapped for a bidirectional pact). Diff-scoped: silent no-op outside a git repo / when `if_changed` didn't change; a `since:` that fails to resolve hard-fails with a shallow-clone hint. Check-only.",
-      "type": "object",
-      "required": ["if_changed", "then_changed", "since"],
-      "properties": {
-        "kind": { "const": "pair_changed_together" },
-        "if_changed": {
-          "type": "string",
-          "description": "Glob; the trigger. When the diff changes a path matching this, a `then_changed` co-change is required."
-        },
-        "then_changed": {
-          "type": "string",
-          "description": "Glob; the obligation. At least one changed path must match it whenever `if_changed` fired."
-        },
-        "since": {
-          "type": "string",
-          "description": "Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}` interpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`."
-        }
-      }
-    },
-
-    "if_present": {
-      "type": "boolean",
-      "default": false,
-      "description": "When true, a JSONPath query returning zero matches is silently OK — only real matches that fail the op produce violations. Use for predicates conditional on a field's presence (e.g. \"every `uses:` must be SHA-pinned\" where a workflow without `uses:` steps shouldn't be flagged)."
-    },
-
-    "rule_filename_case": {
-      "type": "object",
-      "required": ["paths", "case"],
-      "properties": {
-        "kind": { "const": "filename_case" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "case": { "$ref": "#/$defs/case_convention" }
-      }
-    },
-
-    "rule_filename_regex": {
-      "type": "object",
-      "required": ["paths", "pattern"],
-      "properties": {
-        "kind": { "const": "filename_regex" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "pattern": {
-          "type": "string",
-          "description": "Rust regex, automatically anchored with ^...$ by the engine."
-        },
-        "stem": {
-          "type": "boolean",
-          "default": false,
-          "description": "Match the file stem (no extension) instead of the full basename."
-        }
-      }
-    },
-
-    "rule_pair": {
-      "description": "For every file matching `primary`, a file matching the `partner` template must exist. Template tokens: {dir}, {stem}, {ext}, {basename}, {path}, {parent_name}.",
-      "type": "object",
-      "required": ["primary", "partner"],
-      "properties": {
-        "kind": { "const": "pair" },
-        "primary": {
-          "type": "string",
-          "description": "Glob selecting the primary files."
-        },
-        "partner": {
-          "type": "string",
-          "description": "Path template resolved per primary match. Example: \"{dir}/{stem}.h\"."
-        }
-      }
-    },
-
-    "rule_pair_hash": {
-      "description": "Cross-file: the `algorithm` digest of every file matching `source` must appear in the single `target` file — either as an embedded hex substring (`format: contains`, the default) or a coreutils / go-`.sum`-style `<hex>  <path>` manifest line (`format: sums-line`). Detection-only (alint never rewrites the manifest). A missing `target` is one violation; one violation per source whose digest is absent or mismatched. golang/go FIPS `fips140.sum` is the canonical use.",
-      "type": "object",
-      "required": ["source", "target"],
-      "properties": {
-        "kind": { "const": "pair_hash" },
-        "source": {
-          "type": "string",
-          "description": "Literal path or glob selecting the file(s) whose content is hashed (one check per match)."
-        },
-        "target": {
-          "type": "string",
-          "description": "The single file that must carry the digest (a `.sum` / `SHA256SUMS` / file with an embedded hash)."
-        },
-        "algorithm": {
-          "enum": ["sha256", "sha512"],
-          "description": "Digest algorithm (default: sha256)."
-        },
-        "format": {
-          "enum": ["contains", "sums-line"],
-          "description": "How the digest must appear in `target`: `contains` = hex substring anywhere (default); `sums-line` = a `<hex> [*]<path>` line whose path token is the source's path."
-        }
-      }
-    },
-
-    "rule_registry_paths_resolve": {
-      "description": "A manifest enumerates path entries; each must resolve to an on-disk artefact. `extract` selects how the entry list is pulled (structured-query toml/json/yaml, a line list, or regex capture group 1). Optional `orphans` adds the reverse check: on-disk artefacts under `space` that no entry references. Non-literal entries (interpolation / antiquotation) are skipped, not failed.",
-      "type": "object",
-      "required": ["source", "extract"],
-      "properties": {
-        "kind": { "const": "registry_paths_resolve" },
-        "source": {
-          "type": "string",
-          "description": "The manifest/registry file (path, or a glob to run once per matching manifest) that enumerates the path entries."
-        },
-        "extract": {
-          "type": "object",
-          "description": "Exactly one of: toml/json/yaml (RFC 9535 JSONPath string), lines (object; optional `comment` prefix, default `#`), regex (string; capture group 1 is the path).",
-          "minProperties": 1,
-          "maxProperties": 1,
-          "properties": {
-            "toml": { "type": "string" },
-            "json": { "type": "string" },
-            "yaml": { "type": "string" },
-            "lines": {
-              "type": "object",
-              "properties": { "comment": { "type": "string" } },
-              "additionalProperties": false
-            },
-            "regex": { "type": "string" }
-          },
-          "additionalProperties": false
-        },
-        "base": {
-          "type": "string",
-          "description": "Resolve entries relative to: registry_dir (default), lint_root, or an explicit path."
-        },
-        "entries_are_globs": { "type": "boolean" },
-        "expect": { "enum": ["any", "file", "dir"] },
-        "must_contain": { "type": "string" },
-        "exclude_query": { "type": "string" },
-        "orphans": {
-          "type": "object",
-          "required": ["space"],
-          "properties": {
-            "space": { "type": "string" },
-            "unreferenced": { "enum": ["warn", "error", "off"] }
-          },
-          "additionalProperties": false
-        }
-      }
-    },
-
-    "extract_spec": {
-      "type": "object",
-      "description": "Exactly one of: toml/json/yaml (RFC 9535 JSONPath string), lines (object; optional `comment` prefix, default `#`), regex (string; capture group 1 is the value), whole_file (object `{}`; the entire file content as one value — for byte-level cross_file comparison; the non-literal skip does not apply).",
-      "minProperties": 1,
-      "maxProperties": 1,
-      "properties": {
-        "toml": { "type": "string" },
-        "json": { "type": "string" },
-        "yaml": { "type": "string" },
-        "lines": {
-          "type": "object",
-          "properties": { "comment": { "type": "string" } },
-          "additionalProperties": false
-        },
-        "regex": { "type": "string" },
-        "whole_file": {
-          "type": "object",
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-
     "rule_cross_file": {
       "description": "A `source` file must hold a `relation` to one or more `targets` (or the filesystem). Value relations extract values: `equals` (default — every target value equals the single source value; the released `cross_file_value_equals`), `subset` / `superset` / `set_equals` (the source's extracted set vs each target's set). `identical` compares whole files byte-for-byte (no `extract`; optional `skip_header_lines`). `resolves` checks that each path the source extracts exists on disk (`source.extract`, no `targets` — the forward half of `registry_paths_resolve`). `targets` is a `{ files: <glob>, extract }` map or a `[{ file, extract }]` list. `normalize` relaxes value comparison. Non-literal values are skipped, not failed. `cross_file_value_equals` is a byte-compatible alias (relation defaults to equals). The per-relation shape (which of `source.extract` / `targets` is present) is validated at load.",
-      "type": "object",
-      "required": ["source"],
       "properties": {
-        "kind": { "enum": ["cross_file", "cross_file_value_equals"] },
-        "source": {
-          "type": "object",
+        "allow_missing_target": {
+          "type": "boolean"
+        },
+        "kind": {
+          "enum": [
+            "cross_file",
+            "cross_file_value_equals"
+          ]
+        },
+        "normalize": {
+          "description": "A normalize transform, or an ordered list of transforms applied left-to-right (`[trim, semver-minor]`). `semver-major` / `semver-minor` keep only the leading MAJOR / MAJOR.MINOR band (each token's leading digits, leading non-digits stripped) — the protobuf / pnpm version-format reconcile.",
           "oneOf": [
-            { "required": ["file"] },
-            { "required": ["files"] }
+            {
+              "enum": [
+                "none",
+                "trim",
+                "lower",
+                "semver-major",
+                "semver-minor"
+              ]
+            },
+            {
+              "items": {
+                "enum": [
+                  "none",
+                  "trim",
+                  "lower",
+                  "semver-major",
+                  "semver-minor"
+                ]
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "relation": {
+          "enum": [
+            "equals",
+            "subset",
+            "superset",
+            "set_equals",
+            "identical",
+            "resolves"
+          ]
+        },
+        "skip_header_lines": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "source": {
+          "additionalProperties": false,
+          "oneOf": [
+            {
+              "required": [
+                "file"
+              ]
+            },
+            {
+              "required": [
+                "files"
+              ]
+            }
           ],
           "properties": {
-            "file": { "type": "string", "description": "A single source file." },
-            "files": { "type": "string", "description": "A glob whose matches are read and whose extracted values are UNIONED into one set — for the set relations only (subset / superset / set_equals). The 'every match across a glob == a set' shape." },
-            "extract": { "$ref": "#/$defs/extract_spec" }
+            "extract": {
+              "$ref": "#/$defs/extract_spec"
+            },
+            "file": {
+              "description": "A single source file.",
+              "type": "string"
+            },
+            "files": {
+              "description": "A glob whose matches are read and whose extracted values are UNIONED into one set — for the set relations only (subset / superset / set_equals). The 'every match across a glob == a set' shape.",
+              "type": "string"
+            }
           },
-          "additionalProperties": false
+          "type": "object"
         },
         "targets": {
           "oneOf": [
             {
-              "type": "object",
-              "required": ["files"],
+              "additionalProperties": false,
               "properties": {
-                "files": { "type": "string" },
-                "extract": { "$ref": "#/$defs/extract_spec" }
+                "extract": {
+                  "$ref": "#/$defs/extract_spec"
+                },
+                "files": {
+                  "type": "string"
+                }
               },
-              "additionalProperties": false
+              "required": [
+                "files"
+              ],
+              "type": "object"
             },
             {
-              "type": "array",
               "items": {
-                "type": "object",
-                "required": ["file"],
+                "additionalProperties": false,
                 "properties": {
-                  "file": { "type": "string" },
-                  "extract": { "$ref": "#/$defs/extract_spec" }
+                  "extract": {
+                    "$ref": "#/$defs/extract_spec"
+                  },
+                  "file": {
+                    "type": "string"
+                  }
                 },
-                "additionalProperties": false
-              }
+                "required": [
+                  "file"
+                ],
+                "type": "object"
+              },
+              "type": "array"
             }
           ]
-        },
-        "relation": { "enum": ["equals", "subset", "superset", "set_equals", "identical", "resolves"] },
-        "normalize": {
-          "description": "A normalize transform, or an ordered list of transforms applied left-to-right (`[trim, semver-minor]`). `semver-major` / `semver-minor` keep only the leading MAJOR / MAJOR.MINOR band (each token's leading digits, leading non-digits stripped) — the protobuf / pnpm version-format reconcile.",
-          "oneOf": [
-            { "enum": ["none", "trim", "lower", "semver-major", "semver-minor"] },
-            {
-              "type": "array",
-              "items": { "enum": ["none", "trim", "lower", "semver-major", "semver-minor"] }
-            }
-          ]
-        },
-        "allow_missing_target": { "type": "boolean" },
-        "skip_header_lines": { "type": "integer", "minimum": 0 }
-      }
+        }
+      },
+      "required": [
+        "source"
+      ],
+      "type": "object"
     },
-
+    "rule_dir_absent": {
+      "properties": {
+        "git_tracked_only": {
+          "$ref": "#/$defs/git_tracked_only"
+        },
+        "kind": {
+          "const": "dir_absent"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_dir_contains": {
+      "description": "Every directory matching `select` must have at least one direct child basename matching each glob in `require`. Sugar over for_each_dir + file_exists; use for_each_dir for deeper semantics.",
+      "properties": {
+        "kind": {
+          "const": "dir_contains"
+        },
+        "require": {
+          "description": "Basename glob(s) — every dir matching `select` must have at least one child matching each.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          ]
+        },
+        "select": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "select",
+        "require"
+      ],
+      "type": "object"
+    },
+    "rule_dir_exists": {
+      "properties": {
+        "git_tracked_only": {
+          "$ref": "#/$defs/git_tracked_only"
+        },
+        "kind": {
+          "const": "dir_exists"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_dir_only_contains": {
+      "description": "Every direct child *file* of directories matching `select` must match at least one glob in `allow`. Subdirectories of the matched dir are not checked. Allow globs match the child's basename.",
+      "properties": {
+        "allow": {
+          "description": "Basename glob(s) accepted as direct children. Anything else is a violation.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          ]
+        },
+        "kind": {
+          "const": "dir_only_contains"
+        },
+        "select": {
+          "description": "Glob selecting the directories to enumerate.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "select",
+        "allow"
+      ],
+      "type": "object"
+    },
+    "rule_every_matching_has": {
+      "description": "Every file OR directory matching `select` must satisfy every nested rule in `require`. Sugar that combines for_each_file + for_each_dir into one rule. Optional `when_iter:` filters iterations.",
+      "properties": {
+        "kind": {
+          "const": "every_matching_has"
+        },
+        "require": {
+          "items": {
+            "$ref": "#/$defs/nested_rule"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "select": {
+          "description": "Glob(s) selecting the files/dirs to iterate — a single glob, or a list with `!`-prefixed excludes (e.g. [\"packages/*\", \"!packages/internal\"]).",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          ]
+        },
+        "when_iter": {
+          "description": "Per-iteration `when:` filter — see rule_for_each_dir.when_iter.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "select",
+        "require"
+      ],
+      "type": "object"
+    },
+    "rule_executable_bit": {
+      "description": "Assert that every file in scope either has the Unix +x bit set (`require: true`) or does not (`require: false`). No-op on non-Unix platforms. No fix op (chmod auto-apply deferred).",
+      "properties": {
+        "kind": {
+          "const": "executable_bit"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "require": {
+          "description": "`true`: +x must be set. `false`: +x must not be set.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "paths",
+        "require"
+      ],
+      "type": "object"
+    },
+    "rule_executable_has_shebang": {
+      "description": "Every file with the +x bit set must begin with a shebang (`#!`). Catches scripts that were marked executable but whose content is a plain text file or missing a shebang. No-op on non-Unix.",
+      "properties": {
+        "kind": {
+          "const": "executable_has_shebang"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_file_absent": {
+      "properties": {
+        "git_tracked_only": {
+          "$ref": "#/$defs/git_tracked_only"
+        },
+        "kind": {
+          "const": "file_absent"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_file_content_forbidden": {
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_content_forbidden",
+            "content_forbidden"
+          ]
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "pattern": {
+          "description": "Rust regex. File contents must NOT match.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths",
+        "pattern"
+      ],
+      "type": "object"
+    },
+    "rule_file_content_matches": {
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_content_matches",
+            "content_matches"
+          ]
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "pattern": {
+          "description": "Rust regex. File contents must match.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths",
+        "pattern"
+      ],
+      "type": "object"
+    },
+    "rule_file_ends_with": {
+      "description": "Every file in scope must end with the given suffix (byte-level). For a simple trailing-newline check, prefer `final_newline`. Check-only; pair with `file_append` if you want auto-append.",
+      "properties": {
+        "kind": {
+          "const": "file_ends_with"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "suffix": {
+          "description": "Required suffix, matched byte-for-byte.",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths",
+        "suffix"
+      ],
+      "type": "object"
+    },
+    "rule_file_exists": {
+      "properties": {
+        "git_tracked_only": {
+          "$ref": "#/$defs/git_tracked_only"
+        },
+        "kind": {
+          "const": "file_exists"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "respect_gitignore": {
+          "$ref": "#/$defs/per_rule_respect_gitignore"
+        },
+        "root_only": {
+          "default": false,
+          "description": "If true, only files directly at the repository root satisfy the rule.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_file_footer": {
+      "description": "Last `lines` lines of each file in scope must match `pattern` (Rust regex). Mirror of `file_header` anchored at the END of the file. Use for license footers, signed-off-by trailers, generated-file sentinels.",
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_footer",
+            "footer"
+          ]
+        },
+        "lines": {
+          "default": 20,
+          "description": "Number of trailing lines to consider.",
+          "format": "uint",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "pattern": {
+          "description": "Rust regex. The last `lines` lines of each file must match.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths",
+        "pattern"
+      ],
+      "type": "object"
+    },
     "rule_file_graph": {
       "description": "Assemble the repo's file→file reference graph and assert a global structural property the 1-level cross-file kinds can't. `nodes` (glob) selects the graph's files. `edges` is one of `from_content` (extract one reference per match — the `extract` one-of: toml/json/yaml JSONPath, lines, or regex capture group 1 — and resolve it to a path via `resolve`: relative_to_file default, or relative_to_repo_root; bare module names, absolute paths, URLs, computed/interpolated references, and paths that escape the repo root are dropped, not mis-resolved) or `derive_target` (a `from`→`to` name template deriving the target from the node path). `require` is one of: `acyclic` (no dependency cycle among the nodes); `no_dangling` (every path-shaped edge resolves to an existing path — with `derive_target`, the derived sibling must exist); `no_orphans` (no node unreferenced by another, bare or `{ no_orphans: { roots: [...] } }`); `{ forbidden_edges: [{ from, to }] }` (the layering firewall — no edge whose source matches `from` and resolved target matches `to`); or `{ fresh: { hash, marker } }` (the `derive_target` output embeds the source's current content hash, captured by `marker`). Pure-parse, cross-file (no spawn).",
-      "type": "object",
-      "required": ["nodes", "edges", "require"],
       "properties": {
-        "kind": { "const": "file_graph" },
-        "nodes": {
-          "type": "string",
-          "description": "Glob selecting the graph's node files."
-        },
         "edges": {
-          "type": "object",
+          "additionalProperties": false,
           "description": "Exactly one edge extractor: `from_content` (content references → the reference-graph modes) or `derive_target` (a name template → `fresh` codegen-freshness or `no_dangling` derived-sibling existence).",
-          "properties": {
-            "from_content": {
-              "type": "object",
-              "required": ["extract"],
-              "properties": {
-                "extract": { "$ref": "#/$defs/extract_spec" },
-                "resolve": { "enum": ["relative_to_file", "relative_to_repo_root"] }
-              },
-              "additionalProperties": false
+          "oneOf": [
+            {
+              "required": [
+                "from_content"
+              ]
             },
+            {
+              "required": [
+                "derive_target"
+              ]
+            }
+          ],
+          "properties": {
             "derive_target": {
-              "type": "object",
+              "additionalProperties": false,
               "description": "Derive the generated target's path from the source node's path: `from` is a regex matched against the node path, `to` is a replacement template using its captures (e.g. `to: $1.pb.go`).",
-              "required": ["from", "to"],
               "properties": {
-                "from": { "type": "string" },
-                "to": { "type": "string" }
+                "from": {
+                  "type": "string"
+                },
+                "to": {
+                  "type": "string"
+                }
               },
-              "additionalProperties": false
+              "required": [
+                "from",
+                "to"
+              ],
+              "type": "object"
+            },
+            "from_content": {
+              "additionalProperties": false,
+              "properties": {
+                "extract": {
+                  "$ref": "#/$defs/extract_spec"
+                },
+                "resolve": {
+                  "enum": [
+                    "relative_to_file",
+                    "relative_to_repo_root"
+                  ]
+                }
+              },
+              "required": [
+                "extract"
+              ],
+              "type": "object"
             }
           },
-          "additionalProperties": false,
-          "oneOf": [
-            { "required": ["from_content"] },
-            { "required": ["derive_target"] }
-          ]
+          "type": "object"
+        },
+        "kind": {
+          "const": "file_graph"
+        },
+        "nodes": {
+          "description": "Glob selecting the graph's node files.",
+          "type": "string"
         },
         "require": {
           "description": "A bare-string mode (`acyclic` | `no_dangling` | `no_orphans`), or a map for a configured mode (`{ forbidden_edges: [{from,to}] }`, `{ no_orphans: { roots: [...] } }`, or `{ fresh: { hash, marker } }`). `no_dangling` = every path-shaped edge resolves to an existing path (with `edges.derive_target`, each node's derived sibling must exist — e.g. every `X-LICENSE.txt` needs an `X-NOTICE.txt`); `no_orphans` = no node is unreferenced except those matching a `roots` glob; `fresh` (needs `edges.derive_target`) = the derived output carries the source's current `hash` digest, captured by `marker` (group 1).",
           "oneOf": [
-            { "enum": ["acyclic", "no_dangling", "no_orphans"] },
             {
-              "type": "object",
-              "required": ["forbidden_edges"],
+              "enum": [
+                "acyclic",
+                "no_dangling",
+                "no_orphans"
+              ]
+            },
+            {
+              "additionalProperties": false,
               "properties": {
                 "forbidden_edges": {
-                  "type": "array",
-                  "minItems": 1,
                   "items": {
-                    "type": "object",
-                    "required": ["from", "to"],
+                    "additionalProperties": false,
                     "properties": {
-                      "from": { "type": "string" },
-                      "to": { "type": "string" }
+                      "from": {
+                        "type": "string"
+                      },
+                      "to": {
+                        "type": "string"
+                      }
                     },
-                    "additionalProperties": false
-                  }
+                    "required": [
+                      "from",
+                      "to"
+                    ],
+                    "type": "object"
+                  },
+                  "minItems": 1,
+                  "type": "array"
                 }
               },
-              "additionalProperties": false
+              "required": [
+                "forbidden_edges"
+              ],
+              "type": "object"
             },
             {
-              "type": "object",
-              "required": ["no_orphans"],
+              "additionalProperties": false,
               "properties": {
                 "no_orphans": {
-                  "type": "object",
+                  "additionalProperties": false,
                   "properties": {
                     "roots": {
-                      "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
                     }
                   },
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
-              "additionalProperties": false
+              "required": [
+                "no_orphans"
+              ],
+              "type": "object"
             },
             {
-              "type": "object",
-              "required": ["fresh"],
+              "additionalProperties": false,
               "properties": {
                 "fresh": {
-                  "type": "object",
-                  "required": ["marker"],
+                  "additionalProperties": false,
                   "properties": {
-                    "hash": { "enum": ["sha256", "sha512"] },
-                    "marker": { "type": "string" }
+                    "hash": {
+                      "enum": [
+                        "sha256",
+                        "sha512"
+                      ]
+                    },
+                    "marker": {
+                      "type": "string"
+                    }
                   },
-                  "additionalProperties": false
+                  "required": [
+                    "marker"
+                  ],
+                  "type": "object"
                 }
               },
-              "additionalProperties": false
+              "required": [
+                "fresh"
+              ],
+              "type": "object"
             }
           ]
         }
-      }
+      },
+      "required": [
+        "nodes",
+        "edges",
+        "require"
+      ],
+      "type": "object"
     },
-
-    "rule_ordered_block": {
-      "description": "The lines between a `start` / `end` marker pair must stay sorted (and, with `unique`, free of duplicates) under `comparator`. Both markers are optional: omit `end` to sort from `start` to EOF, omit both to sort the whole file (the markerless 'this file is one sorted list' form). The generic form of per-project keep-sorted scripts. Per-file: markers match the trimmed line; blank lines inside a block are ignored.",
-      "type": "object",
+    "rule_file_hash": {
+      "description": "Each file in scope must have content whose SHA-256 equals the declared `sha256`. Accepts a bare 64-char hex string or a `sha256:`-prefixed form.",
       "properties": {
-        "kind": { "const": "ordered_block" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "start": {
-          "type": "string",
-          "description": "Marker line opening a block (matched on the trimmed line). Optional — omit to anchor the block at the start of the file."
+        "kind": {
+          "const": "file_hash"
         },
-        "end": {
-          "type": "string",
-          "description": "Marker line closing a block. Optional — omit to run the block to EOF."
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
         },
-        "comparator": { "enum": ["lexical", "lexical-ci", "numeric"] },
-        "unique": { "type": "boolean" },
-        "select": {
-          "type": "string",
-          "description": "Regex; when set, only lines inside a block matching it are sortable entries (others — comments, group headers — pass through). The sectioned / keep-sorted-subset shape."
+        "sha256": {
+          "pattern": "^(sha256:)?[0-9a-fA-F]{64}$",
+          "type": "string"
         }
-      }
+      },
+      "required": [
+        "paths",
+        "sha256"
+      ],
+      "type": "object"
     },
-
-    "rule_for_each_match": {
-      "description": "For each line matching `select` (a regex), the line must satisfy the nested `require:` predicates: `matches` (the line matches all listed regexes), `forbid` (matches none), `equal` (the listed named `select` captures are all equal — checked on every `select` match on the line). The in-file line quantifier (the dual of `ordered_block`'s `select:`): one violation per offending line. Closes per-line changelog grammars ('every entry line must ALSO match Q1..Qn', which `file_content_matches` cannot express — its match is existence, not a per-line conjunction) and intra-line capture equality (RE2 has no backreference). Per-file.",
-      "type": "object",
-      "required": ["paths", "select", "require"],
+    "rule_file_header": {
       "properties": {
-        "kind": { "const": "for_each_match" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "select": {
-          "type": "string",
-          "description": "Regex; a line is a checked element iff it matches. Named captures are available to `require.equal`."
+        "kind": {
+          "enum": [
+            "file_header",
+            "header"
+          ]
+        },
+        "lines": {
+          "default": 20,
+          "description": "Number of leading lines to consider.",
+          "format": "uint",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "pattern": {
+          "description": "Rust regex. The first `lines` lines of each file in scope must match.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths",
+        "pattern"
+      ],
+      "type": "object"
+    },
+    "rule_file_is_ascii": {
+      "description": "Every byte in every file in scope must be < 0x80 (pure ASCII), except codepoints listed in `allow:`. Stricter than file_is_text; check-only — auto-replacement for non-ASCII bytes would silently lose meaning. With `allow:` the file is decoded as UTF-8 and checked per character; without it, the strict byte-level fast path is used.",
+      "properties": {
+        "allow": {
+          "description": "Permitted non-ASCII codepoints — each entry a single character (e.g. \"ö\"), a `U+XXXX` codepoint, or a `U+XXXX-U+YYYY` inclusive range.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "const": "file_is_ascii"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_file_is_text": {
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_is_text",
+            "is_text"
+          ]
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_file_max_lines": {
+      "description": "Files in scope must have at most `max_lines` lines, with the same `wc -l`-style accounting as `file_min_lines`. Use to catch the everything-module anti-pattern.",
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_max_lines",
+            "max_lines"
+          ]
+        },
+        "max_lines": {
+          "description": "Maximum allowed line count.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "max_lines"
+      ],
+      "type": "object"
+    },
+    "rule_file_max_size": {
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_max_size",
+            "max_size"
+          ]
+        },
+        "max_bytes": {
+          "description": "Maximum allowed file size in bytes.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "max_bytes"
+      ],
+      "type": "object"
+    },
+    "rule_file_min_lines": {
+      "description": "Files in scope must have at least `min_lines` lines (where a line is `\\n`-terminated, with an unterminated trailing segment counting as one more, matching `wc -l` semantics). Common use: require README / CHANGELOG / SECURITY.md to be more than a title plus one sentence.",
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_min_lines",
+            "min_lines"
+          ]
+        },
+        "min_lines": {
+          "description": "Minimum allowed line count.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "min_lines"
+      ],
+      "type": "object"
+    },
+    "rule_file_min_size": {
+      "description": "Files in scope must be at least `min_bytes` bytes. Catches placeholder / stub files that pass existence checks but contain no useful content (e.g. a 20-byte README).",
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_min_size",
+            "min_size"
+          ]
+        },
+        "min_bytes": {
+          "description": "Minimum allowed file size in bytes.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "min_bytes"
+      ],
+      "type": "object"
+    },
+    "rule_file_shebang": {
+      "description": "First line of each file in scope must match the `shebang` regex. Pairs with `executable_has_shebang` (presence) and `shebang_has_executable` (the inverse) to enforce shebang shape, e.g. require `^#!/usr/bin/env bash$`.",
+      "properties": {
+        "kind": {
+          "enum": [
+            "file_shebang",
+            "shebang"
+          ]
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "shebang": {
+          "default": "^#!",
+          "description": "Rust regex; the first line of every matched file must match. Default\n`^#!` only enforces shebang presence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_file_starts_with": {
+      "description": "Every file in scope must begin with the given prefix (byte-level). Useful for SPDX headers, generated-file sentinels, magic bytes. Check-only; pair with `file_prepend` if you want auto-prepend (prevents silent duplication on near-matches).",
+      "properties": {
+        "kind": {
+          "const": "file_starts_with"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "prefix": {
+          "description": "Required prefix, matched byte-for-byte.",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths",
+        "prefix"
+      ],
+      "type": "object"
+    },
+    "rule_filename_case": {
+      "properties": {
+        "case": {
+          "$ref": "#/$defs/case_convention"
+        },
+        "kind": {
+          "const": "filename_case"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "case"
+      ],
+      "type": "object"
+    },
+    "rule_filename_regex": {
+      "properties": {
+        "kind": {
+          "const": "filename_regex"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "pattern": {
+          "description": "Rust regex, automatically anchored with ^...$ by the engine.",
+          "type": "string"
+        },
+        "stem": {
+          "default": false,
+          "description": "Match the file stem (no extension) instead of the full basename.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "paths",
+        "pattern"
+      ],
+      "type": "object"
+    },
+    "rule_final_newline": {
+      "description": "Every non-empty file in scope must end with a newline byte. Empty files are considered fine.",
+      "properties": {
+        "kind": {
+          "const": "final_newline"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_for_each_dir": {
+      "description": "For every directory matching `select`, every rule in `require` must pass. Path-template tokens in the nested rules are pre-substituted per iteration; use `{path}` to refer to the iterated directory itself. Optional `when_iter:` filters which iterations are evaluated, e.g. `iter.has_file(\"Cargo.toml\")` to scope to workspace members.",
+      "properties": {
+        "kind": {
+          "const": "for_each_dir"
         },
         "require": {
-          "type": "object",
+          "description": "Nested rules evaluated against each matched directory.",
+          "items": {
+            "$ref": "#/$defs/nested_rule"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "select": {
+          "description": "Glob(s) selecting the directories to iterate — a single glob, or a list with `!`-prefixed excludes (e.g. [\"src/*\", \"!src/internal\"]).",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          ]
+        },
+        "when_iter": {
+          "description": "Per-iteration `when:` filter — evaluated against `iter.*` in the iterated entry's context. Iterations whose verdict is false are skipped before any nested rule is built. Examples: `iter.has_file(\"Cargo.toml\")`, `iter.basename matches \"^pkg-\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "select",
+        "require"
+      ],
+      "type": "object"
+    },
+    "rule_for_each_file": {
+      "description": "For every file matching `select`, every rule in `require` must pass. Path-template tokens in the nested rules are pre-substituted per iteration. Optional `when_iter:` filters iterations.",
+      "properties": {
+        "kind": {
+          "const": "for_each_file"
+        },
+        "require": {
+          "description": "Nested rules evaluated against each matched file.",
+          "items": {
+            "$ref": "#/$defs/nested_rule"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "select": {
+          "description": "Glob(s) selecting the files to iterate — a single glob, or a list with `!`-prefixed excludes.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          ]
+        },
+        "when_iter": {
+          "description": "Per-iteration `when:` filter — see rule_for_each_dir.when_iter. `iter.has_file(...)` always evaluates to false on file iteration; useful predicates here include `iter.basename`, `iter.ext`, `iter.parent_name`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "select",
+        "require"
+      ],
+      "type": "object"
+    },
+    "rule_for_each_match": {
+      "description": "For each line matching `select` (a regex), the line must satisfy the nested `require:` predicates: `matches` (the line matches all listed regexes), `forbid` (matches none), `equal` (the listed named `select` captures are all equal — checked on every `select` match on the line). The in-file line quantifier (the dual of `ordered_block`'s `select:`): one violation per offending line. Closes per-line changelog grammars ('every entry line must ALSO match Q1..Qn', which `file_content_matches` cannot express — its match is existence, not a per-line conjunction) and intra-line capture equality (RE2 has no backreference). Per-file.",
+      "properties": {
+        "kind": {
+          "const": "for_each_match"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "require": {
+          "additionalProperties": false,
           "description": "Predicates applied to each selected line; at least one of `matches` / `forbid` / `equal` is required.",
           "properties": {
-            "matches": {
-              "type": "array",
-              "items": { "type": "string" },
-              "description": "The selected line must match ALL of these regexes."
+            "equal": {
+              "description": "These named `select` captures must all be equal (the only way to assert intra-line capture equality, since RE2 has no backreference).",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 2,
+              "type": "array"
             },
             "forbid": {
-              "type": "array",
-              "items": { "type": "string" },
-              "description": "The selected line must match NONE of these regexes."
+              "description": "The selected line must match NONE of these regexes.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             },
-            "equal": {
-              "type": "array",
-              "items": { "type": "string" },
-              "minItems": 2,
-              "description": "These named `select` captures must all be equal (the only way to assert intra-line capture equality, since RE2 has no backreference)."
+            "matches": {
+              "description": "The selected line must match ALL of these regexes.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
-          "additionalProperties": false
+          "type": "object"
+        },
+        "select": {
+          "description": "Regex; a line is a checked element iff it matches. Named captures are available to `require.equal`.",
+          "type": "string"
         }
-      }
+      },
+      "required": [
+        "paths",
+        "select",
+        "require"
+      ],
+      "type": "object"
     },
-
     "rule_generated_file_fresh": {
       "description": "A committed artefact must equal what a declared `command` generator produces. Two modes, selected by shape (exactly one of `file` / `outputs` required): STDOUT mode (`file`) compares one committed file to the generator's stdout — non-mutating, never writes the tree. MUTATING / in-place mode (`outputs`, a glob or list of globs) runs an in-place generator and asserts the regenerated files are unchanged: alint snapshots `outputs`, runs the generator, diffs, reports any stale / new / removed file, and RESTORES the snapshot — so `alint check` stays pure (no regenerated files left behind); the alint-native form of `make gen && git diff --exit-code`. Either mode runs a process, so the kind is trust-gated to the user's own top-level config (same tier as the `command` rule). Single-shot, opt-in.",
-      "type": "object",
-      "required": ["command"],
       "oneOf": [
-        { "required": ["file"] },
-        { "required": ["outputs"] }
+        {
+          "required": [
+            "file"
+          ]
+        },
+        {
+          "required": [
+            "outputs"
+          ]
+        }
       ],
       "properties": {
-        "kind": { "const": "generated_file_fresh" },
+        "command": {
+          "description": "Generator argv (no shell). STDOUT mode: emit the file's contents to stdout. MUTATING mode: write the `outputs` in place.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
         "file": {
-          "type": "string",
-          "description": "STDOUT mode: the committed generated file to verify against the generator's stdout."
+          "description": "STDOUT mode: the committed generated file to verify against the generator's stdout.",
+          "type": "string"
+        },
+        "kind": {
+          "const": "generated_file_fresh"
+        },
+        "normalize": {
+          "enum": [
+            "none",
+            "trim",
+            "final-newline"
+          ]
         },
         "outputs": {
           "description": "MUTATING mode: the glob (or list of globs) the in-place generator rewrites; its presence selects the mutating mode. alint snapshots these, runs the generator, diffs, and restores them.",
           "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
           ]
         },
-        "command": {
-          "type": "array",
-          "items": { "type": "string" },
-          "minItems": 1,
-          "description": "Generator argv (no shell). STDOUT mode: emit the file's contents to stdout. MUTATING mode: write the `outputs` in place."
+        "timeout": {
+          "description": "Generator timeout in seconds (default 120). On timeout the child is killed and one violation is emitted.",
+          "minimum": 1,
+          "type": "integer"
         },
         "workdir": {
-          "type": "string",
-          "description": "Generator cwd, relative to the lint root (default: lint root)."
-        },
-        "normalize": { "enum": ["none", "trim", "final-newline"] },
-        "timeout": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Generator timeout in seconds (default 120). On timeout the child is killed and one violation is emitted."
+          "description": "Generator cwd, relative to the lint root (default: lint root).",
+          "type": "string"
         }
-      }
-    },
-
-    "rule_import_gate": {
-      "description": "Forbid imports whose extracted target matches `forbid` (a regex), within the `paths` scope — an architectural import firewall. Matches the EXTRACTED import target (not the raw line), the precise low-false-positive specialisation of `file_content_forbidden`. `language` (go/python/rust/js/scala/java/dart/nix) selects a built-in import-line pattern; `import_pattern` overrides it (capture group 1 = target; required for `generic`). `allow` globs exempt files inside the scope. Per-file.",
-      "type": "object",
-      "required": ["forbid"],
-      "properties": {
-        "kind": { "const": "import_gate" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "forbid": {
-          "type": "string",
-          "description": "Regex tested against the extracted import target."
-        },
-        "language": { "enum": ["go", "python", "rust", "js", "scala", "java", "dart", "nix", "generic"] },
-        "import_pattern": {
-          "type": "string",
-          "description": "Explicit import-line regex (capture group 1 = imported target); overrides the language preset."
-        },
-        "allow": {
-          "type": "array",
-          "items": { "type": "string" },
-          "description": "File globs inside the scope exempt from the gate."
-        }
-      }
-    },
-
-    "rule_command_idempotent": {
-      "description": "Run a user-declared formatter/checker in its --check (idempotence) mode once: exit 0 = the tree is formatter-clean (silent), non-zero = violation(s). alint never runs a mutating formatter and never writes the tree (the sibling of generated_file_fresh; same trust tier as the command rule — trust-gated to the user's own top-level config). With `files_from` (+ optional `files_pattern`) the tool's offender list is parsed into one violation per file. Single-shot, opt-in.",
-      "type": "object",
-      "required": ["command"],
-      "properties": {
-        "kind": { "const": "command_idempotent" },
-        "command": {
-          "type": "array",
-          "items": { "type": "string" },
-          "minItems": 1,
-          "description": "Checker argv (no shell), run in its --check / idempotence mode; exit 0 = clean."
-        },
-        "workdir": {
-          "type": "string",
-          "description": "Checker cwd, relative to the lint root (default: lint root)."
-        },
-        "files_from": {
-          "enum": ["none", "stdout", "stderr"],
-          "description": "On failure, parse this stream into per-file violations (default: none = one violation for the whole invocation)."
-        },
-        "files_pattern": {
-          "type": "string",
-          "description": "Regex whose capture group 1 is a file path, applied per output line (requires `files_from`; omit for bare-path listers)."
-        },
-        "timeout": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Checker timeout in seconds (default 120). On timeout the child is killed and one violation is emitted."
-        }
-      }
-    },
-
-    "rule_for_each_dir": {
-      "description": "For every directory matching `select`, every rule in `require` must pass. Path-template tokens in the nested rules are pre-substituted per iteration; use `{path}` to refer to the iterated directory itself. Optional `when_iter:` filters which iterations are evaluated, e.g. `iter.has_file(\"Cargo.toml\")` to scope to workspace members.",
-      "type": "object",
-      "required": ["select", "require"],
-      "properties": {
-        "kind": { "const": "for_each_dir" },
-        "select": {
-          "description": "Glob(s) selecting the directories to iterate — a single glob, or a list with `!`-prefixed excludes (e.g. [\"src/*\", \"!src/internal\"]).",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" }, "minItems": 1 }
-          ]
-        },
-        "when_iter": {
-          "type": "string",
-          "description": "Per-iteration `when:` filter — evaluated against `iter.*` in the iterated entry's context. Iterations whose verdict is false are skipped before any nested rule is built. Examples: `iter.has_file(\"Cargo.toml\")`, `iter.basename matches \"^pkg-\"`."
-        },
-        "require": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/nested_rule" },
-          "description": "Nested rules evaluated against each matched directory."
-        }
-      }
-    },
-
-    "rule_for_each_file": {
-      "description": "For every file matching `select`, every rule in `require` must pass. Path-template tokens in the nested rules are pre-substituted per iteration. Optional `when_iter:` filters iterations.",
-      "type": "object",
-      "required": ["select", "require"],
-      "properties": {
-        "kind": { "const": "for_each_file" },
-        "select": {
-          "description": "Glob(s) selecting the files to iterate — a single glob, or a list with `!`-prefixed excludes.",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" }, "minItems": 1 }
-          ]
-        },
-        "when_iter": {
-          "type": "string",
-          "description": "Per-iteration `when:` filter — see rule_for_each_dir.when_iter. `iter.has_file(...)` always evaluates to false on file iteration; useful predicates here include `iter.basename`, `iter.ext`, `iter.parent_name`."
-        },
-        "require": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/nested_rule" },
-          "description": "Nested rules evaluated against each matched file."
-        }
-      }
-    },
-
-    "rule_dir_only_contains": {
-      "description": "Every direct child *file* of directories matching `select` must match at least one glob in `allow`. Subdirectories of the matched dir are not checked. Allow globs match the child's basename.",
-      "type": "object",
-      "required": ["select", "allow"],
-      "properties": {
-        "kind": { "const": "dir_only_contains" },
-        "select": {
-          "type": "string",
-          "description": "Glob selecting the directories to enumerate."
-        },
-        "allow": {
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" }, "minItems": 1 }
-          ],
-          "description": "Basename glob(s) accepted as direct children. Anything else is a violation."
-        }
-      }
-    },
-
-    "rule_unique_by": {
-      "description": "Flag any group of files (matching `select`) sharing the same rendered `key`. One violation per collision group, anchored on the lexicographically-first file. Path-template tokens ({path}, {dir}, {basename}, {stem}, {ext}, {parent_name}) may appear in `key`. With `case_insensitive: true` the key is folded to lowercase before grouping, catching collisions that only occur on a case-insensitive filesystem (Windows / macOS).",
-      "type": "object",
-      "required": ["select"],
-      "properties": {
-        "kind": { "const": "unique_by" },
-        "select": {
-          "type": "string",
-          "description": "Glob selecting the files to deduplicate."
-        },
-        "key": {
-          "type": "string",
-          "default": "{basename}",
-          "description": "Path-template producing a key per matched file. Default: {basename}."
-        },
-        "case_insensitive": {
-          "type": "boolean",
-          "default": false,
-          "description": "Fold the key to lowercase before grouping (case-insensitive-filesystem collision detection)."
-        }
-      }
-    },
-
-    "rule_dir_contains": {
-      "description": "Every directory matching `select` must have at least one direct child basename matching each glob in `require`. Sugar over for_each_dir + file_exists; use for_each_dir for deeper semantics.",
-      "type": "object",
-      "required": ["select", "require"],
-      "properties": {
-        "kind": { "const": "dir_contains" },
-        "select": { "type": "string" },
-        "require": {
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" }, "minItems": 1 }
-          ],
-          "description": "Basename glob(s) — every dir matching `select` must have at least one child matching each."
-        }
-      }
-    },
-
-    "rule_every_matching_has": {
-      "description": "Every file OR directory matching `select` must satisfy every nested rule in `require`. Sugar that combines for_each_file + for_each_dir into one rule. Optional `when_iter:` filters iterations.",
-      "type": "object",
-      "required": ["select", "require"],
-      "properties": {
-        "kind": { "const": "every_matching_has" },
-        "select": {
-          "description": "Glob(s) selecting the files/dirs to iterate — a single glob, or a list with `!`-prefixed excludes (e.g. [\"packages/*\", \"!packages/internal\"]).",
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" }, "minItems": 1 }
-          ]
-        },
-        "when_iter": {
-          "type": "string",
-          "description": "Per-iteration `when:` filter — see rule_for_each_dir.when_iter."
-        },
-        "require": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/nested_rule" }
-        }
-      }
-    },
-
-    "rule_no_trailing_whitespace": {
-      "description": "No line in any file in scope ends with a space or tab. Non-UTF-8 files are skipped silently.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_trailing_whitespace" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_final_newline": {
-      "description": "Every non-empty file in scope must end with a newline byte. Empty files are considered fine.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "final_newline" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_line_endings": {
-      "description": "Every line ending in every file in scope must use the `target` style (`lf` or `crlf`). Mixed endings within a file also fail.",
-      "type": "object",
-      "required": ["paths", "target"],
-      "properties": {
-        "kind": { "const": "line_endings" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "target": { "type": "string", "enum": ["lf", "crlf"] }
-      }
-    },
-
-    "rule_line_max_width": {
-      "description": "No line in any file in scope exceeds `max_width` Unicode scalar values (chars). Display width is NOT computed — use a formatter for that. Check-only; truncation is not a safe auto-fix.",
-      "type": "object",
-      "required": ["paths", "max_width"],
-      "properties": {
-        "kind": { "const": "line_max_width" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "max_width": { "type": "integer", "minimum": 1 }
-      }
-    },
-
-    "rule_no_merge_conflict_markers": {
-      "description": "Flag files that still contain git conflict markers at the start of a line (`<<<<<<< `, `=======`, `>>>>>>> `, `||||||| `). Check-only; conflict resolution requires human judgment.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_merge_conflict_markers" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_no_bidi_controls": {
-      "description": "Flag Unicode bidirectional control characters (U+202A–202E, U+2066–2069) anywhere in a file. Trojan Source (CVE-2021-42574) defense. Fixable via `file_strip_bidi`.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_bidi_controls" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_no_zero_width_chars": {
-      "description": "Flag zero-width characters (U+200B/C/D, plus body-internal U+FEFF). A leading U+FEFF (BOM) is not flagged here — use `no_bom` for that. Fixable via `file_strip_zero_width`.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_zero_width_chars" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_file_is_ascii": {
-      "description": "Every byte in every file in scope must be < 0x80 (pure ASCII), except codepoints listed in `allow:`. Stricter than file_is_text; check-only — auto-replacement for non-ASCII bytes would silently lose meaning. With `allow:` the file is decoded as UTF-8 and checked per character; without it, the strict byte-level fast path is used.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "file_is_ascii" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "allow": {
-          "type": "array",
-          "description": "Permitted non-ASCII codepoints — each entry a single character (e.g. \"ö\"), a `U+XXXX` codepoint, or a `U+XXXX-U+YYYY` inclusive range.",
-          "items": { "type": "string" }
-        }
-      }
-    },
-
-    "rule_no_bom": {
-      "description": "Flag files that start with a UTF-8 / UTF-16 / UTF-32 BOM. Fixable via `file_strip_bom`.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_bom" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_file_hash": {
-      "description": "Each file in scope must have content whose SHA-256 equals the declared `sha256`. Accepts a bare 64-char hex string or a `sha256:`-prefixed form.",
-      "type": "object",
-      "required": ["paths", "sha256"],
-      "properties": {
-        "kind": { "const": "file_hash" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "sha256": { "type": "string", "pattern": "^(sha256:)?[0-9a-fA-F]{64}$" }
-      }
-    },
-
-    "rule_max_directory_depth": {
-      "description": "Every path in scope must sit at depth ≤ `max_depth` (number of `/`-separated components). Check-only; file relocation is a human decision.",
-      "type": "object",
-      "required": ["paths", "max_depth"],
-      "properties": {
-        "kind": { "const": "max_directory_depth" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "max_depth": { "type": "integer", "minimum": 1 }
-      }
-    },
-
-    "rule_max_files_per_directory": {
-      "description": "Every directory containing at least one in-scope file must hold ≤ `max_files` in-scope files (immediate children, non-recursive). Check-only.",
-      "type": "object",
-      "required": ["paths", "max_files"],
-      "properties": {
-        "kind": { "const": "max_files_per_directory" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "max_files": { "type": "integer", "minimum": 1 }
-      }
-    },
-
-    "rule_no_empty_files": {
-      "description": "Flag zero-byte files. Fixable via `file_remove`, which deletes the empty file.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_empty_files" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_no_case_conflicts": {
-      "description": "Flag pairs of paths that differ only by case (e.g. README.md + readme.md). These can't coexist on macOS HFS+/APFS or Windows NTFS.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_case_conflicts" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_no_illegal_windows_names": {
-      "description": "Reject path components Windows can't represent: reserved device names (CON/PRN/AUX/NUL/COM1-9/LPT1-9 regardless of extension), trailing dots or spaces, and the forbidden chars <>:\"|?*.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_illegal_windows_names" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_no_symlinks": {
-      "description": "Flag tracked paths that are symbolic links. Symlinks are a portability headache across Windows/macOS/Linux and CI runners. Fixable via `file_remove`, which deletes the symlink.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "no_symlinks" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_executable_bit": {
-      "description": "Assert that every file in scope either has the Unix +x bit set (`require: true`) or does not (`require: false`). No-op on non-Unix platforms. No fix op (chmod auto-apply deferred).",
-      "type": "object",
-      "required": ["paths", "require"],
-      "properties": {
-        "kind": { "const": "executable_bit" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "require": {
-          "type": "boolean",
-          "description": "`true`: +x must be set. `false`: +x must not be set."
-        }
-      }
-    },
-
-    "rule_executable_has_shebang": {
-      "description": "Every file with the +x bit set must begin with a shebang (`#!`). Catches scripts that were marked executable but whose content is a plain text file or missing a shebang. No-op on non-Unix.",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "executable_has_shebang" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_shebang_has_executable": {
-      "description": "Every file that starts with `#!` must have the Unix +x bit set. The inverse of `executable_has_shebang`. No-op on non-Unix. No fix op (chmod auto-apply deferred).",
-      "type": "object",
-      "required": ["paths"],
-      "properties": {
-        "kind": { "const": "shebang_has_executable" },
-        "paths": { "$ref": "#/$defs/paths_spec" }
-      }
-    },
-
-    "rule_no_submodules": {
-      "description": "Flag the presence of `.gitmodules` at the repo root. Always targets `.gitmodules` — no `paths` field accepted. Fixable via `file_remove`.",
-      "type": "object",
-      "required": ["kind"],
-      "properties": {
-        "kind": { "const": "no_submodules" }
       },
-      "not": {
-        "required": ["paths"]
-      }
+      "required": [
+        "command"
+      ],
+      "type": "object"
     },
-
-    "rule_indent_style": {
-      "description": "Every non-blank line must indent with the configured style. `tabs` rejects any leading space; `spaces` rejects any leading tab and optionally requires the leading-space count to be a multiple of `width`. Check-only — tab-width-aware reindentation is deferred.",
-      "type": "object",
-      "required": ["paths", "style"],
+    "rule_git_blame_age": {
+      "description": "Fire on lines matching a regex whose `git blame` author-time is older than `max_age_days`. Closes the gap between `level: warning` on every TODO (too noisy) and `level: off` (accepts unbounded debt accumulation). Use cases: stale TODO / FIXME / XXX / HACK markers, abandoned `@deprecated` JSDoc tags, model-attributed TODOs that nobody followed up on. Outside a git repo, on untracked files, or when blame fails for any other reason, the rule silently no-ops per file. Heuristic notes: formatting passes (cargo fmt, prettier) reset blame age unless the formatting commit is listed in `.git-blame-ignore-revs`; vendored / imported code carries the import commit's timestamp; squash-merged PRs collapse to a single date. Check-only — auto-removing matched lines is destructive.",
       "properties": {
-        "kind": { "const": "indent_style" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "style": {
-          "type": "string",
-          "enum": ["tabs", "spaces"]
+        "kind": {
+          "const": "git_blame_age"
         },
-        "width": {
-          "type": "integer",
+        "max_age_days": {
+          "description": "Minimum line age (in days) for a matching line to fire as a violation.\nLines younger than this pass silently.",
+          "format": "uint64",
           "minimum": 1,
-          "description": "When `style: spaces`, the leading-space count on every non-blank line must be a multiple of this. Ignored for `style: tabs`."
-        }
-      }
-    },
-
-    "rule_max_consecutive_blank_lines": {
-      "description": "Cap the number of blank lines that may appear in a row. A blank line is empty or only whitespace. Fixable via `file_collapse_blank_lines`, which collapses over-long runs to exactly `max` blank lines.",
-      "type": "object",
-      "required": ["paths", "max"],
-      "properties": {
-        "kind": { "const": "max_consecutive_blank_lines" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "max": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Maximum number of blank lines allowed in a row. `0` means no blank lines at all."
-        }
-      }
-    },
-
-    "rule_file_starts_with": {
-      "description": "Every file in scope must begin with the given prefix (byte-level). Useful for SPDX headers, generated-file sentinels, magic bytes. Check-only; pair with `file_prepend` if you want auto-prepend (prevents silent duplication on near-matches).",
-      "type": "object",
-      "required": ["paths", "prefix"],
-      "properties": {
-        "kind": { "const": "file_starts_with" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "prefix": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Required prefix, matched byte-for-byte."
-        }
-      }
-    },
-
-    "rule_file_ends_with": {
-      "description": "Every file in scope must end with the given suffix (byte-level). For a simple trailing-newline check, prefer `final_newline`. Check-only; pair with `file_append` if you want auto-append.",
-      "type": "object",
-      "required": ["paths", "suffix"],
-      "properties": {
-        "kind": { "const": "file_ends_with" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "suffix": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Required suffix, matched byte-for-byte."
-        }
-      }
-    },
-
-    "rule_command": {
-      "description": "Shell out to an external CLI per matched file. argv[0] is the program; remaining tokens support path-template substitution (`{path}`, `{dir}`, `{stem}`, `{ext}`, `{basename}`, `{parent_name}`). Working dir = repo root; stdin = /dev/null. Env: ALINT_PATH, ALINT_ROOT, ALINT_RULE_ID, ALINT_LEVEL, plus ALINT_VAR_<NAME> per `vars:` and ALINT_FACT_<NAME> per resolved fact. Verdict: exit 0 = pass; non-zero = one violation whose message is the (truncated) stdout+stderr. Trust-gated: only allowed in the user's top-level config (rejected at load-time when introduced via `extends:` or a bundled ruleset).",
-      "type": "object",
-      "required": ["paths", "command"],
-      "properties": {
-        "kind": { "const": "command" },
-        "paths": { "$ref": "#/$defs/paths_spec" },
-        "command": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "type": "string" },
-          "description": "Argv tokens. The first token is the program (looked up via PATH if it's a bare name); remaining tokens accept `{path}` and friends."
+          "type": "integer"
         },
-        "timeout": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Per-file timeout in seconds. Default 30. Past this, the child is killed and a violation reports the timeout."
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "pattern": {
+          "description": "Rust-regex pattern applied to each blame line's content. Capture group 1\n(when present) is exposed as `{{ctx.match}}` in the message template;\nwithout a capture group, `{{ctx.match}}` substitutes the full match.",
+          "type": "string"
         }
-      }
-    },
-
-    "fact": {
-      "description": "A single fact declaration. Each fact has an `id` plus exactly one kind-specific field.",
-      "type": "object",
-      "required": ["id"],
-      "properties": {
-        "id": { "$ref": "#/$defs/rule_id" }
       },
-      "oneOf": [
+      "required": [
+        "paths",
+        "pattern",
+        "max_age_days"
+      ],
+      "type": "object"
+    },
+    "rule_git_commit_author_allowlist": {
+      "anyOf": [
         {
-          "required": ["any_file_exists"],
-          "properties": {
-            "any_file_exists": { "$ref": "#/$defs/string_or_string_array" }
-          }
+          "required": [
+            "email_pattern"
+          ]
         },
         {
-          "required": ["all_files_exist"],
-          "properties": {
-            "all_files_exist": { "$ref": "#/$defs/string_or_string_array" }
-          }
-        },
-        {
-          "required": ["count_files"],
-          "properties": {
-            "count_files": { "type": "string" }
-          }
-        },
-        {
-          "required": ["file_content_matches"],
-          "properties": {
-            "file_content_matches": {
-              "type": "object",
-              "required": ["paths", "pattern"],
-              "additionalProperties": false,
-              "properties": {
-                "paths": { "$ref": "#/$defs/string_or_string_array" },
-                "pattern": {
-                  "type": "string",
-                  "description": "Rust-regex pattern matched against the content of every file in `paths`. The fact is true iff at least one file contains a match. Non-UTF-8 files are skipped."
-                }
-              }
-            }
-          }
-        },
-        {
-          "required": ["git_branch"],
-          "properties": {
-            "git_branch": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {},
-              "description": "Read `<repo>/.git/HEAD` and return the current branch name (string). Detached HEAD, no `.git/` directory, or any unrecognized layout resolves to an empty string (falsy under `when:`)."
-            }
-          }
-        },
-        {
-          "required": ["custom"],
-          "properties": {
-            "custom": {
-              "type": "object",
-              "required": ["argv"],
-              "additionalProperties": false,
-              "properties": {
-                "argv": {
-                  "type": "array",
-                  "minItems": 1,
-                  "items": { "type": "string" },
-                  "description": "Program + arguments, passed verbatim to the OS (no shell). Fact value is the process's stdout (trimmed). Non-zero exit, spawn failure, or non-UTF-8 output all resolve to an empty string. SECURITY: `custom:` is only valid in the user's top-level config — alint refuses to load an extended config that declares one."
-                }
-              }
-            }
-          }
+          "required": [
+            "name_pattern"
+          ]
         }
       ],
-      "unevaluatedProperties": false
+      "description": "Assert every commit author in scope matches an allowed email and/or name pattern. At least one of `email_pattern:` / `name_pattern:` is required; specifying both means BOTH must match (AND). A commit whose author fails any specified pattern fires one violation. With `since:` unset, only HEAD is checked; with `since:` set to a ref, every commit in `<since>..HEAD` is checked. Demand: enterprise repos enforcing contributor identity against a corporate domain; OSS projects catching sock-puppet / compromised-account commits. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
+      "properties": {
+        "email_pattern": {
+          "default": null,
+          "description": "Rust-regex the author email (`git log %ae`) must match, e.g.\n`^.+@example\\.com$`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "include_merges": {
+          "default": false,
+          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "type": "boolean"
+        },
+        "kind": {
+          "const": "git_commit_author_allowlist"
+        },
+        "name_pattern": {
+          "default": null,
+          "description": "Rust-regex the author name (`git log %an`) must match.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "since": {
+          "default": null,
+          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "rule_git_commit_gpg_signed": {
+      "description": "Assert every commit in scope has a verifying signature (`git verify-commit` exits 0). A commit that is unsigned, or signed with a key that doesn't verify against the local keyring, fires one violation. With `since:` unset, only HEAD is checked; with `since:` set to a ref, every commit in `<since>..HEAD` is checked. Demand: kernel maintainers, security-sensitive OSS, GitHub 'Require signed commits' branch protection. Reflects git's own verdict — does NOT distinguish 'unsigned' from 'signed with an untrusted key' (trust is git's GPG config / `.git/allowed_signers`). Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
+      "properties": {
+        "include_merges": {
+          "default": false,
+          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "type": "boolean"
+        },
+        "kind": {
+          "const": "git_commit_gpg_signed"
+        },
+        "since": {
+          "default": null,
+          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "rule_git_commit_message": {
+      "anyOf": [
+        {
+          "required": [
+            "pattern"
+          ]
+        },
+        {
+          "required": [
+            "subject_max_length"
+          ]
+        },
+        {
+          "required": [
+            "requires_body"
+          ]
+        }
+      ],
+      "description": "Validate one or more commit messages against shape rules: regex, max subject length, body required. With `since:` unset, only HEAD is checked. With `since:` set to a ref, every commit in `<since>..HEAD` is checked (oldest first, merge commits excluded by default); right shape for PR-trigger workflows where HEAD is a synthetic `actions/checkout` merge commit. At least one of `pattern:` / `subject_max_length:` / `requires_body: true` must be set. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
+      "properties": {
+        "include_merges": {
+          "default": false,
+          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset; combining `include_merges: true` with no\n`since:` is a load-time error.",
+          "type": "boolean"
+        },
+        "kind": {
+          "const": "git_commit_message"
+        },
+        "pattern": {
+          "default": null,
+          "description": "Rust-regex pattern the full message (subject + body, joined with\nnewlines) must match. Use `(?s)` to make `.` match newlines.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "requires_body": {
+          "default": false,
+          "description": "When true, the message must have a non-empty body, that is, at least\none line of content after the subject's blank-line separator.",
+          "type": "boolean"
+        },
+        "since": {
+          "default": null,
+          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does: SHA (full or abbreviated), branch (`origin/main`),\ntag (`v1.2.3`), or relative ref (`HEAD~5`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "subject_max_length": {
+          "default": null,
+          "description": "Maximum number of characters allowed in the subject line. Common\nvalues: 50 (Tim Pope's recommendation), 72 (GitHub PR-title cutoff).",
+          "format": "uint",
+          "minimum": 1,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "rule_git_commit_no_fixup": {
+      "description": "Fail on residual `fixup!` / `squash!` / `amend!` commits in scope — the ones `git commit --fixup`/`--squash` produce, meant to be collapsed by `git rebase --autosquash` before merging. With `since:` unset, only HEAD is checked; with `since:` set to a ref, every commit in `<since>..HEAD` is checked. No configuration knobs — the matched prefixes are exactly what `--autosquash` understands. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
+      "properties": {
+        "include_merges": {
+          "default": false,
+          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "type": "boolean"
+        },
+        "kind": {
+          "const": "git_commit_no_fixup"
+        },
+        "since": {
+          "default": null,
+          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "rule_git_commit_signed_off": {
+      "description": "Assert every commit in scope carries a DCO `Signed-off-by:` trailer. With `since:` unset, only HEAD is checked; with `since:` set to a ref, every commit in `<since>..HEAD` is checked (oldest first, merge commits excluded by default) — the right shape for PR-trigger workflows. Required by CNCF / Linux Foundation / kernel-style projects. Outside a git repo, with no commits, or when `git` is unavailable, silently no-ops. A `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
+      "properties": {
+        "include_merges": {
+          "default": false,
+          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "type": "boolean"
+        },
+        "kind": {
+          "const": "git_commit_signed_off"
+        },
+        "pattern": {
+          "default": null,
+          "description": "Trailer pattern each commit message must contain. Defaults to the\ncanonical DCO sign-off shape. Override to enforce a stricter form\n(e.g. a corporate-domain email).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "since": {
+          "default": null,
+          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD. Accepts anything\n`git rev-parse` does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "rule_git_commit_subject_matches": {
+      "description": "Each commit's subject line (the first line of its message) must match the `matches:` regex — the subject-grammar member of the commit family (e.g. `pkg/path: lowercase summary`, conventional-commit types). Anchored to the subject alone, unlike `git_commit_message`'s whole-message `pattern:`; use `git_commit_message`'s `subject_max_length:` for a length cap. With `since:` unset, only HEAD is checked; with `since:` set, every commit in `<since>..HEAD`. Outside a git repo / with no commits / when git is unavailable, silently no-ops; a bad `since:` ref hard-fails with a shallow-clone hint.",
+      "properties": {
+        "include_merges": {
+          "default": false,
+          "description": "When validating a range (`since:` set), include merge commits. Has no\neffect when `since:` is unset.",
+          "type": "boolean"
+        },
+        "kind": {
+          "const": "git_commit_subject_matches"
+        },
+        "matches": {
+          "description": "Rust-regex the commit subject (first line of the message) must match.",
+          "type": "string"
+        },
+        "since": {
+          "default": null,
+          "description": "Git ref to use as the base of the commit range. When set, validates\nevery commit in `<since>..HEAD` instead of just HEAD.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "matches"
+      ],
+      "type": "object"
+    },
+    "rule_git_no_denied_paths": {
+      "description": "Fire when any tracked path matches a configured glob denylist. Companion of `git_tracked_only` for the absence axis: catches secrets, large binaries, or accidentally-tracked artifacts that would otherwise need a `file_absent` per pattern. With `since:` set, only paths changed in the `<since>...HEAD` diff are flagged (PR-scoped). Outside a git repo, silently no-ops; a `since:` ref that fails to resolve hard-fails with a shallow-clone hint.",
+      "properties": {
+        "denied": {
+          "description": "Globset patterns no tracked path may match. Both whole-path patterns\n(`secrets/**`) and basename-only patterns (`*.env`) work.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "kind": {
+          "const": "git_no_denied_paths"
+        },
+        "since": {
+          "default": null,
+          "description": "Optional git ref. When set, only denied paths that changed in the\n`<since>...HEAD` diff are flagged, catches a secret added in a PR even if\nHEAD's tree still tracks an older one. Accepts the `{{env.X}}`\ninterpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "denied"
+      ],
+      "type": "object"
+    },
+    "rule_id": {
+      "description": "Unique kebab-case identifier for the rule.",
+      "pattern": "^[a-z][a-z0-9_-]*$",
+      "type": "string"
+    },
+    "rule_import_gate": {
+      "description": "Forbid imports whose extracted target matches `forbid` (a regex), within the `paths` scope — an architectural import firewall. Matches the EXTRACTED import target (not the raw line), the precise low-false-positive specialisation of `file_content_forbidden`. `language` (go/python/rust/js/scala/java/dart/nix) selects a built-in import-line pattern; `import_pattern` overrides it (capture group 1 = target; required for `generic`). `allow` globs exempt files inside the scope. Per-file.",
+      "properties": {
+        "allow": {
+          "description": "File globs inside the scope exempt from the gate.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "forbid": {
+          "description": "Regex tested against the extracted import target.",
+          "type": "string"
+        },
+        "import_pattern": {
+          "description": "Explicit import-line regex (capture group 1 = imported target); overrides the language preset.",
+          "type": "string"
+        },
+        "kind": {
+          "const": "import_gate"
+        },
+        "language": {
+          "enum": [
+            "go",
+            "python",
+            "rust",
+            "js",
+            "scala",
+            "java",
+            "dart",
+            "nix",
+            "generic"
+          ]
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "forbid"
+      ],
+      "type": "object"
+    },
+    "rule_indent_style": {
+      "description": "Every non-blank line must indent with the configured style. `tabs` rejects any leading space; `spaces` rejects any leading tab and optionally requires the leading-space count to be a multiple of `width`. Check-only — tab-width-aware reindentation is deferred.",
+      "properties": {
+        "kind": {
+          "const": "indent_style"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "style": {
+          "enum": [
+            "tabs",
+            "spaces"
+          ],
+          "type": "string"
+        },
+        "width": {
+          "description": "When `style: spaces`, the leading-space count on every non-blank line must be a multiple of this. Ignored for `style: tabs`.",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "paths",
+        "style"
+      ],
+      "type": "object"
+    },
+    "rule_json_path_equals": {
+      "description": "Value at a JSONPath (RFC 9535) expression in every JSON file in `paths` must deep-equal `equals`. Multiple matches all must match; zero matches is a violation (value missing) unless `if_present: true`. Typical use: `$.license == \"MIT\"` on every `packages/*/package.json`.",
+      "properties": {
+        "equals": {
+          "description": "Expected value. Any JSON type (string, number, boolean, null, array, object)."
+        },
+        "if_present": {
+          "$ref": "#/$defs/if_present"
+        },
+        "kind": {
+          "const": "json_path_equals"
+        },
+        "path": {
+          "description": "JSONPath expression rooted at `$`. Supports dot-access (`$.foo.bar`), array index (`$.deps[0]`), wildcards (`$.deps[*]`), filters, and every other RFC 9535 construct.",
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "path",
+        "equals"
+      ],
+      "type": "object"
+    },
+    "rule_json_path_matches": {
+      "description": "Value at a JSONPath in every JSON file in `paths` must be a string and must match `matches` (a Rust regex). Non-string matches produce a clear 'not a string' violation.",
+      "properties": {
+        "if_present": {
+          "$ref": "#/$defs/if_present"
+        },
+        "kind": {
+          "const": "json_path_matches"
+        },
+        "matches": {
+          "description": "Rust-regex pattern to match against the value at `path`.",
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "path",
+        "matches"
+      ],
+      "type": "object"
+    },
+    "rule_json_schema_passes": {
+      "description": "Validate every JSON / YAML / TOML file in `paths` against the JSON Schema at `schema_path`. Each schema-violation error becomes one violation; a target that fails to parse produces one parse-error violation. Format is detected from the target's extension; pass `format:` to override.",
+      "properties": {
+        "format": {
+          "description": "Override the auto-detected target format. When omitted, format is inferred from each target file's extension (.json / .yaml / .yml / .toml).",
+          "enum": [
+            "json",
+            "yaml",
+            "yml",
+            "toml"
+          ],
+          "type": "string"
+        },
+        "kind": {
+          "const": "json_schema_passes"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "schema_path": {
+          "description": "Path to a JSON Schema file relative to the lint root. Schema must itself be JSON even when validating YAML / TOML targets.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths",
+        "schema_path"
+      ],
+      "type": "object"
+    },
+    "rule_kind_dispatch": {
+      "description": "Dispatch on the `kind` discriminator. Each branch sets the required kind-specific fields.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/rule_file_exists"
+        },
+        {
+          "$ref": "#/$defs/rule_file_absent"
+        },
+        {
+          "$ref": "#/$defs/rule_dir_exists"
+        },
+        {
+          "$ref": "#/$defs/rule_dir_absent"
+        },
+        {
+          "$ref": "#/$defs/rule_file_content_matches"
+        },
+        {
+          "$ref": "#/$defs/rule_file_content_forbidden"
+        },
+        {
+          "$ref": "#/$defs/rule_file_header"
+        },
+        {
+          "$ref": "#/$defs/rule_file_max_size"
+        },
+        {
+          "$ref": "#/$defs/rule_file_min_size"
+        },
+        {
+          "$ref": "#/$defs/rule_file_min_lines"
+        },
+        {
+          "$ref": "#/$defs/rule_file_max_lines"
+        },
+        {
+          "$ref": "#/$defs/rule_file_footer"
+        },
+        {
+          "$ref": "#/$defs/rule_file_shebang"
+        },
+        {
+          "$ref": "#/$defs/rule_file_is_text"
+        },
+        {
+          "$ref": "#/$defs/rule_json_path_equals"
+        },
+        {
+          "$ref": "#/$defs/rule_json_path_matches"
+        },
+        {
+          "$ref": "#/$defs/rule_yaml_path_equals"
+        },
+        {
+          "$ref": "#/$defs/rule_yaml_path_matches"
+        },
+        {
+          "$ref": "#/$defs/rule_toml_path_equals"
+        },
+        {
+          "$ref": "#/$defs/rule_toml_path_matches"
+        },
+        {
+          "$ref": "#/$defs/rule_xml_path_equals"
+        },
+        {
+          "$ref": "#/$defs/rule_xml_path_matches"
+        },
+        {
+          "$ref": "#/$defs/rule_json_schema_passes"
+        },
+        {
+          "$ref": "#/$defs/rule_commented_out_code"
+        },
+        {
+          "$ref": "#/$defs/rule_markdown_paths_resolve"
+        },
+        {
+          "$ref": "#/$defs/rule_git_no_denied_paths"
+        },
+        {
+          "$ref": "#/$defs/rule_git_commit_message"
+        },
+        {
+          "$ref": "#/$defs/rule_git_commit_signed_off"
+        },
+        {
+          "$ref": "#/$defs/rule_git_commit_subject_matches"
+        },
+        {
+          "$ref": "#/$defs/rule_git_commit_no_fixup"
+        },
+        {
+          "$ref": "#/$defs/rule_git_commit_author_allowlist"
+        },
+        {
+          "$ref": "#/$defs/rule_git_commit_gpg_signed"
+        },
+        {
+          "$ref": "#/$defs/rule_git_blame_age"
+        },
+        {
+          "$ref": "#/$defs/rule_changeset_requires_path"
+        },
+        {
+          "$ref": "#/$defs/rule_pair_changed_together"
+        },
+        {
+          "$ref": "#/$defs/rule_filename_case"
+        },
+        {
+          "$ref": "#/$defs/rule_filename_regex"
+        },
+        {
+          "$ref": "#/$defs/rule_pair"
+        },
+        {
+          "$ref": "#/$defs/rule_pair_hash"
+        },
+        {
+          "$ref": "#/$defs/rule_registry_paths_resolve"
+        },
+        {
+          "$ref": "#/$defs/rule_cross_file"
+        },
+        {
+          "$ref": "#/$defs/rule_file_graph"
+        },
+        {
+          "$ref": "#/$defs/rule_ordered_block"
+        },
+        {
+          "$ref": "#/$defs/rule_for_each_match"
+        },
+        {
+          "$ref": "#/$defs/rule_generated_file_fresh"
+        },
+        {
+          "$ref": "#/$defs/rule_import_gate"
+        },
+        {
+          "$ref": "#/$defs/rule_command_idempotent"
+        },
+        {
+          "$ref": "#/$defs/rule_for_each_dir"
+        },
+        {
+          "$ref": "#/$defs/rule_for_each_file"
+        },
+        {
+          "$ref": "#/$defs/rule_dir_only_contains"
+        },
+        {
+          "$ref": "#/$defs/rule_unique_by"
+        },
+        {
+          "$ref": "#/$defs/rule_dir_contains"
+        },
+        {
+          "$ref": "#/$defs/rule_every_matching_has"
+        },
+        {
+          "$ref": "#/$defs/rule_no_trailing_whitespace"
+        },
+        {
+          "$ref": "#/$defs/rule_final_newline"
+        },
+        {
+          "$ref": "#/$defs/rule_line_endings"
+        },
+        {
+          "$ref": "#/$defs/rule_line_max_width"
+        },
+        {
+          "$ref": "#/$defs/rule_no_merge_conflict_markers"
+        },
+        {
+          "$ref": "#/$defs/rule_no_bidi_controls"
+        },
+        {
+          "$ref": "#/$defs/rule_no_zero_width_chars"
+        },
+        {
+          "$ref": "#/$defs/rule_file_is_ascii"
+        },
+        {
+          "$ref": "#/$defs/rule_no_bom"
+        },
+        {
+          "$ref": "#/$defs/rule_file_hash"
+        },
+        {
+          "$ref": "#/$defs/rule_max_directory_depth"
+        },
+        {
+          "$ref": "#/$defs/rule_max_files_per_directory"
+        },
+        {
+          "$ref": "#/$defs/rule_no_empty_files"
+        },
+        {
+          "$ref": "#/$defs/rule_no_case_conflicts"
+        },
+        {
+          "$ref": "#/$defs/rule_no_illegal_windows_names"
+        },
+        {
+          "$ref": "#/$defs/rule_no_symlinks"
+        },
+        {
+          "$ref": "#/$defs/rule_executable_bit"
+        },
+        {
+          "$ref": "#/$defs/rule_executable_has_shebang"
+        },
+        {
+          "$ref": "#/$defs/rule_shebang_has_executable"
+        },
+        {
+          "$ref": "#/$defs/rule_no_submodules"
+        },
+        {
+          "$ref": "#/$defs/rule_indent_style"
+        },
+        {
+          "$ref": "#/$defs/rule_max_consecutive_blank_lines"
+        },
+        {
+          "$ref": "#/$defs/rule_file_starts_with"
+        },
+        {
+          "$ref": "#/$defs/rule_file_ends_with"
+        },
+        {
+          "$ref": "#/$defs/rule_command"
+        }
+      ]
+    },
+    "rule_line_endings": {
+      "description": "Every line ending in every file in scope must use the `target` style (`lf` or `crlf`). Mixed endings within a file also fail.",
+      "properties": {
+        "kind": {
+          "const": "line_endings"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "target": {
+          "enum": [
+            "lf",
+            "crlf"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "paths",
+        "target"
+      ],
+      "type": "object"
+    },
+    "rule_line_max_width": {
+      "description": "No line in any file in scope exceeds `max_width` Unicode scalar values (chars). Display width is NOT computed — use a formatter for that. Check-only; truncation is not a safe auto-fix.",
+      "properties": {
+        "kind": {
+          "const": "line_max_width"
+        },
+        "max_width": {
+          "description": "Maximum number of Unicode scalar values (chars) allowed per line.",
+          "format": "uint",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "max_width"
+      ],
+      "type": "object"
+    },
+    "rule_markdown_paths_resolve": {
+      "description": "Validate that backticked workspace paths in markdown files resolve to real files or directories in the repo. Targets the AGENTS.md / CLAUDE.md / .cursorrules staleness problem: agent-context files reference paths in inline backticks, and those paths drift as the codebase evolves. Skips fenced and 4-space-indented code blocks (those contain code samples, not factual claims about the tree). Required `prefixes` field marks which path-shapes to validate (e.g. `[\"src/\", \"crates/\", \"docs/\"]`); backticked tokens not starting with a configured prefix are ignored, eliminating the FP class of `\\`npm\\`` / `\\`function\\`` / etc.",
+      "properties": {
+        "ignore_template_vars": {
+          "default": true,
+          "description": "Skip backticked tokens containing template-variable\nmarkers (`{{ }}`, `${ }`, `<…>`). Default true.",
+          "type": "boolean"
+        },
+        "kind": {
+          "const": "markdown_paths_resolve"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "prefixes": {
+          "description": "Whitelist of path-shape prefixes to validate. A backticked\ntoken must start with one of these to be considered a path\ncandidate. No defaults — every project's layout differs and\nthe user must declare which prefixes mark a path.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "paths",
+        "prefixes"
+      ],
+      "type": "object"
+    },
+    "rule_max_consecutive_blank_lines": {
+      "description": "Cap the number of blank lines that may appear in a row. A blank line is empty or only whitespace. Fixable via `file_collapse_blank_lines`, which collapses over-long runs to exactly `max` blank lines.",
+      "properties": {
+        "kind": {
+          "const": "max_consecutive_blank_lines"
+        },
+        "max": {
+          "description": "Maximum number of blank lines allowed in a row. `0` means\nno blank lines at all.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "max"
+      ],
+      "type": "object"
+    },
+    "rule_max_directory_depth": {
+      "description": "Every path in scope must sit at depth ≤ `max_depth` (number of `/`-separated components). Check-only; file relocation is a human decision.",
+      "properties": {
+        "kind": {
+          "const": "max_directory_depth"
+        },
+        "max_depth": {
+          "description": "Maximum allowed path depth (number of `/`-separated components).",
+          "format": "uint",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "max_depth"
+      ],
+      "type": "object"
+    },
+    "rule_max_files_per_directory": {
+      "description": "Every directory containing at least one in-scope file must hold ≤ `max_files` in-scope files (immediate children, non-recursive). Check-only.",
+      "properties": {
+        "kind": {
+          "const": "max_files_per_directory"
+        },
+        "max_files": {
+          "description": "Maximum number of in-scope files allowed as immediate children\nof any one directory (non-recursive).",
+          "format": "uint",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "max_files"
+      ],
+      "type": "object"
+    },
+    "rule_no_bidi_controls": {
+      "description": "Flag Unicode bidirectional control characters (U+202A–202E, U+2066–2069) anywhere in a file. Trojan Source (CVE-2021-42574) defense. Fixable via `file_strip_bidi`.",
+      "properties": {
+        "kind": {
+          "const": "no_bidi_controls"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_no_bom": {
+      "description": "Flag files that start with a UTF-8 / UTF-16 / UTF-32 BOM. Fixable via `file_strip_bom`.",
+      "properties": {
+        "kind": {
+          "const": "no_bom"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_no_case_conflicts": {
+      "description": "Flag pairs of paths that differ only by case (e.g. README.md + readme.md). These can't coexist on macOS HFS+/APFS or Windows NTFS.",
+      "properties": {
+        "kind": {
+          "const": "no_case_conflicts"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_no_empty_files": {
+      "description": "Flag zero-byte files. Fixable via `file_remove`, which deletes the empty file.",
+      "properties": {
+        "kind": {
+          "const": "no_empty_files"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_no_illegal_windows_names": {
+      "description": "Reject path components Windows can't represent: reserved device names (CON/PRN/AUX/NUL/COM1-9/LPT1-9 regardless of extension), trailing dots or spaces, and the forbidden chars <>:\"|?*.",
+      "properties": {
+        "kind": {
+          "const": "no_illegal_windows_names"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_no_merge_conflict_markers": {
+      "description": "Flag files that still contain git conflict markers at the start of a line (`<<<<<<< `, `=======`, `>>>>>>> `, `||||||| `). Check-only; conflict resolution requires human judgment.",
+      "properties": {
+        "kind": {
+          "const": "no_merge_conflict_markers"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_no_submodules": {
+      "description": "Flag the presence of `.gitmodules` at the repo root. Always targets `.gitmodules` — no `paths` field accepted. Fixable via `file_remove`.",
+      "not": {
+        "required": [
+          "paths"
+        ]
+      },
+      "properties": {
+        "kind": {
+          "const": "no_submodules"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    "rule_no_symlinks": {
+      "description": "Flag tracked paths that are symbolic links. Symlinks are a portability headache across Windows/macOS/Linux and CI runners. Fixable via `file_remove`, which deletes the symlink.",
+      "properties": {
+        "kind": {
+          "const": "no_symlinks"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_no_trailing_whitespace": {
+      "description": "No line in any file in scope ends with a space or tab. Non-UTF-8 files are skipped silently.",
+      "properties": {
+        "kind": {
+          "const": "no_trailing_whitespace"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_no_zero_width_chars": {
+      "description": "Flag zero-width characters (U+200B/C/D, plus body-internal U+FEFF). A leading U+FEFF (BOM) is not flagged here — use `no_bom` for that. Fixable via `file_strip_zero_width`.",
+      "properties": {
+        "kind": {
+          "const": "no_zero_width_chars"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_ordered_block": {
+      "description": "The lines between a `start` / `end` marker pair must stay sorted (and, with `unique`, free of duplicates) under `comparator`. Both markers are optional: omit `end` to sort from `start` to EOF, omit both to sort the whole file (the markerless 'this file is one sorted list' form). The generic form of per-project keep-sorted scripts. Per-file: markers match the trimmed line; blank lines inside a block are ignored.",
+      "properties": {
+        "comparator": {
+          "enum": [
+            "lexical",
+            "lexical-ci",
+            "numeric"
+          ]
+        },
+        "end": {
+          "description": "Marker line closing a block. Optional — omit to run the block to EOF.",
+          "type": "string"
+        },
+        "kind": {
+          "const": "ordered_block"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        },
+        "select": {
+          "description": "Regex; when set, only lines inside a block matching it are sortable entries (others — comments, group headers — pass through). The sectioned / keep-sorted-subset shape.",
+          "type": "string"
+        },
+        "start": {
+          "description": "Marker line opening a block (matched on the trimmed line). Optional — omit to anchor the block at the start of the file.",
+          "type": "string"
+        },
+        "unique": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "rule_pair": {
+      "description": "For every file matching `primary`, a file matching the `partner` template must exist. Template tokens: {dir}, {stem}, {ext}, {basename}, {path}, {parent_name}.",
+      "properties": {
+        "kind": {
+          "const": "pair"
+        },
+        "partner": {
+          "description": "Path template resolved per primary match. Example: \"{dir}/{stem}.h\".",
+          "type": "string"
+        },
+        "primary": {
+          "description": "Glob selecting the primary files.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "primary",
+        "partner"
+      ],
+      "type": "object"
+    },
+    "rule_pair_changed_together": {
+      "description": "If the `<since>...HEAD` diff changes any path matching `if_changed:`, at least one path matching `then_changed:` must change in the same range — the co-change gate (a FORMAT_VERSION must bump when the format struct changes; version.txt and the lockfile change together). Both globs and `since:` (the base ref) are required. Directional: a `then_changed`-only change never triggers it (add a second rule with the globs swapped for a bidirectional pact). Diff-scoped: silent no-op outside a git repo / when `if_changed` didn't change; a `since:` that fails to resolve hard-fails with a shallow-clone hint. Check-only.",
+      "properties": {
+        "if_changed": {
+          "description": "Glob; the trigger. When the diff changes a path matching this, a\n`then_changed` co-change is required.",
+          "type": "string"
+        },
+        "kind": {
+          "const": "pair_changed_together"
+        },
+        "since": {
+          "description": "Base ref for the `<since>...HEAD` diff. Use the canonical `{{env.X}}`\ninterpolation, e.g. `since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`.",
+          "type": "string"
+        },
+        "then_changed": {
+          "description": "Glob; the obligation. At least one changed path must match it whenever\n`if_changed` fired.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "if_changed",
+        "then_changed",
+        "since"
+      ],
+      "type": "object"
+    },
+    "rule_pair_hash": {
+      "description": "Cross-file: the `algorithm` digest of every file matching `source` must appear in the single `target` file — either as an embedded hex substring (`format: contains`, the default) or a coreutils / go-`.sum`-style `<hex>  <path>` manifest line (`format: sums-line`). Detection-only (alint never rewrites the manifest). A missing `target` is one violation; one violation per source whose digest is absent or mismatched. golang/go FIPS `fips140.sum` is the canonical use.",
+      "properties": {
+        "algorithm": {
+          "description": "Digest algorithm (default: sha256).",
+          "enum": [
+            "sha256",
+            "sha512"
+          ]
+        },
+        "format": {
+          "description": "How the digest must appear in `target`: `contains` = hex substring anywhere (default); `sums-line` = a `<hex> [*]<path>` line whose path token is the source's path.",
+          "enum": [
+            "contains",
+            "sums-line"
+          ]
+        },
+        "kind": {
+          "const": "pair_hash"
+        },
+        "source": {
+          "description": "Literal path or glob selecting the file(s) whose content is hashed (one check per match).",
+          "type": "string"
+        },
+        "target": {
+          "description": "The single file that must carry the digest (a `.sum` / `SHA256SUMS` / file with an embedded hash).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source",
+        "target"
+      ],
+      "type": "object"
+    },
+    "rule_registry_paths_resolve": {
+      "description": "A manifest enumerates path entries; each must resolve to an on-disk artefact. `extract` selects how the entry list is pulled (structured-query toml/json/yaml, a line list, or regex capture group 1). Optional `orphans` adds the reverse check: on-disk artefacts under `space` that no entry references. Non-literal entries (interpolation / antiquotation) are skipped, not failed.",
+      "properties": {
+        "base": {
+          "description": "Resolve entries relative to: registry_dir (default), lint_root, or an explicit path.",
+          "type": "string"
+        },
+        "entries_are_globs": {
+          "type": "boolean"
+        },
+        "exclude_query": {
+          "type": "string"
+        },
+        "expect": {
+          "enum": [
+            "any",
+            "file",
+            "dir"
+          ]
+        },
+        "extract": {
+          "additionalProperties": false,
+          "description": "Exactly one of: toml/json/yaml (RFC 9535 JSONPath string), lines (object; optional `comment` prefix, default `#`), regex (string; capture group 1 is the path).",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "json": {
+              "type": "string"
+            },
+            "lines": {
+              "additionalProperties": false,
+              "properties": {
+                "comment": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "regex": {
+              "type": "string"
+            },
+            "toml": {
+              "type": "string"
+            },
+            "yaml": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "kind": {
+          "const": "registry_paths_resolve"
+        },
+        "must_contain": {
+          "type": "string"
+        },
+        "orphans": {
+          "additionalProperties": false,
+          "properties": {
+            "space": {
+              "type": "string"
+            },
+            "unreferenced": {
+              "enum": [
+                "warn",
+                "error",
+                "off"
+              ]
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        "source": {
+          "description": "The manifest/registry file (path, or a glob to run once per matching manifest) that enumerates the path entries.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source",
+        "extract"
+      ],
+      "type": "object"
+    },
+    "rule_shebang_has_executable": {
+      "description": "Every file that starts with `#!` must have the Unix +x bit set. The inverse of `executable_has_shebang`. No-op on non-Unix. No fix op (chmod auto-apply deferred).",
+      "properties": {
+        "kind": {
+          "const": "shebang_has_executable"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths"
+      ],
+      "type": "object"
+    },
+    "rule_template_instance": {
+      "description": "A rule entry that expands a `templates:` body. The instance's `id:` is required; `vars:` provides the substitutions for the template's `{{vars.<name>}}` placeholders. Any other field overrides the corresponding field in the expanded template.",
+      "properties": {
+        "extends_template": {
+          "description": "Id of an entry in the top-level `templates:` block to instantiate.",
+          "type": "string"
+        },
+        "id": {
+          "$ref": "#/$defs/rule_id"
+        },
+        "level": {
+          "$ref": "#/$defs/level"
+        },
+        "message": {
+          "type": "string"
+        },
+        "policy_url": {
+          "format": "uri",
+          "type": "string"
+        },
+        "vars": {
+          "additionalProperties": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ]
+          },
+          "description": "Map of `name → value` to substitute into `{{vars.<name>}}` placeholders in the template body.",
+          "type": "object"
+        },
+        "when": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "extends_template"
+      ],
+      "type": "object"
+    },
+    "rule_toml_path_equals": {
+      "description": "TOML sibling of `json_path_equals`. Typical use: enforce `[package].edition == \"2024\"` on every `Cargo.toml`.",
+      "properties": {
+        "equals": {},
+        "if_present": {
+          "$ref": "#/$defs/if_present"
+        },
+        "kind": {
+          "const": "toml_path_equals"
+        },
+        "path": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "path",
+        "equals"
+      ],
+      "type": "object"
+    },
+    "rule_toml_path_matches": {
+      "description": "TOML sibling of `json_path_matches`.",
+      "properties": {
+        "if_present": {
+          "$ref": "#/$defs/if_present"
+        },
+        "kind": {
+          "const": "toml_path_matches"
+        },
+        "matches": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "path",
+        "matches"
+      ],
+      "type": "object"
+    },
+    "rule_unique_by": {
+      "description": "Flag any group of files (matching `select`) sharing the same rendered `key`. One violation per collision group, anchored on the lexicographically-first file. Path-template tokens ({path}, {dir}, {basename}, {stem}, {ext}, {parent_name}) may appear in `key`. With `case_insensitive: true` the key is folded to lowercase before grouping, catching collisions that only occur on a case-insensitive filesystem (Windows / macOS).",
+      "properties": {
+        "case_insensitive": {
+          "default": false,
+          "description": "Fold the key to lowercase before grouping, so keys that\ncollide only under case-folding count as duplicates — the\ncase-insensitive-filesystem hazard (Windows / macOS).",
+          "type": "boolean"
+        },
+        "key": {
+          "default": "{basename}",
+          "description": "Path-template producing a key per matched file. Default: {basename}.",
+          "type": "string"
+        },
+        "kind": {
+          "const": "unique_by"
+        },
+        "select": {
+          "description": "Glob selecting the files to deduplicate.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "select"
+      ],
+      "type": "object"
+    },
+    "rule_xml_path_equals": {
+      "description": "XML sibling of `json_path_equals`. XML maps to the same value tree via the xmltodict-style convention: attributes are `@name` keys, repeated child elements become an array, a leaf element collapses to its text string, namespaces flatten to local names, and every leaf value is a string (quote your `equals:`, e.g. `equals: \"4.0.0\"`). Typical use: enforce `$.Project.PropertyGroup.TargetFramework == \"net8.0\"` on every `.csproj`, or a Maven `$.project.parent.version` across `pom.xml`.",
+      "properties": {
+        "equals": {},
+        "if_present": {
+          "$ref": "#/$defs/if_present"
+        },
+        "kind": {
+          "const": "xml_path_equals"
+        },
+        "path": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "path",
+        "equals"
+      ],
+      "type": "object"
+    },
+    "rule_xml_path_matches": {
+      "description": "XML sibling of `json_path_matches` (same xmltodict-style mapping as `xml_path_equals`; all XML leaf values are strings). Typical use: `$.Project.ItemGroup.PackageReference[*]['@Version']` matches a version pattern across `.csproj`.",
+      "properties": {
+        "if_present": {
+          "$ref": "#/$defs/if_present"
+        },
+        "kind": {
+          "const": "xml_path_matches"
+        },
+        "matches": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "path",
+        "matches"
+      ],
+      "type": "object"
+    },
+    "rule_yaml_path_equals": {
+      "description": "YAML sibling of `json_path_equals`. Parses the file as YAML before applying the JSONPath query. Use this on GitHub Actions workflows, docker-compose.yml, kubernetes manifests, `.gitlab-ci.yml`, etc.",
+      "properties": {
+        "equals": {},
+        "if_present": {
+          "$ref": "#/$defs/if_present"
+        },
+        "kind": {
+          "const": "yaml_path_equals"
+        },
+        "path": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "path",
+        "equals"
+      ],
+      "type": "object"
+    },
+    "rule_yaml_path_matches": {
+      "description": "YAML sibling of `json_path_matches`.",
+      "properties": {
+        "if_present": {
+          "$ref": "#/$defs/if_present"
+        },
+        "kind": {
+          "const": "yaml_path_matches"
+        },
+        "matches": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "paths": {
+          "$ref": "#/$defs/paths_spec"
+        }
+      },
+      "required": [
+        "paths",
+        "path",
+        "matches"
+      ],
+      "type": "object"
+    },
+    "scope_filter": {
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": [
+            "has_ancestor"
+          ]
+        },
+        {
+          "required": [
+            "changed_since"
+          ]
+        }
+      ],
+      "description": "Per-file rule scoping. `has_ancestor` (v0.9.6+) admits files whose ancestor chain contains a named manifest; `changed_since` (v0.11+) admits files in a `<ref>...HEAD` git diff. At least one must be set; setting both is an AND. Supported on per-file rules and on `dir_absent` (since v0.9.18). Cross-file rules (`pair`, `for_each_dir`, `file_exists`, etc.) reject `scope_filter:` at build time. Combine with the rule's existing `paths:` glob — all gates must match for the rule to fire.",
+      "properties": {
+        "changed_since": {
+          "description": "Git ref; the rule only fires on files in the `<ref>...HEAD` diff (the same merge-base diff as `alint check --changed`). Right shape for grandfathering pre-existing files in a PR — e.g. require an SPDX header only on files the PR touched. Accepts the `{{env.X}}` interpolation (e.g. `changed_since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`). Outside a git repo the predicate matches nothing (silent); an unresolvable ref inside a repo is a hard error with a shallow-clone hint.",
+          "minLength": 1,
+          "type": "string"
+        },
+        "has_ancestor": {
+          "description": "Manifest filename (or list of filenames) whose presence in any ancestor directory of the linted file admits the rule. Each entry is a literal filename like `Cargo.toml` or `package.json` — no path separators, no glob metacharacters; the ancestor walk handles \"anywhere up the tree\" by traversing `Path::parent()` upward.",
+          "oneOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "items": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "string_or_string_array": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "template": {
+      "additionalProperties": true,
+      "description": "A reusable rule shape. Identical to a regular rule except `level` is optional (instances may add it) and the body is matched after `{{vars.<name>}}` substitution.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/rule_id"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
     }
-  }
+  },
+  "$id": "https://raw.githubusercontent.com/asamarts/alint/main/schemas/v1/config.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Schema for .alint.yml configuration files. Authoritative reference: docs/design/ARCHITECTURE.md in the alint repository.",
+  "properties": {
+    "allow_out_of_root": {
+      "description": "Top-level-only escape hatch for path confinement: permit rules to read a config-declared path that escapes the repo root. `true` allows every rule; a map `{ kinds: [...], rules: [...] }` allows only the listed rule kinds / ids. Absent or `false` keeps the secure default (every config-derived path read is confined). REJECTED from `extends:`'d rulesets — only the user's own top-level config may set it. Applies to file reads (currently `registry_paths_resolve` source, `json_schema_passes` schema_path, `pair_hash` target); resolve/index checks stay confined. Permitted reads emit an informational note. See docs/design/v0.12/allow_out_of_root.md.",
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "kinds": {
+              "description": "Rule kinds permitted to read out of the repo root.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "rules": {
+              "description": "Rule ids permitted to read out of the repo root.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "extends": {
+      "description": "Configs to inherit from. Each entry is either a bare string (local path, `https://` URL with SRI, or `alint://bundled/<name>@<rev>`) or a mapping `{url, only?, except?}` that filters the inherited rule set before merging.\n\nEntries resolved left-to-right; later entries override earlier ones, and the current file's own definitions override everything it extends.\n\n**Rule merging is field-level by `id`.** A child can override just the fields it wants to change — `rules: [{id: inherited, level: warning}]` keeps the parent's `kind`/`paths`/etc. and only downgrades severity. `{id: inherited, level: off}` disables a rule without redeclaring it.\n\n**Selective adoption** via `only:` (keep these ids, drop everything else) or `except:` (drop these ids). The two are mutually exclusive on a single entry. Unknown ids are a load-time error so typos surface immediately.\n\nRemote and bundled configs cannot themselves declare `extends:` (no principled base for relative resolution in a fetched body); nest extends locally instead.",
+      "items": {
+        "$ref": "#/$defs/extends_entry"
+      },
+      "type": "array"
+    },
+    "facts": {
+      "description": "Properties of the repository evaluated once per run; referenced from `when` clauses as facts.<id>.",
+      "items": {
+        "$ref": "#/$defs/fact"
+      },
+      "type": "array"
+    },
+    "fix_size_limit": {
+      "default": 1048576,
+      "description": "Max bytes a content-editing fix will touch. Files over this limit are reported as Skipped with a stderr warning. Default: 1 MiB. Explicit null disables the cap. Path-only fixes (file_create, file_remove, file_rename) ignore this setting.",
+      "minimum": 0,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "ignore": {
+      "description": "Additional glob patterns excluded on top of .gitignore.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "nested_configs": {
+      "default": false,
+      "description": "Opt in to discovery of nested `.alint.yml` / `.alint.yaml` files in subdirectories. When true, the loader walks the tree from this config's directory (honoring `.gitignore` + `ignore`) and finds any nested config files. Each nested rule's path-like scope fields (`paths`, `select`, `primary`) are automatically prefixed with the nested config's relative directory, so rules declared in `packages/frontend/.alint.yml` apply only under `packages/frontend/**`. Id collisions across configs are rejected with a clear error — per-subtree overrides aren't supported in this release (use `when:` on the root rule for that). Only the root config sets this; nested configs can't spawn further nested discovery.",
+      "type": "boolean"
+    },
+    "respect_gitignore": {
+      "default": true,
+      "description": "Whether to honor .gitignore files during the walk.",
+      "type": "boolean"
+    },
+    "rules": {
+      "description": "Rules evaluated against the repository tree.",
+      "items": {
+        "$ref": "#/$defs/rule"
+      },
+      "type": "array"
+    },
+    "templates": {
+      "description": "Reusable rule shapes referenced by `extends_template:` in `rules:` entries. Each template carries an `id:` and any other rule-spec fields; `{{vars.<name>}}` placeholders in those fields substitute from each instance's `vars:` map at expansion time. Templates are leaf-only — a template may not itself `extends_template:` another. Templates merge through the `extends:` chain by id, so a downstream config can override an upstream template's body.",
+      "items": {
+        "$ref": "#/$defs/template"
+      },
+      "type": "array"
+    },
+    "vars": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Free-form string variables referenced from rule messages as {{vars.<name>}} and from `when` clauses as vars.<name>.",
+      "type": "object"
+    },
+    "version": {
+      "const": 1,
+      "description": "Config schema version. Always 1 for this schema."
+    }
+  },
+  "required": [
+    "version"
+  ],
+  "title": "alint configuration (v1)",
+  "type": "object"
 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -26,6 +26,7 @@ tempfile.workspace = true
 
 [dev-dependencies]
 alint-dsl.workspace = true
+jsonschema.workspace = true
 
 [lints]
 workspace = true

--- a/xtask/src/gen_schema.rs
+++ b/xtask/src/gen_schema.rs
@@ -1,0 +1,142 @@
+//! `xtask gen-schema` - assemble `schemas/v1/config.json` from the hand-written
+//! base, replacing the `$defs/rule_*` branch of each migrated rule kind with a
+//! schemars-derived schema. See ADR-0001 and docs/design/spec-driven-development.md.
+//!
+//! Migration is incremental: kinds not yet migrated pass through from the
+//! committed base verbatim, so the published schema stays complete and valid at
+//! every step. Fidelity is checked semantically (validation behavior), not by
+//! byte-equality, because schemars emits cosmetic keywords (e.g. `format: uint`)
+//! that the hand-written schema omits without changing what validates.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+
+fn root_schema_path() -> Result<PathBuf> {
+    Ok(crate::workspace_root()?.join("schemas/v1/config.json"))
+}
+
+fn in_crate_schema_path() -> Result<PathBuf> {
+    Ok(crate::workspace_root()?.join("crates/alint-dsl/schemas/v1/config.json"))
+}
+
+/// Build the generated schema in memory: the committed base with every migrated
+/// `$defs` entry replaced by its schemars-derived equivalent.
+pub fn build_generated_schema() -> Result<Value> {
+    let base_src = std::fs::read_to_string(root_schema_path()?)
+        .context("read base schema schemas/v1/config.json")?;
+    let mut schema: Value = serde_json::from_str(&base_src).context("parse base schema as JSON")?;
+
+    let defs = schema
+        .get_mut("$defs")
+        .and_then(Value::as_object_mut)
+        .context("base schema has no `$defs` object")?;
+
+    for (def_name, def_schema) in alint_rules::migrated_rule_defs() {
+        if !defs.contains_key(def_name) {
+            bail!("migrated def `{def_name}` is not present in the base schema `$defs`");
+        }
+        defs.insert(def_name.to_string(), def_schema);
+    }
+    Ok(schema)
+}
+
+fn render(schema: &Value) -> Result<String> {
+    let mut rendered = serde_json::to_string_pretty(schema)?;
+    rendered.push('\n');
+    Ok(rendered)
+}
+
+/// Write the generated schema to the root and in-crate copies, or (with `check`)
+/// fail if either is stale.
+pub fn run(check: bool) -> Result<()> {
+    let generated = build_generated_schema()?;
+    let rendered = render(&generated)?;
+
+    if check {
+        let root = std::fs::read_to_string(root_schema_path()?)?;
+        let in_crate = std::fs::read_to_string(in_crate_schema_path()?)?;
+        if root != rendered || in_crate != rendered {
+            bail!(
+                "schemas/v1/config.json is stale (or not yet in generated form). \
+                 Run `cargo run -p xtask -- gen-schema` to regenerate and commit the result."
+            );
+        }
+        println!("schema is up to date");
+        return Ok(());
+    }
+
+    std::fs::write(root_schema_path()?, &rendered)?;
+    std::fs::write(in_crate_schema_path()?, &rendered)?;
+    println!("wrote schemas/v1/config.json and the in-crate copy");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_to_json(rel_path: &str) -> Value {
+        let path = crate::workspace_root().unwrap().join(rel_path);
+        let yaml = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        let value: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).unwrap();
+        serde_json::to_value(value).unwrap()
+    }
+
+    fn committed_schema() -> Value {
+        let src = std::fs::read_to_string(root_schema_path().unwrap()).unwrap();
+        serde_json::from_str(&src).unwrap()
+    }
+
+    // Representative file_header rule configs: the first three are valid, the
+    // last two must be rejected (missing required `pattern`; `lines` below the
+    // minimum of 1).
+    fn file_header_cases() -> Vec<Value> {
+        vec![
+            serde_json::json!({"version":1,"rules":[{"id":"h","kind":"file_header","level":"error","paths":"**/*.rs","pattern":"// SPDX"}]}),
+            serde_json::json!({"version":1,"rules":[{"id":"h","kind":"file_header","level":"error","paths":"**/*.rs","pattern":"// SPDX","lines":5}]}),
+            serde_json::json!({"version":1,"rules":[{"id":"h","kind":"header","level":"error","paths":"**/*.rs","pattern":"// SPDX"}]}),
+            serde_json::json!({"version":1,"rules":[{"id":"h","kind":"file_header","level":"error","paths":"**/*.rs"}]}),
+            serde_json::json!({"version":1,"rules":[{"id":"h","kind":"file_header","level":"error","paths":"**/*.rs","pattern":"// SPDX","lines":0}]}),
+        ]
+    }
+
+    #[test]
+    fn generated_schema_accepts_all_kinds_fixture() {
+        let schema = build_generated_schema().unwrap();
+        let validator = jsonschema::validator_for(&schema).unwrap();
+        let cfg = config_to_json("crates/alint-dsl/tests/fixtures/all_kinds.yaml");
+        assert!(
+            validator.is_valid(&cfg),
+            "all_kinds.yaml must validate against the generated schema (the derived \
+             file_header branch must not have narrowed acceptance)"
+        );
+    }
+
+    #[test]
+    fn generated_and_committed_agree_on_file_header_configs() {
+        let committed = jsonschema::validator_for(&committed_schema()).unwrap();
+        let generated = jsonschema::validator_for(&build_generated_schema().unwrap()).unwrap();
+        for case in file_header_cases() {
+            assert_eq!(
+                committed.is_valid(&case),
+                generated.is_valid(&case),
+                "committed and generated schema disagree for: {case}"
+            );
+        }
+    }
+
+    #[test]
+    fn generated_schema_enforces_file_header_contract() {
+        let generated = jsonschema::validator_for(&build_generated_schema().unwrap()).unwrap();
+        let cases = file_header_cases();
+        // valid baseline accepted
+        assert!(generated.is_valid(&cases[0]));
+        // missing required `pattern` rejected
+        assert!(!generated.is_valid(&cases[3]));
+        // `lines: 0` (below minimum 1) rejected
+        assert!(!generated.is_valid(&cases[4]));
+    }
+}

--- a/xtask/src/gen_schema.rs
+++ b/xtask/src/gen_schema.rs
@@ -34,6 +34,15 @@ pub fn build_generated_schema() -> Result<Value> {
         .context("base schema has no `$defs` object")?;
 
     for (def_name, options) in alint_rules::migrated_option_schemas() {
+        // schemars emits an option field's enum/struct type as a `$ref` to a
+        // `#/$defs/<TypeName>` definition carried in the derived schema's own
+        // `$defs`. Merge those definitions into the main schema's `$defs` so the
+        // refs resolve (e.g. commented_out_code's `language: #/$defs/Language`).
+        if let Some(extra_defs) = options.get("$defs").and_then(Value::as_object) {
+            for (name, def) in extra_defs {
+                defs.insert(name.clone(), def.clone());
+            }
+        }
         let base = defs
             .get(def_name)
             .with_context(|| format!("migrated def `{def_name}` is not present in `$defs`"))?

--- a/xtask/src/gen_schema.rs
+++ b/xtask/src/gen_schema.rs
@@ -33,13 +33,29 @@ pub fn build_generated_schema() -> Result<Value> {
         .and_then(Value::as_object_mut)
         .context("base schema has no `$defs` object")?;
 
-    for (def_name, options) in alint_rules::migrated_option_schemas() {
+    for (def_name, mut options) in alint_rules::migrated_option_schemas() {
+        // Normalize derived descriptions BEFORE merging, so the merged enum
+        // definitions match the committed (already-normalized) copy on re-runs;
+        // otherwise the collision guard below would compare a normalized base
+        // def against a freshly-derived (un-normalized) one and bail, making
+        // generation non-idempotent.
+        normalize_descriptions(&mut options);
         // schemars emits an option field's enum/struct type as a `$ref` to a
         // `#/$defs/<TypeName>` definition carried in the derived schema's own
         // `$defs`. Merge those definitions into the main schema's `$defs` so the
         // refs resolve (e.g. commented_out_code's `language: #/$defs/Language`).
         if let Some(extra_defs) = options.get("$defs").and_then(Value::as_object) {
             for (name, def) in extra_defs {
+                // Guard against two distinct Rust types sharing one schemars def
+                // name (e.g. pair_hash::Format vs structured_path::Format): a
+                // silent last-write-wins would point a `$ref` at the wrong type.
+                if defs.get(name).is_some_and(|existing| existing != def) {
+                    bail!(
+                        "schemars `$defs` collision on `{name}` while composing `{def_name}`: \
+                         two distinct types share that name. Rename one with \
+                         `#[schemars(rename = \"...\")]` on its Rust type."
+                    );
+                }
                 defs.insert(name.clone(), def.clone());
             }
         }
@@ -47,9 +63,32 @@ pub fn build_generated_schema() -> Result<Value> {
             .get(def_name)
             .with_context(|| format!("migrated def `{def_name}` is not present in `$defs`"))?
             .clone();
-        defs.insert(def_name.to_string(), compose_branch(&base, &options));
+        defs.insert(def_name.to_string(), compose_branch(&base, &options)?);
     }
+
+    normalize_descriptions(&mut schema);
     Ok(schema)
+}
+
+/// Collapse internal whitespace (including the `\n` schemars inserts between
+/// wrapped rustdoc lines) in every `description` string, so the published schema
+/// carries clean single-line prose rather than literal newlines.
+fn normalize_descriptions(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map.iter_mut() {
+                if key == "description" {
+                    if let Value::String(text) = child {
+                        *text = text.split_whitespace().collect::<Vec<_>>().join(" ");
+                    }
+                } else {
+                    normalize_descriptions(child);
+                }
+            }
+        }
+        Value::Array(items) => items.iter_mut().for_each(normalize_descriptions),
+        _ => {}
+    }
 }
 
 /// Compose a `$defs/rule_<kind>` branch from the schemars-derived options schema
@@ -58,7 +97,7 @@ pub fn build_generated_schema() -> Result<Value> {
 /// stable and not expressible as plain Rust struct fields); the option
 /// properties and their `required` set come from the derived schema, so an
 /// option rename or type change in the Rust struct propagates automatically.
-fn compose_branch(base: &Value, options: &Value) -> Value {
+fn compose_branch(base: &Value, options: &Value) -> Result<Value> {
     let base_props = base.get("properties").and_then(Value::as_object);
     let base_required = base.get("required").and_then(Value::as_array);
 
@@ -72,16 +111,18 @@ fn compose_branch(base: &Value, options: &Value) -> Value {
     if let Some(opts) = options.get("properties").and_then(Value::as_object) {
         for (key, value) in opts {
             let mut prop = value.clone();
-            // Safety net: if a field's rustdoc description has not been migrated
-            // yet, carry the committed base branch's description so the published
-            // schema never loses documentation during an incremental rollout.
-            if prop.get("description").is_none() {
-                if let Some(base_desc) = base_props
-                    .and_then(|p| p.get(key))
-                    .and_then(|p| p.get("description"))
-                {
-                    if let Some(obj) = prop.as_object_mut() {
-                        obj.insert("description".to_string(), base_desc.clone());
+            // Safety net for fields schemars renders as a bare `$ref` (enums):
+            // the derived prop carries neither the base `description` nor its
+            // `default`, so restore both from the committed base when the derived
+            // schema omits them. Keeps option docs and defaults intact during an
+            // incremental rollout.
+            if let Some(obj) = prop.as_object_mut() {
+                let base_prop = base_props.and_then(|p| p.get(key));
+                for carried in ["description", "default"] {
+                    if !obj.contains_key(carried) {
+                        if let Some(v) = base_prop.and_then(|p| p.get(carried)) {
+                            obj.insert(carried.to_string(), v.clone());
+                        }
                     }
                 }
             }
@@ -112,7 +153,41 @@ fn compose_branch(base: &Value, options: &Value) -> Value {
     } else {
         obj.insert("required".to_string(), Value::Array(required));
     }
-    branch
+    assert_branch_combinators_resolve(&branch)?;
+    Ok(branch)
+}
+
+/// A branch-level `anyOf`/`oneOf`/`allOf` preserved from the base hard-codes
+/// property names in its sub-schemas' `required` (e.g. `git_commit_message`'s "at
+/// least one of `pattern`/`subject_max_length`/`requires_body`"). If a Rust field
+/// rename drops one, the constraint would silently reference a property the
+/// derived schema no longer defines. Fail loudly instead.
+fn assert_branch_combinators_resolve(branch: &Value) -> Result<()> {
+    let props: std::collections::HashSet<&str> = branch
+        .get("properties")
+        .and_then(Value::as_object)
+        .map(|m| m.keys().map(String::as_str).collect())
+        .unwrap_or_default();
+    for combinator in ["anyOf", "oneOf", "allOf"] {
+        let Some(subs) = branch.get(combinator).and_then(Value::as_array) else {
+            continue;
+        };
+        for sub in subs {
+            let Some(reqs) = sub.get("required").and_then(Value::as_array) else {
+                continue;
+            };
+            for name in reqs.iter().filter_map(Value::as_str) {
+                if !props.contains(name) {
+                    bail!(
+                        "branch-level `{combinator}` references property `{name}` that the \
+                         derived schema does not define (likely a renamed Rust field); update \
+                         the base branch's `{combinator}` in schemas/v1/config.json."
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 fn render(schema: &Value) -> Result<String> {
@@ -128,12 +203,24 @@ pub fn run(check: bool) -> Result<()> {
     let rendered = render(&generated)?;
 
     if check {
-        let root = std::fs::read_to_string(root_schema_path()?)?;
-        let in_crate = std::fs::read_to_string(in_crate_schema_path()?)?;
-        if root != rendered || in_crate != rendered {
+        let root_path = root_schema_path()?;
+        let in_crate_path = in_crate_schema_path()?;
+        let root = std::fs::read_to_string(&root_path)
+            .with_context(|| format!("read {}", root_path.display()))?;
+        let in_crate = std::fs::read_to_string(&in_crate_path)
+            .with_context(|| format!("read {}", in_crate_path.display()))?;
+        let stale: Vec<&str> = [
+            (root != rendered).then_some("schemas/v1/config.json"),
+            (in_crate != rendered).then_some("crates/alint-dsl/schemas/v1/config.json"),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+        if !stale.is_empty() {
             bail!(
-                "schemas/v1/config.json is stale (or not yet in generated form). \
-                 Run `cargo run -p xtask -- gen-schema` to regenerate and commit the result."
+                "schema is stale (or not yet in generated form): {}. \
+                 Run `cargo run -p xtask -- gen-schema` to regenerate and commit the result.",
+                stale.join(", ")
             );
         }
         println!("schema is up to date");
@@ -270,5 +357,42 @@ mod tests {
             checked > 10,
             "expected many configs, only checked {checked}"
         );
+    }
+
+    #[test]
+    fn migrated_option_schemas_list_is_well_formed() {
+        let mut seen = std::collections::HashSet::new();
+        for (name, _) in alint_rules::migrated_option_schemas() {
+            assert!(seen.insert(name), "duplicate migrated def name: {name}");
+        }
+        // Exercises the present-in-`$defs` check and the enum `$defs` collision
+        // guard inside `build_generated_schema`.
+        build_generated_schema().unwrap();
+    }
+
+    #[test]
+    fn generated_schema_rejects_bad_options_on_migrated_kinds() {
+        let v = jsonschema::validator_for(&build_generated_schema().unwrap()).unwrap();
+        // Stray unknown option on a migrated kind (caught by the shared
+        // `unevaluatedProperties: false`).
+        assert!(!v.is_valid(&serde_json::json!(
+            {"version":1,"rules":[{"id":"x","kind":"file_header","level":"error","paths":"a","pattern":"p","bogus":1}]}
+        )));
+        // Invalid enum value on a migrated enum-typed field (locks in that the
+        // enum constraint survived the schemars `oneOf`/`$defs` round-trip).
+        assert!(!v.is_valid(&serde_json::json!(
+            {"version":1,"rules":[{"id":"x","kind":"pair_hash","level":"error","source":"a","target":"b","algorithm":"md5"}]}
+        )));
+        // Valid baseline accepted.
+        assert!(v.is_valid(&serde_json::json!(
+            {"version":1,"rules":[{"id":"x","kind":"pair_hash","level":"error","source":"a","target":"b","algorithm":"sha256"}]}
+        )));
+    }
+
+    #[test]
+    fn gen_schema_check_passes_on_committed_tree() {
+        // The committed schema is kept in generated form, so the `--check` gate
+        // must be green; this exercises `run(check=true)` (the read + compare).
+        run(true).expect("gen-schema --check should pass on the committed tree");
     }
 }

--- a/xtask/src/gen_schema.rs
+++ b/xtask/src/gen_schema.rs
@@ -33,13 +33,71 @@ pub fn build_generated_schema() -> Result<Value> {
         .and_then(Value::as_object_mut)
         .context("base schema has no `$defs` object")?;
 
-    for (def_name, def_schema) in alint_rules::migrated_rule_defs() {
-        if !defs.contains_key(def_name) {
-            bail!("migrated def `{def_name}` is not present in the base schema `$defs`");
-        }
-        defs.insert(def_name.to_string(), def_schema);
+    for (def_name, options) in alint_rules::migrated_option_schemas() {
+        let base = defs
+            .get(def_name)
+            .with_context(|| format!("migrated def `{def_name}` is not present in `$defs`"))?
+            .clone();
+        defs.insert(def_name.to_string(), compose_branch(&base, &options));
     }
     Ok(schema)
+}
+
+/// Compose a `$defs/rule_<kind>` branch from the schemars-derived options schema
+/// and the committed base branch. The `kind` discriminator (including aliases)
+/// and the `paths` property/requirement are preserved from the base (they are
+/// stable and not expressible as plain Rust struct fields); the option
+/// properties and their `required` set come from the derived schema, so an
+/// option rename or type change in the Rust struct propagates automatically.
+fn compose_branch(base: &Value, options: &Value) -> Value {
+    let base_props = base.get("properties").and_then(Value::as_object);
+    let base_required = base.get("required").and_then(Value::as_array);
+
+    let mut properties = serde_json::Map::new();
+    if let Some(kind) = base_props.and_then(|p| p.get("kind")) {
+        properties.insert("kind".to_string(), kind.clone());
+    }
+    if let Some(paths) = base_props.and_then(|p| p.get("paths")) {
+        properties.insert("paths".to_string(), paths.clone());
+    }
+    if let Some(opts) = options.get("properties").and_then(Value::as_object) {
+        for (key, value) in opts {
+            let mut prop = value.clone();
+            // Safety net: if a field's rustdoc description has not been migrated
+            // yet, carry the committed base branch's description so the published
+            // schema never loses documentation during an incremental rollout.
+            if prop.get("description").is_none() {
+                if let Some(base_desc) = base_props
+                    .and_then(|p| p.get(key))
+                    .and_then(|p| p.get("description"))
+                {
+                    if let Some(obj) = prop.as_object_mut() {
+                        obj.insert("description".to_string(), base_desc.clone());
+                    }
+                }
+            }
+            properties.insert(key.clone(), prop);
+        }
+    }
+
+    let mut required: Vec<Value> = Vec::new();
+    if base_required.is_some_and(|r| r.iter().any(|x| x == "paths")) {
+        required.push(Value::from("paths"));
+    }
+    if let Some(req) = options.get("required").and_then(Value::as_array) {
+        required.extend(req.iter().cloned());
+    }
+
+    let mut branch = serde_json::Map::new();
+    if let Some(desc) = base.get("description") {
+        branch.insert("description".to_string(), desc.clone());
+    }
+    branch.insert("type".to_string(), Value::from("object"));
+    if !required.is_empty() {
+        branch.insert("required".to_string(), Value::Array(required));
+    }
+    branch.insert("properties".to_string(), Value::Object(properties));
+    Value::Object(branch)
 }
 
 fn render(schema: &Value) -> Result<String> {

--- a/xtask/src/gen_schema.rs
+++ b/xtask/src/gen_schema.rs
@@ -88,16 +88,22 @@ fn compose_branch(base: &Value, options: &Value) -> Value {
         required.extend(req.iter().cloned());
     }
 
-    let mut branch = serde_json::Map::new();
-    if let Some(desc) = base.get("description") {
-        branch.insert("description".to_string(), desc.clone());
+    // Start from the base branch so branch-level keywords the assembler does not
+    // model (the rule `description`, and any branch-level `anyOf`/`oneOf` such as
+    // git_commit_message's "at least one of pattern/subject_max_length") survive;
+    // then overwrite only the property set and required list with the composed ones.
+    let mut branch = base.clone();
+    let obj = branch
+        .as_object_mut()
+        .expect("rule branch is a JSON object");
+    obj.insert("type".to_string(), Value::from("object"));
+    obj.insert("properties".to_string(), Value::Object(properties));
+    if required.is_empty() {
+        obj.remove("required");
+    } else {
+        obj.insert("required".to_string(), Value::Array(required));
     }
-    branch.insert("type".to_string(), Value::from("object"));
-    if !required.is_empty() {
-        branch.insert("required".to_string(), Value::Array(required));
-    }
-    branch.insert("properties".to_string(), Value::Object(properties));
-    Value::Object(branch)
+    branch
 }
 
 fn render(schema: &Value) -> Result<String> {
@@ -196,5 +202,64 @@ mod tests {
         assert!(!generated.is_valid(&cases[3]));
         // `lines: 0` (below minimum 1) rejected
         assert!(!generated.is_valid(&cases[4]));
+    }
+
+    fn collect_yaml(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    collect_yaml(&path, out);
+                } else if path.extension().is_some_and(|x| x == "yml" || x == "yaml") {
+                    out.push(path);
+                }
+            }
+        }
+    }
+
+    /// Broad fidelity gate: every real config in the repo (the all-kinds
+    /// fixture, every bundled ruleset, every example) must get the SAME
+    /// accept/reject verdict from the committed and the generated schema. These
+    /// are all valid configs, so this rules out the generated schema NARROWING
+    /// acceptance for any migrated kind. (Widening is caught by the rejection
+    /// cases in `cargo test -p alint-dsl` against the regenerated schema.)
+    #[test]
+    fn generated_and_committed_agree_on_real_configs() {
+        let root = crate::workspace_root().unwrap();
+        let committed = jsonschema::validator_for(&committed_schema()).unwrap();
+        let generated = jsonschema::validator_for(&build_generated_schema().unwrap()).unwrap();
+
+        let mut configs = vec![root.join("crates/alint-dsl/tests/fixtures/all_kinds.yaml")];
+        collect_yaml(&root.join("crates/alint-dsl/rulesets/v1"), &mut configs);
+        if let Ok(entries) = std::fs::read_dir(root.join("examples")) {
+            for entry in entries.flatten() {
+                let cfg = entry.path().join(".alint.yml");
+                if cfg.is_file() {
+                    configs.push(cfg);
+                }
+            }
+        }
+
+        let mut checked = 0;
+        for path in configs {
+            let Ok(text) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(value) = serde_yaml_ng::from_str::<serde_yaml_ng::Value>(&text) else {
+                continue;
+            };
+            let json = serde_json::to_value(value).unwrap();
+            assert_eq!(
+                committed.is_valid(&json),
+                generated.is_valid(&json),
+                "committed vs generated schema disagree for {}",
+                path.display()
+            );
+            checked += 1;
+        }
+        assert!(
+            checked > 10,
+            "expected many configs, only checked {checked}"
+        );
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -31,6 +31,7 @@ use clap::{Parser, Subcommand};
 mod bench;
 mod bench_release;
 mod docs_export;
+mod gen_schema;
 mod roadmap_generator;
 
 pub(crate) use bench_release::{build_release_binary, git_sha, now_iso, workspace_root};
@@ -234,6 +235,14 @@ enum Commands {
         #[arg(long, default_value = "Roadmap")]
         title: String,
     },
+    /// Generate `schemas/v1/config.json` from Rust types (schemars) for the
+    /// migrated rule kinds, passing hand-written branches through for the rest.
+    /// See ADR-0001 and docs/design/spec-driven-development.md.
+    GenSchema {
+        /// Verify the committed schema is up to date instead of rewriting it.
+        #[arg(long)]
+        check: bool,
+    },
 }
 
 fn main() -> Result<()> {
@@ -295,6 +304,7 @@ fn main() -> Result<()> {
             };
             roadmap_generator::generate_public_roadmap(&input, &output, &title)
         }
+        Commands::GenSchema { check } => gen_schema::run(check),
     }
 }
 


### PR DESCRIPTION
## Spec-driven development: Phase 0 (ADRs) + Phase 1 (schema-from-types)

The first two phases of the spec-driven-development initiative. Full proposal and
phased plan: `docs/design/spec-driven-development.md` (recorded as **ADR-0001**).
The thesis: put machine-checkable **contracts** on the highest rung (generate
downstream, fail CI on drift); keep prose (design docs, ADRs) as point-in-time
scaffolding.

### Phase 0 - Governance

- **`docs/adr/`** - MADR 4.0 ADRs: 0001 (adopt SDD) + backfilled 0002-0004 (YAML
  config language, engine dispatch/determinism, the `extends` trust boundary),
  plus `0000-template.md`.
- **`docs/design/constitution.md`** - the load-bearing invariants, each linked to
  its enforcing test. **`docs/design/TEMPLATE.md`** - the design-doc template.
- alint **dogfoods its own `docs/adr@v1` ruleset** on its own ADRs (wired into
  `.alint.yml`); `alint check` stays green.

### Phase 1 - Config schema generated from Rust types (the keystone)

The hand-written 2180-line `schemas/v1/config.json` was the largest untracked
drift source (no test that its option keys matched the structs that parse configs).
It is now **generated from the Rust `Options` structs via schemars for 38 of ~56
option-bearing rule kinds** - so an option rename or type change propagates
automatically.

- `xtask gen-schema [--check]` - a generic assembler that preserves
  `kind`/aliases/`paths`/`required`/`anyOf` from the committed base and derives the
  option properties, descriptions, constraints, and enum `$defs` from Rust.
  `options_schema_for!` + `migrated_option_schemas()` are the per-kind hooks.
- **Gate:** `gen-schema --check` runs in preflight and CI (`ci/scripts/docs.sh`) -
  the schema can no longer drift from the types.
- **Fidelity:** verified three ways - a corpus-agreement test (committed vs
  generated agree on `all_kinds` + every bundled ruleset + every example), all 13
  `alint-dsl` schema tests (every rejection case), and a per-kind structural audit
  (no dropped properties, no lost constraints, enums preserved).
- **Passthrough by design:** the deeply nested kinds (`cross_file`, `file_graph`,
  `registry_paths_resolve`, `for_each_*`, `dir_contains`/`dir_only_contains`,
  `every_matching_has`, `generated_file_fresh`, `import_gate`, the structured-query
  family) plus two whose option type can't be faithfully derived (`filename_case`'s
  custom alias deserializer, `json_schema_passes`'s runtime-validated `format`)
  stay hand-written and pass through verbatim - zero regression.

### Review fixes (commit `2a531af3`)

A thorough adversarial review found no narrowing/widening bugs but several real
issues, all fixed: a `$defs` enum-name **collision guard**; the CI gate no longer
skips pull requests; restored 17 trimmed field docs (incl. the `${{ }}`-not-
interpolated security caveat); single-line descriptions; restored enum `default`s;
an `anyOf` rename assertion; and tests for the gate, integrity, and migrated-kind
rejection. Idempotency of generation is now proven by `gen-schema --check`.

### Verification

Idempotent regeneration, `gen_schema` + `alint-dsl` schema tests green, clippy
clean, full preflight green (fmt/clippy/test/doc/version-pins/dep-floors/dogfood).

### Not in this PR

Phases 2-5 of the proposal (generate rule + CLI reference; `facts.json` +
alint.org drift loop; Structurizr C4 + code-extracted graphs; Kani/Miri/contracts).
Migrating the deeply-nested passthrough kinds is a later, optional follow-up.
