### PR TITLE
fix(rules): emit forward-slash paths in violation messages (fixes Windows CI)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,9 @@ crates/alint/tests/cli/*.stdout text eol=lf
 crates/alint/tests/cli/*.stderr text eol=lf
 crates/alint/tests/cli/*.in text eol=lf
 crates/alint/tests/cli/*.toml text eol=lf
+
+# Generated config schema: `gen-schema --check` (and its xtask test) read these
+# back and byte-compare against a `\n`-only rendered string, so a CRLF checkout
+# on Windows would spuriously report the schema as stale.
+schemas/v1/config.json text eol=lf
+crates/alint-dsl/schemas/v1/config.json text eol=lf

--- a/crates/alint-rules/src/cross_file.rs
+++ b/crates/alint-rules/src/cross_file.rs
@@ -481,7 +481,7 @@ impl CrossFileRule {
         let msg = self
             .message
             .clone()
-            .unwrap_or_else(|| format!("{} {reason}", target.display()));
+            .unwrap_or_else(|| format!("{} {reason}", crate::slash(target)));
         Some(Violation::new(msg).with_path(target.to_path_buf()))
     }
 
@@ -541,7 +541,7 @@ impl CrossFileRule {
                 let msg = self.message.clone().unwrap_or_else(|| {
                     format!(
                         "{} is not byte-identical to {}",
-                        target.display(),
+                        crate::slash(&target),
                         self.source_file,
                     )
                 });
@@ -585,7 +585,7 @@ impl CrossFileRule {
                 let msg = self.message.clone().unwrap_or_else(|| {
                     format!(
                         "{}: declared path {entry:?} does not resolve to a file or directory",
-                        src.display(),
+                        crate::slash(src),
                     )
                 });
                 out.push(Violation::new(msg).with_path(src.to_path_buf()));
@@ -694,7 +694,7 @@ impl CrossFileRule {
     }
 
     fn violation(path: &Path, reason: &str) -> Violation {
-        Violation::new(format!("{}: {reason}", path.display())).with_path(path.to_path_buf())
+        Violation::new(format!("{}: {reason}", crate::slash(path))).with_path(path.to_path_buf())
     }
 
     /// An informational note (non-violation finding) — e.g. a
@@ -707,7 +707,7 @@ impl CrossFileRule {
         let msg = self.message.clone().unwrap_or_else(|| {
             format!(
                 "{} value {target_value:?} != {} value {source:?}",
-                target.display(),
+                crate::slash(target),
                 self.source_file,
             )
         });

--- a/crates/alint-rules/src/file_graph.rs
+++ b/crates/alint-rules/src/file_graph.rs
@@ -501,7 +501,7 @@ impl FileGraphRule {
                     &target,
                     &format!(
                         "is missing or unreadable (the derived output for {})",
-                        source.display()
+                        crate::slash(source)
                     ),
                 ));
                 continue;
@@ -517,7 +517,7 @@ impl FileGraphRule {
                     &format!(
                         "is out of date with {}: it carries no {} freshness marker matching the \
                          source's current digest (regenerate it)",
-                        source.display(),
+                        crate::slash(source),
                         algo.label(),
                     ),
                 ));
@@ -527,7 +527,7 @@ impl FileGraphRule {
     }
 
     fn node_violation(node: &Path, reason: &str) -> Violation {
-        Violation::new(format!("file_graph node {} {reason}", node.display()))
+        Violation::new(format!("file_graph node {} {reason}", crate::slash(node)))
             .with_path(node.to_path_buf())
     }
 
@@ -535,8 +535,8 @@ impl FileGraphRule {
         let msg = self.message.clone().unwrap_or_else(|| {
             format!(
                 "{} has a forbidden dependency edge to {} (forbidden_edges: from {:?} to {:?})",
-                src.display(),
-                target.display(),
+                crate::slash(src),
+                crate::slash(target),
                 pat.from_glob,
                 pat.to_glob,
             )
@@ -547,12 +547,12 @@ impl FileGraphRule {
     fn cycle_violation(&self, nodes: &[PathBuf], cycle: &[usize]) -> Violation {
         let mut rendered: String = cycle
             .iter()
-            .map(|&i| nodes[i].display().to_string())
+            .map(|&i| crate::slash(&nodes[i]))
             .collect::<Vec<_>>()
             .join(" \u{2192} ");
         // Close the loop so the cycle reads unambiguously.
         rendered.push_str(" \u{2192} ");
-        rendered.push_str(&nodes[cycle[0]].display().to_string());
+        rendered.push_str(&crate::slash(&nodes[cycle[0]]));
         let msg = self
             .message
             .clone()
@@ -564,8 +564,8 @@ impl FileGraphRule {
         let msg = self.message.clone().unwrap_or_else(|| {
             format!(
                 "{} references {}, which does not resolve to any path on disk",
-                src.display(),
-                target.display(),
+                crate::slash(src),
+                crate::slash(target),
             )
         });
         Violation::new(msg).with_path(src.to_path_buf())
@@ -575,7 +575,7 @@ impl FileGraphRule {
         let msg = self.message.clone().unwrap_or_else(|| {
             format!(
                 "{} is an orphan: no other node references it (and it is not a declared root)",
-                node.display(),
+                crate::slash(node),
             )
         });
         Violation::new(msg).with_path(node.to_path_buf())
@@ -588,7 +588,7 @@ impl FileGraphRule {
         let msg = self
             .message
             .clone()
-            .unwrap_or_else(|| format!("{} {reason}", target.display()));
+            .unwrap_or_else(|| format!("{} {reason}", crate::slash(target)));
         Violation::new(msg).with_path(target.to_path_buf())
     }
 }

--- a/crates/alint-rules/src/lib.rs
+++ b/crates/alint-rules/src/lib.rs
@@ -20,6 +20,28 @@ macro_rules! options_schema_for {
 }
 pub(crate) use options_schema_for;
 
+/// Render a path for a violation message with forward slashes on every platform.
+/// `Path::display()` emits the OS-native separator (`\` on Windows), which is
+/// inconsistent with the rest of alint's output and makes message contents
+/// platform-dependent; this mirrors the normalization the walker already applies
+/// to reported paths.
+#[must_use]
+pub(crate) fn slash(path: impl AsRef<std::path::Path>) -> String {
+    path.as_ref().display().to_string().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod slash_tests {
+    #[test]
+    fn renders_forward_slashes_regardless_of_separator() {
+        use std::path::Path;
+        // On Linux `\` is a legal filename byte, so this exercises exactly the
+        // replacement the fix relies on for Windows path separators.
+        assert_eq!(super::slash(Path::new("a\\b\\c")), "a/b/c");
+        assert_eq!(super::slash(Path::new("a/b/c")), "a/b/c");
+    }
+}
+
 pub mod case;
 pub mod changeset_requires_path;
 pub mod command;


### PR DESCRIPTION
## Fix the pre-existing Windows CI failure

`cross-platform.yml` (the Windows/macOS smoke test) has been **red on `main`** for several commits. Root cause: `file_graph` and `cross_file` interpolate paths into violation messages via `Path::display()`, which renders the OS-native separator (`\` on Windows). The 7 failing tests assert `message.contains("docs/missing.md")` (forward slashes), so they fail on Windows even though the rules fire correctly - a message-formatting bug, not a logic bug.

### Fix
- Add a `crate::slash()` helper (the same normalization `walker.rs` already applies to reported paths) + a unit test proving `\` -> `/`.
- Use it at every path-in-message site in `file_graph` and `cross_file` (the `*_violation` helpers, the identical/resolves/mismatch messages, and cycle rendering).

Forward-slash paths are the convention for linter output across platforms. **No behavior change on Linux/macOS** (`slash` is a no-op when paths already use `/`); the full `alint-rules` suite passes 643/643, clippy is clean, and preflight is green.

The bug only manifests on Windows, so this PR's **Windows CI check is the confirmation** that the 7 tests go green.

### Scope
Only the two rules whose tests assert message path shape. Other rules' message paths could be normalized for full cross-platform output consistency as a follow-up.
