### PR TITLE
feat(schema): migrate import_gate, executable_bit, structured-query family, json_schema_passes

### DIFF
--- a/crates/alint-dsl/schemas/v1/config.json
+++ b/crates/alint-dsl/schemas/v1/config.json
@@ -59,6 +59,28 @@
         }
       ]
     },
+    "ImportLanguage": {
+      "oneOf": [
+        {
+          "enum": [
+            "go",
+            "python",
+            "rust",
+            "js",
+            "scala",
+            "java",
+            "dart",
+            "nix"
+          ],
+          "type": "string"
+        },
+        {
+          "const": "generic",
+          "description": "No preset — an explicit `import_pattern` is required.",
+          "type": "string"
+        }
+      ]
+    },
     "Language": {
       "enum": [
         "auto",
@@ -79,6 +101,16 @@
       "enum": [
         "tabs",
         "spaces"
+      ],
+      "type": "string"
+    },
+    "TargetFormat": {
+      "description": "The `format:` override values for `json_schema_passes`. Distinct from `structured_path::Format` (which has `xml`, not `yml`): this validator targets json/yaml/toml documents and accepts `yml` as a `yaml` alias.",
+      "enum": [
+        "json",
+        "yaml",
+        "yml",
+        "toml"
       ],
       "type": "string"
     },
@@ -1120,7 +1152,7 @@
           "$ref": "#/$defs/paths_spec"
         },
         "require": {
-          "description": "`true`: +x must be set. `false`: +x must not be set.",
+          "description": "`true` → +x must be set; `false` → +x must NOT be set.",
           "type": "boolean"
         }
       },
@@ -2209,7 +2241,8 @@
       "description": "Forbid imports whose extracted target matches `forbid` (a regex), within the `paths` scope — an architectural import firewall. Matches the EXTRACTED import target (not the raw line), the precise low-false-positive specialisation of `file_content_forbidden`. `language` (go/python/rust/js/scala/java/dart/nix) selects a built-in import-line pattern; `import_pattern` overrides it (capture group 1 = target; required for `generic`). `allow` globs exempt files inside the scope. Per-file.",
       "properties": {
         "allow": {
-          "description": "File globs inside the scope exempt from the gate.",
+          "default": [],
+          "description": "File globs inside the scope that are exempt from the gate.",
           "items": {
             "type": "string"
           },
@@ -2220,24 +2253,26 @@
           "type": "string"
         },
         "import_pattern": {
-          "description": "Explicit import-line regex (capture group 1 = imported target); overrides the language preset.",
-          "type": "string"
+          "default": null,
+          "description": "Explicit import-line regex (capture group 1 = target). Overrides the `language` preset.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "kind": {
           "const": "import_gate"
         },
         "language": {
-          "enum": [
-            "go",
-            "python",
-            "rust",
-            "js",
-            "scala",
-            "java",
-            "dart",
-            "nix",
-            "generic"
-          ]
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ImportLanguage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Built-in import-line pattern preset (capture group 1 = the imported target). Omit to require an explicit `import_pattern`."
         },
         "paths": {
           "$ref": "#/$defs/paths_spec"
@@ -2285,13 +2320,15 @@
           "description": "Expected value. Any JSON type (string, number, boolean, null, array, object)."
         },
         "if_present": {
-          "$ref": "#/$defs/if_present"
+          "default": false,
+          "description": "When true, a query returning zero matches is silently OK - only real matches that fail the op produce violations.",
+          "type": "boolean"
         },
         "kind": {
           "const": "json_path_equals"
         },
         "path": {
-          "description": "JSONPath expression rooted at `$`. Supports dot-access (`$.foo.bar`), array index (`$.deps[0]`), wildcards (`$.deps[*]`), filters, and every other RFC 9535 construct.",
+          "description": "`JSONPath` expression rooted at `$`. Supports dot-access (`$.foo.bar`), array index (`$.deps[0]`), wildcards (`$.deps[*]`), filters, and every other RFC 9535 construct.",
           "type": "string"
         },
         "paths": {
@@ -2309,7 +2346,9 @@
       "description": "Value at a JSONPath in every JSON file in `paths` must be a string and must match `matches` (a Rust regex). Non-string matches produce a clear 'not a string' violation.",
       "properties": {
         "if_present": {
-          "$ref": "#/$defs/if_present"
+          "default": false,
+          "description": "When true, a query returning zero matches is silently OK - only real matches that fail the op produce violations.",
+          "type": "boolean"
         },
         "kind": {
           "const": "json_path_matches"
@@ -2319,6 +2358,7 @@
           "type": "string"
         },
         "path": {
+          "description": "`JSONPath` expression rooted at `$`.",
           "type": "string"
         },
         "paths": {
@@ -2336,14 +2376,15 @@
       "description": "Validate every JSON / YAML / TOML file in `paths` against the JSON Schema at `schema_path`. Each schema-violation error becomes one violation; a target that fails to parse produces one parse-error violation. Format is detected from the target's extension; pass `format:` to override.",
       "properties": {
         "format": {
-          "description": "Override the auto-detected target format. When omitted, format is inferred from each target file's extension (.json / .yaml / .yml / .toml).",
-          "enum": [
-            "json",
-            "yaml",
-            "yml",
-            "toml"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TargetFormat"
+            },
+            {
+              "type": "null"
+            }
           ],
-          "type": "string"
+          "description": "Override the auto-detected target format. When omitted, format is inferred from each target file's extension (.json / .yaml / .yml / .toml)."
         },
         "kind": {
           "const": "json_schema_passes"
@@ -2352,7 +2393,7 @@
           "$ref": "#/$defs/paths_spec"
         },
         "schema_path": {
-          "description": "Path to a JSON Schema file relative to the lint root. Schema must itself be JSON even when validating YAML / TOML targets.",
+          "description": "Path to a JSON Schema file relative to the lint root. The schema must itself be JSON even when validating YAML / TOML targets.",
           "type": "string"
         }
       },
@@ -3156,14 +3197,19 @@
     "rule_toml_path_equals": {
       "description": "TOML sibling of `json_path_equals`. Typical use: enforce `[package].edition == \"2024\"` on every `Cargo.toml`.",
       "properties": {
-        "equals": {},
+        "equals": {
+          "description": "Expected value. Any JSON type (string, number, boolean, null, array, object)."
+        },
         "if_present": {
-          "$ref": "#/$defs/if_present"
+          "default": false,
+          "description": "When true, a query returning zero matches is silently OK - only real matches that fail the op produce violations.",
+          "type": "boolean"
         },
         "kind": {
           "const": "toml_path_equals"
         },
         "path": {
+          "description": "`JSONPath` expression rooted at `$`. Supports dot-access (`$.foo.bar`), array index (`$.deps[0]`), wildcards (`$.deps[*]`), filters, and every other RFC 9535 construct.",
           "type": "string"
         },
         "paths": {
@@ -3181,15 +3227,19 @@
       "description": "TOML sibling of `json_path_matches`.",
       "properties": {
         "if_present": {
-          "$ref": "#/$defs/if_present"
+          "default": false,
+          "description": "When true, a query returning zero matches is silently OK - only real matches that fail the op produce violations.",
+          "type": "boolean"
         },
         "kind": {
           "const": "toml_path_matches"
         },
         "matches": {
+          "description": "Rust-regex pattern to match against the value at `path`.",
           "type": "string"
         },
         "path": {
+          "description": "`JSONPath` expression rooted at `$`.",
           "type": "string"
         },
         "paths": {
@@ -3232,14 +3282,19 @@
     "rule_xml_path_equals": {
       "description": "XML sibling of `json_path_equals`. XML maps to the same value tree via the xmltodict-style convention: attributes are `@name` keys, repeated child elements become an array, a leaf element collapses to its text string, namespaces flatten to local names, and every leaf value is a string (quote your `equals:`, e.g. `equals: \"4.0.0\"`). Typical use: enforce `$.Project.PropertyGroup.TargetFramework == \"net8.0\"` on every `.csproj`, or a Maven `$.project.parent.version` across `pom.xml`.",
       "properties": {
-        "equals": {},
+        "equals": {
+          "description": "Expected value. Any JSON type (string, number, boolean, null, array, object)."
+        },
         "if_present": {
-          "$ref": "#/$defs/if_present"
+          "default": false,
+          "description": "When true, a query returning zero matches is silently OK - only real matches that fail the op produce violations.",
+          "type": "boolean"
         },
         "kind": {
           "const": "xml_path_equals"
         },
         "path": {
+          "description": "`JSONPath` expression rooted at `$`. Supports dot-access (`$.foo.bar`), array index (`$.deps[0]`), wildcards (`$.deps[*]`), filters, and every other RFC 9535 construct.",
           "type": "string"
         },
         "paths": {
@@ -3257,15 +3312,19 @@
       "description": "XML sibling of `json_path_matches` (same xmltodict-style mapping as `xml_path_equals`; all XML leaf values are strings). Typical use: `$.Project.ItemGroup.PackageReference[*]['@Version']` matches a version pattern across `.csproj`.",
       "properties": {
         "if_present": {
-          "$ref": "#/$defs/if_present"
+          "default": false,
+          "description": "When true, a query returning zero matches is silently OK - only real matches that fail the op produce violations.",
+          "type": "boolean"
         },
         "kind": {
           "const": "xml_path_matches"
         },
         "matches": {
+          "description": "Rust-regex pattern to match against the value at `path`.",
           "type": "string"
         },
         "path": {
+          "description": "`JSONPath` expression rooted at `$`.",
           "type": "string"
         },
         "paths": {
@@ -3282,14 +3341,19 @@
     "rule_yaml_path_equals": {
       "description": "YAML sibling of `json_path_equals`. Parses the file as YAML before applying the JSONPath query. Use this on GitHub Actions workflows, docker-compose.yml, kubernetes manifests, `.gitlab-ci.yml`, etc.",
       "properties": {
-        "equals": {},
+        "equals": {
+          "description": "Expected value. Any JSON type (string, number, boolean, null, array, object)."
+        },
         "if_present": {
-          "$ref": "#/$defs/if_present"
+          "default": false,
+          "description": "When true, a query returning zero matches is silently OK - only real matches that fail the op produce violations.",
+          "type": "boolean"
         },
         "kind": {
           "const": "yaml_path_equals"
         },
         "path": {
+          "description": "`JSONPath` expression rooted at `$`. Supports dot-access (`$.foo.bar`), array index (`$.deps[0]`), wildcards (`$.deps[*]`), filters, and every other RFC 9535 construct.",
           "type": "string"
         },
         "paths": {
@@ -3307,15 +3371,19 @@
       "description": "YAML sibling of `json_path_matches`.",
       "properties": {
         "if_present": {
-          "$ref": "#/$defs/if_present"
+          "default": false,
+          "description": "When true, a query returning zero matches is silently OK - only real matches that fail the op produce violations.",
+          "type": "boolean"
         },
         "kind": {
           "const": "yaml_path_matches"
         },
         "matches": {
+          "description": "Rust-regex pattern to match against the value at `path`.",
           "type": "string"
         },
         "path": {
+          "description": "`JSONPath` expression rooted at `$`.",
           "type": "string"
         },
         "paths": {

--- a/crates/alint-rules/src/executable_bit.rs
+++ b/crates/alint-rules/src/executable_bit.rs
@@ -13,12 +13,14 @@
 use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Scope, Violation};
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
     /// `true` → +x must be set; `false` → +x must NOT be set.
     require: bool,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 // Fields are read only by the `#[cfg(unix)]` evaluate path; on

--- a/crates/alint-rules/src/import_gate.rs
+++ b/crates/alint-rules/src/import_gate.rs
@@ -25,8 +25,11 @@ use alint_core::{
 use regex::Regex;
 use serde::Deserialize;
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
+// Rename in the schema so the derived `$defs` entry does not collide with
+// commented_out_code's (different) `Language` enum.
+#[schemars(rename = "ImportLanguage")]
 enum Language {
     Go,
     Python,
@@ -78,10 +81,13 @@ impl Language {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// Regex tested against the extracted import target.
     forbid: String,
+    /// Built-in import-line pattern preset (capture group 1 = the imported
+    /// target). Omit to require an explicit `import_pattern`.
     #[serde(default)]
     language: Option<Language>,
     /// Explicit import-line regex (capture group 1 = target).
@@ -92,6 +98,8 @@ struct Options {
     #[serde(default)]
     allow: Vec<String>,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct ImportGateRule {

--- a/crates/alint-rules/src/json_schema_passes.rs
+++ b/crates/alint-rules/src/json_schema_passes.rs
@@ -41,21 +41,31 @@ use serde_json::Value;
 
 use crate::structured_path::Format;
 
-#[derive(Debug, Deserialize)]
+/// The `format:` override values for `json_schema_passes`. Distinct from
+/// `structured_path::Format` (which has `xml`, not `yml`): this validator targets
+/// json/yaml/toml documents and accepts `yml` as a `yaml` alias.
+#[derive(Debug, Clone, Copy, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "lowercase")]
+enum TargetFormat {
+    Json,
+    Yaml,
+    Yml,
+    Toml,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// Path to a JSON Schema file, relative to the lint root.
-    /// JSON only — even when validating YAML / TOML targets,
-    /// the schema document itself must be JSON. Most upstream
-    /// schemas (Cargo's, GitHub Actions') ship as JSON anyway.
+    /// Path to a JSON Schema file relative to the lint root. The schema must
+    /// itself be JSON even when validating YAML / TOML targets.
     schema_path: PathBuf,
-    /// Override the auto-detected target file format. One of
-    /// `json` / `yaml` / `toml`. When omitted, the format is
-    /// detected from the target file's extension; targets with
-    /// no detectable extension produce a per-file violation.
+    /// Override the auto-detected target format. When omitted, format is inferred
+    /// from each target file's extension (.json / .yaml / .yml / .toml).
     #[serde(default)]
-    format: Option<String>,
+    format: Option<TargetFormat>,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct JsonSchemaPassesRule {
@@ -224,18 +234,11 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
         .deserialize_options()
         .map_err(|e| Error::rule_config(&spec.id, format!("invalid options: {e}")))?;
 
-    let format_override = match opts.format.as_deref() {
-        None => None,
-        Some("json") => Some(Format::Json),
-        Some("yaml" | "yml") => Some(Format::Yaml),
-        Some("toml") => Some(Format::Toml),
-        Some(other) => {
-            return Err(Error::rule_config(
-                &spec.id,
-                format!("unknown format `{other}`; expected json | yaml | toml"),
-            ));
-        }
-    };
+    let format_override = opts.format.map(|f| match f {
+        TargetFormat::Json => Format::Json,
+        TargetFormat::Yaml | TargetFormat::Yml => Format::Yaml,
+        TargetFormat::Toml => Format::Toml,
+    });
 
     if spec.fix.is_some() {
         return Err(Error::rule_config(

--- a/crates/alint-rules/src/lib.rs
+++ b/crates/alint-rules/src/lib.rs
@@ -134,6 +134,7 @@ pub mod unique_by;
 /// its hand-written branch verbatim, so the published schema stays complete and
 /// valid at every step.
 #[must_use]
+#[allow(clippy::too_many_lines)]
 pub fn migrated_option_schemas() -> Vec<(&'static str, serde_json::Value)> {
     vec![
         ("rule_file_header", file_header::options_schema()),
@@ -224,6 +225,44 @@ pub fn migrated_option_schemas() -> Vec<(&'static str, serde_json::Value)> {
         (
             "rule_command_idempotent",
             command_idempotent::options_schema(),
+        ),
+        ("rule_import_gate", import_gate::options_schema()),
+        ("rule_executable_bit", executable_bit::options_schema()),
+        (
+            "rule_json_path_equals",
+            structured_path::equals_options_schema(),
+        ),
+        (
+            "rule_yaml_path_equals",
+            structured_path::equals_options_schema(),
+        ),
+        (
+            "rule_toml_path_equals",
+            structured_path::equals_options_schema(),
+        ),
+        (
+            "rule_xml_path_equals",
+            structured_path::equals_options_schema(),
+        ),
+        (
+            "rule_json_path_matches",
+            structured_path::matches_options_schema(),
+        ),
+        (
+            "rule_yaml_path_matches",
+            structured_path::matches_options_schema(),
+        ),
+        (
+            "rule_toml_path_matches",
+            structured_path::matches_options_schema(),
+        ),
+        (
+            "rule_xml_path_matches",
+            structured_path::matches_options_schema(),
+        ),
+        (
+            "rule_json_schema_passes",
+            json_schema_passes::options_schema(),
         ),
     ]
 }

--- a/crates/alint-rules/src/structured_path.rs
+++ b/crates/alint-rules/src/structured_path.rs
@@ -251,23 +251,49 @@ pub enum Op {
 // ---------------------------------------------------------------
 
 /// Options shared by every `*_path_equals` rule kind.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct EqualsOptions {
+    /// `JSONPath` expression rooted at `$`. Supports dot-access (`$.foo.bar`),
+    /// array index (`$.deps[0]`), wildcards (`$.deps[*]`), filters, and every
+    /// other RFC 9535 construct.
     path: String,
+    /// Expected value. Any JSON type (string, number, boolean, null, array, object).
     equals: Value,
+    /// When true, a query returning zero matches is silently OK - only real
+    /// matches that fail the op produce violations.
     #[serde(default)]
     if_present: bool,
 }
 
 /// Options shared by every `*_path_matches` rule kind.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct MatchesOptions {
+    /// `JSONPath` expression rooted at `$`.
     path: String,
+    /// Rust-regex pattern to match against the value at `path`.
     matches: String,
+    /// When true, a query returning zero matches is silently OK - only real
+    /// matches that fail the op produce violations.
     #[serde(default)]
     if_present: bool,
+}
+
+/// schemars-derived options schema for the four `*_path_equals` kinds; composed
+/// into their `$defs` branches by `xtask gen-schema`. See
+/// [`crate::migrated_option_schemas`].
+#[must_use]
+pub fn equals_options_schema() -> serde_json::Value {
+    serde_json::to_value(schemars::schema_for!(EqualsOptions))
+        .expect("EqualsOptions JSON schema serializes")
+}
+
+/// schemars-derived options schema for the four `*_path_matches` kinds.
+#[must_use]
+pub fn matches_options_schema() -> serde_json::Value {
+    serde_json::to_value(schemars::schema_for!(MatchesOptions))
+        .expect("MatchesOptions JSON schema serializes")
 }
 
 // ---------------------------------------------------------------

--- a/schemas/v1/config.json
+++ b/schemas/v1/config.json
@@ -59,6 +59,28 @@
         }
       ]
     },
+    "ImportLanguage": {
+      "oneOf": [
+        {
+          "enum": [
+            "go",
+            "python",
+            "rust",
+            "js",
+            "scala",
+            "java",
+            "dart",
+            "nix"
+          ],
+          "type": "string"
+        },
+        {
+          "const": "generic",
+          "description": "No preset — an explicit `import_pattern` is required.",
+          "type": "string"
+        }
+      ]
+    },
     "Language": {
       "enum": [
         "auto",
@@ -79,6 +101,16 @@
       "enum": [
         "tabs",
         "spaces"
+      ],
+      "type": "string"
+    },
+    "TargetFormat": {
+      "description": "The `format:` override values for `json_schema_passes`. Distinct from `structured_path::Format` (which has `xml`, not `yml`): this validator targets json/yaml/toml documents and accepts `yml` as a `yaml` alias.",
+      "enum": [
+        "json",
+        "yaml",
+        "yml",
+        "toml"
       ],
       "type": "string"
     },
@@ -1120,7 +1152,7 @@
           "$ref": "#/$defs/paths_spec"
         },
         "require": {
-          "description": "`true`: +x must be set. `false`: +x must not be set.",
+          "description": "`true` → +x must be set; `false` → +x must NOT be set.",
           "type": "boolean"
         }
       },
@@ -2209,7 +2241,8 @@
       "description": "Forbid imports whose extracted target matches `forbid` (a regex), within the `paths` scope — an architectural import firewall. Matches the EXTRACTED import target (not the raw line), the precise low-false-positive specialisation of `file_content_forbidden`. `language` (go/python/rust/js/scala/java/dart/nix) selects a built-in import-line pattern; `import_pattern` overrides it (capture group 1 = target; required for `generic`). `allow` globs exempt files inside the scope. Per-file.",
       "properties": {
         "allow": {
-          "description": "File globs inside the scope exempt from the gate.",
+          "default": [],
+          "description": "File globs inside the scope that are exempt from the gate.",
           "items": {
             "type": "string"
           },
@@ -2220,24 +2253,26 @@
           "type": "string"
         },
         "import_pattern": {
-          "description": "Explicit import-line regex (capture group 1 = imported target); overrides the language preset.",
-          "type": "string"
+          "default": null,
+          "description": "Explicit import-line regex (capture group 1 = target). Overrides the `language` preset.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "kind": {
           "const": "import_gate"
         },
         "language": {
-          "enum": [
-            "go",
-            "python",
-            "rust",
-            "js",
-            "scala",
-            "java",
-            "dart",
-            "nix",
-            "generic"
-          ]
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ImportLanguage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Built-in import-line pattern preset (capture group 1 = the imported target). Omit to require an explicit `import_pattern`."
         },
         "paths": {
           "$ref": "#/$defs/paths_spec"
@@ -2285,13 +2320,15 @@
           "description": "Expected value. Any JSON type (string, number, boolean, null, array, object)."
         },
         "if_present": {
-          "$ref": "#/$defs/if_present"
+          "default": false,
+          "description": "When true, a query returning zero matches is silently OK - only real matches that fail the op produce violations.",
+          "type": "boolean"
         },
         "kind": {
           "const": "json_path_equals"
         },
         "path": {
-          "description": "JSONPath expression rooted at `$`. Supports dot-access (`$.foo.bar`), array index (`$.deps[0]`), wildcards (`$.deps[*]`), filters, and every other RFC 9535 construct.",
+          "description": "`JSONPath` expression rooted at `$`. Supports dot-access (`$.foo.bar`), array index (`$.deps[0]`), wildcards (`$.deps[*]`), filters, and every other RFC 9535 construct.",
           "type": "string"
         },
         "paths": {
@@ -2309,7 +2346,9 @@
       "description": "Value at a JSONPath in every JSON file in `paths` must be a string and must match `matches` (a Rust regex). Non-string matches produce a clear 'not a string' violation.",
       "properties": {
         "if_present": {
-          "$ref": "#/$defs/if_present"
+          "default": false,
+          "description": "When true, a query returning zero matches is silently OK - only real matches that fail the op produce violations.",
+          "type": "boolean"
         },
         "kind": {
           "const": "json_path_matches"
@@ -2319,6 +2358,7 @@
           "type": "string"
         },
         "path": {
+          "description": "`JSONPath` expression rooted at `$`.",
           "type": "string"
         },
         "paths": {
@@ -2336,14 +2376,15 @@
       "description": "Validate every JSON / YAML / TOML file in `paths` against the JSON Schema at `schema_path`. Each schema-violation error becomes one violation; a target that fails to parse produces one parse-error violation. Format is detected from the target's extension; pass `format:` to override.",
       "properties": {
         "format": {
-          "description": "Override the auto-detected target format. When omitted, format is inferred from each target file's extension (.json / .yaml / .yml / .toml).",
-          "enum": [
-            "json",
-            "yaml",
-            "yml",
-            "toml"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TargetFormat"
+            },
+            {
+              "type": "null"
+            }
           ],
-          "type": "string"
+          "description": "Override the auto-detected target format. When omitted, format is inferred from each target file's extension (.json / .yaml / .yml / .toml)."
         },
         "kind": {
           "const": "json_schema_passes"
@@ -2352,7 +2393,7 @@
           "$ref": "#/$defs/paths_spec"
         },
         "schema_path": {
-          "description": "Path to a JSON Schema file relative to the lint root. Schema must itself be JSON even when validating YAML / TOML targets.",
+          "description": "Path to a JSON Schema file relative to the lint root. The schema must itself be JSON even when validating YAML / TOML targets.",
           "type": "string"
         }
       },
@@ -3156,14 +3197,19 @@
     "rule_toml_path_equals": {
       "description": "TOML sibling of `json_path_equals`. Typical use: enforce `[package].edition == \"2024\"` on every `Cargo.toml`.",
       "properties": {
-        "equals": {},
+        "equals": {
+          "description": "Expected value. Any JSON type (string, number, boolean, null, array, object)."
+        },
         "if_present": {
-          "$ref": "#/$defs/if_present"
+          "default": false,
+          "description": "When true, a query returning zero matches is silently OK - only real matches that fail the op produce violations.",
+          "type": "boolean"
         },
         "kind": {
           "const": "toml_path_equals"
         },
         "path": {
+          "description": "`JSONPath` expression rooted at `$`. Supports dot-access (`$.foo.bar`), array index (`$.deps[0]`), wildcards (`$.deps[*]`), filters, and every other RFC 9535 construct.",
           "type": "string"
         },
         "paths": {
@@ -3181,15 +3227,19 @@
       "description": "TOML sibling of `json_path_matches`.",
       "properties": {
         "if_present": {
-          "$ref": "#/$defs/if_present"
+          "default": false,
+          "description": "When true, a query returning zero matches is silently OK - only real matches that fail the op produce violations.",
+          "type": "boolean"
         },
         "kind": {
           "const": "toml_path_matches"
         },
         "matches": {
+          "description": "Rust-regex pattern to match against the value at `path`.",
           "type": "string"
         },
         "path": {
+          "description": "`JSONPath` expression rooted at `$`.",
           "type": "string"
         },
         "paths": {
@@ -3232,14 +3282,19 @@
     "rule_xml_path_equals": {
       "description": "XML sibling of `json_path_equals`. XML maps to the same value tree via the xmltodict-style convention: attributes are `@name` keys, repeated child elements become an array, a leaf element collapses to its text string, namespaces flatten to local names, and every leaf value is a string (quote your `equals:`, e.g. `equals: \"4.0.0\"`). Typical use: enforce `$.Project.PropertyGroup.TargetFramework == \"net8.0\"` on every `.csproj`, or a Maven `$.project.parent.version` across `pom.xml`.",
       "properties": {
-        "equals": {},
+        "equals": {
+          "description": "Expected value. Any JSON type (string, number, boolean, null, array, object)."
+        },
         "if_present": {
-          "$ref": "#/$defs/if_present"
+          "default": false,
+          "description": "When true, a query returning zero matches is silently OK - only real matches that fail the op produce violations.",
+          "type": "boolean"
         },
         "kind": {
           "const": "xml_path_equals"
         },
         "path": {
+          "description": "`JSONPath` expression rooted at `$`. Supports dot-access (`$.foo.bar`), array index (`$.deps[0]`), wildcards (`$.deps[*]`), filters, and every other RFC 9535 construct.",
           "type": "string"
         },
         "paths": {
@@ -3257,15 +3312,19 @@
       "description": "XML sibling of `json_path_matches` (same xmltodict-style mapping as `xml_path_equals`; all XML leaf values are strings). Typical use: `$.Project.ItemGroup.PackageReference[*]['@Version']` matches a version pattern across `.csproj`.",
       "properties": {
         "if_present": {
-          "$ref": "#/$defs/if_present"
+          "default": false,
+          "description": "When true, a query returning zero matches is silently OK - only real matches that fail the op produce violations.",
+          "type": "boolean"
         },
         "kind": {
           "const": "xml_path_matches"
         },
         "matches": {
+          "description": "Rust-regex pattern to match against the value at `path`.",
           "type": "string"
         },
         "path": {
+          "description": "`JSONPath` expression rooted at `$`.",
           "type": "string"
         },
         "paths": {
@@ -3282,14 +3341,19 @@
     "rule_yaml_path_equals": {
       "description": "YAML sibling of `json_path_equals`. Parses the file as YAML before applying the JSONPath query. Use this on GitHub Actions workflows, docker-compose.yml, kubernetes manifests, `.gitlab-ci.yml`, etc.",
       "properties": {
-        "equals": {},
+        "equals": {
+          "description": "Expected value. Any JSON type (string, number, boolean, null, array, object)."
+        },
         "if_present": {
-          "$ref": "#/$defs/if_present"
+          "default": false,
+          "description": "When true, a query returning zero matches is silently OK - only real matches that fail the op produce violations.",
+          "type": "boolean"
         },
         "kind": {
           "const": "yaml_path_equals"
         },
         "path": {
+          "description": "`JSONPath` expression rooted at `$`. Supports dot-access (`$.foo.bar`), array index (`$.deps[0]`), wildcards (`$.deps[*]`), filters, and every other RFC 9535 construct.",
           "type": "string"
         },
         "paths": {
@@ -3307,15 +3371,19 @@
       "description": "YAML sibling of `json_path_matches`.",
       "properties": {
         "if_present": {
-          "$ref": "#/$defs/if_present"
+          "default": false,
+          "description": "When true, a query returning zero matches is silently OK - only real matches that fail the op produce violations.",
+          "type": "boolean"
         },
         "kind": {
           "const": "yaml_path_matches"
         },
         "matches": {
+          "description": "Rust-regex pattern to match against the value at `path`.",
           "type": "string"
         },
         "path": {
+          "description": "`JSONPath` expression rooted at `$`.",
           "type": "string"
         },
         "paths": {


### PR DESCRIPTION
## Migrate 11 more rule kinds to schemars-derived schemas (49 type-derived)

Continues the schema-from-types work, taking the prioritized follow-up items from "easy/medium" while explaining why one is deliberately left hand-written.

### #1 - trivial
- `import_gate`, `executable_bit`.
- `import_gate`'s `Language` enum is renamed to **`ImportLanguage`** in the schema (`#[schemars(rename)]`) so its derived `$defs` entry doesn't collide with `commented_out_code`'s *different* `Language` enum. This is exactly the case the Phase 1 **collision guard** was built for - without the rename it would `bail!` at `gen-schema` time instead of silently clobbering a `$ref`.

### #2 - structured-query family (8 kinds)
`json`/`yaml`/`toml`/`xml` x `_path_equals`/`_path_matches`, via the shared `EqualsOptions`/`MatchesOptions` structs. `if_present` is now an inline boolean instead of a shared `$ref`.

### #3 - json_schema_passes
`format: Option<String>` (validated at runtime against json/yaml/yml/toml) becomes a typed `Option<TargetFormat>` enum, which also makes the `build()` conversion typed and lets serde reject bad values. `schema_path` (`PathBuf`) derives to a string.

**`filename_case` is deliberately NOT migrated.** Its `CaseConvention` deserializer *normalizes-and-matches* an open set (strip non-alpha + lowercase, so `Pascal Case`/`PASCAL-CASE`/`pascalcase` all work), while the schema's 33-value enum is a hand-*curated* autocomplete list - stricter than what the type accepts, and not a property of the type. Deriving would either over-restrict (8 canonical variants) or loosen the schema to any-string; hardcoding the 33 values in a schemars attribute is no single-source-of-truth gain. Leaving it hand-written is the correct call.

### Verification
- `gen_schema` 7/7 (collision guard + corpus agreement across **49 kinds** + migrated-kind rejection), `alint-dsl` schema 13/13, full `alint-rules` suite green.
- Idempotent (`gen-schema --check`), clippy clean, preflight green.

### Still passthrough (by design)
The genuinely deeply-nested kinds (`cross_file`, `file_graph`, `registry_paths_resolve`, `for_each_*`, `dir_contains`/`dir_only_contains`, `every_matching_has`, `generated_file_fresh`, `for_each_match`), the common-field existence kinds (`file_exists`/`file_absent`/`dir_exists`/`dir_absent`), and `filename_case` - all stable, low-churn, and high-risk/low-reward to derive.
