### PR TITLE
feat(formal-methods): proptest properties + a verified Kani proof of path confinement (Phase 5 / WS4)

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -1,0 +1,31 @@
+# Kani bounded-proof job (Phase 5 / WS4, docs/design/formal-methods.md).
+#
+# Runs the `#[kani::proof]` harnesses (today: the path-confinement policy
+# proof in alint-rules). Kept OFF the PR path and on a weekly schedule +
+# manual dispatch, because model-checking time should never block a merge
+# — the proptest properties on the PR path are the always-on behaviour
+# spec; this is the deeper, slower guarantee.
+name: Kani proofs
+
+on:
+  schedule:
+    # Mondays 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kani-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  kani:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run Kani proofs
+        uses: model-checking/kani-github-action@v1
+        with:
+          args: "-p alint-rules"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,7 @@ dependencies = [
  "content_inspector",
  "globset",
  "jsonschema",
+ "proptest",
  "regex",
  "roxmltree",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,10 @@ tokio = { version = "1", features = ["rt-multi-thread", "io-std", "macros", "syn
 unsafe_code = "forbid"
 missing_debug_implementations = "warn"
 unused_must_use = "deny"
+# `cfg(kani)` is set by the Kani verifier (`cargo kani`), not cargo, so
+# declare it known to silence `unexpected_cfgs` in normal builds. See the
+# `#[cfg(kani)]` proof harnesses (docs/design/formal-methods.md).
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/alint-rules/Cargo.toml
+++ b/crates/alint-rules/Cargo.toml
@@ -31,6 +31,7 @@ roxmltree.workspace = true
 jsonschema.workspace = true
 
 [dev-dependencies]
+proptest.workspace = true
 tempfile.workspace = true
 
 [lints]

--- a/crates/alint-rules/src/cross_file.rs
+++ b/crates/alint-rules/src/cross_file.rs
@@ -1022,6 +1022,53 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
 mod tests {
     use super::*;
     use alint_core::{FileEntry, FileIndex};
+    use proptest::prelude::*;
+
+    proptest! {
+        /// Every `normalize` transform is idempotent: normalising an
+        /// already-normalised value is a no-op. A non-idempotent
+        /// transform would make `equals` comparisons depend on how many
+        /// times normalisation ran — a latent correctness bug. (This is
+        /// the behaviour spec; proptest is the partial proof.)
+        #[test]
+        fn normalize_transforms_are_idempotent(s in r"\PC{0,48}") {
+            for t in [
+                Normalize::Trim,
+                Normalize::Lower,
+                Normalize::SemverMajor,
+                Normalize::SemverMinor,
+            ] {
+                let once = t.apply(&s);
+                let twice = t.apply(&once);
+                prop_assert_eq!(&twice, &once, "{:?} is not idempotent on {:?}", t, s);
+            }
+        }
+
+        /// `apply_normalize` with a single transform equals that
+        /// transform applied directly — the fold has no off-by-one.
+        #[test]
+        fn apply_normalize_single_equals_transform(s in r"\PC{0,48}") {
+            let t = Normalize::SemverMinor;
+            prop_assert_eq!(apply_normalize(&[t], &s), t.apply(&s));
+        }
+
+        /// `semver_minor` always yields a clean band: empty, or digits
+        /// optionally followed by `.` and more digits (`MAJOR` or
+        /// `MAJOR.MINOR`). No stray separators or non-digits survive.
+        #[test]
+        fn semver_minor_yields_a_clean_band(s in r"\PC{0,48}") {
+            let band = semver_minor(&s);
+            if !band.is_empty() {
+                let mut parts = band.split('.');
+                let major = parts.next().unwrap();
+                prop_assert!(!major.is_empty() && major.bytes().all(|b| b.is_ascii_digit()));
+                if let Some(minor) = parts.next() {
+                    prop_assert!(!minor.is_empty() && minor.bytes().all(|b| b.is_ascii_digit()));
+                }
+                prop_assert!(parts.next().is_none(), "at most MAJOR.MINOR");
+            }
+        }
+    }
 
     fn index(files: &[&str]) -> FileIndex {
         FileIndex::from_entries(

--- a/crates/alint-rules/src/pathsafe.rs
+++ b/crates/alint-rules/src/pathsafe.rs
@@ -41,7 +41,22 @@ pub(crate) fn normalize_confined(p: &Path) -> Option<PathBuf> {
     if out.as_os_str().is_empty() {
         return None;
     }
+    debug_assert!(
+        is_confined(&out),
+        "normalize_confined produced a non-confined path: {}",
+        out.display()
+    );
     Some(out)
+}
+
+/// The confinement invariant every `Some(_)` from [`normalize_confined`]
+/// upholds: a non-empty, purely root-relative path — every component is
+/// `Normal` (no `..`, no `.`, no absolute `RootDir`/`Prefix`). Checked at
+/// runtime by the `debug_assert` above and exhaustively-for-bounded-inputs
+/// by the `confinement_invariant` property test. This is the security
+/// contract: a value satisfying it is safe to `root.join(..)`.
+fn is_confined(p: &Path) -> bool {
+    !p.as_os_str().is_empty() && p.components().all(|c| matches!(c, Component::Normal(_)))
 }
 
 /// The verdict for a config-derived *read* path, accounting for the
@@ -80,9 +95,90 @@ pub(crate) fn out_of_root_note(path: &Path) -> String {
     )
 }
 
+/// A bounded, verifiable model of the confinement policy — the only
+/// distinction the walk makes between path components, decoupled from
+/// `std::path::Component` (which carries an unbounded `OsStr`) so the
+/// policy is provable over fixed-size inputs. `normalize_confined` is the
+/// real, `PathBuf`-building implementation this abstracts; the
+/// `agrees_with_proven_model` property checks they never disagree.
+#[cfg(any(test, kani))]
+mod model {
+    use std::path::Component;
+
+    #[cfg_attr(kani, derive(kani::Arbitrary))]
+    #[derive(Clone, Copy)]
+    pub(super) enum Step {
+        Normal,
+        Parent,
+        Cur,
+        AbsRoot,
+    }
+
+    pub(super) fn step_of(c: &Component) -> Step {
+        match c {
+            Component::Normal(_) => Step::Normal,
+            Component::CurDir => Step::Cur,
+            Component::ParentDir => Step::Parent,
+            Component::RootDir | Component::Prefix(_) => Step::AbsRoot,
+        }
+    }
+
+    /// Fold component steps into the surviving root-relative depth, or
+    /// `None` on any escape (an absolute component, or a `..` that
+    /// underflows the root). `Some(depth)` requires `depth > 0` — the
+    /// root itself is never a valid confined path.
+    pub(super) fn confine_steps(steps: impl IntoIterator<Item = Step>) -> Option<usize> {
+        let mut depth = 0usize;
+        for s in steps {
+            match s {
+                Step::Normal => depth += 1,
+                Step::Cur => {}
+                Step::Parent => depth = depth.checked_sub(1)?,
+                Step::AbsRoot => return None,
+            }
+        }
+        (depth > 0).then_some(depth)
+    }
+}
+
+/// Kani bounded proof of the confinement policy. Run with `cargo kani`
+/// (not part of standard preflight — Kani is a separate, heavier
+/// toolchain). See `docs/design/formal-methods.md`.
+#[cfg(kani)]
+mod kani_proofs {
+    use super::model::{Step, confine_steps};
+
+    /// For every bounded component sequence: an absolute component
+    /// always escapes (`None`), and a surviving path has a positive
+    /// depth that never exceeds its `Normal` count — so the result can
+    /// never reference a component the input didn't supply, and the
+    /// `..` arithmetic never underflows/panics.
+    #[kani::proof]
+    #[kani::unwind(7)]
+    fn confine_steps_is_sound() {
+        let steps: [Step; 6] = kani::any();
+        let result = confine_steps(steps);
+        if steps.iter().any(|s| matches!(s, Step::AbsRoot)) {
+            assert!(
+                result.is_none(),
+                "an absolute component must escape the root"
+            );
+        }
+        if let Some(depth) = result {
+            let normals = steps.iter().filter(|s| matches!(s, Step::Normal)).count();
+            assert!(depth > 0, "a confined path is never the empty root");
+            assert!(
+                depth <= normals,
+                "depth cannot exceed the Normal-component count"
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::normalize_confined;
+    use proptest::prelude::*;
     use std::path::{Path, PathBuf};
 
     fn confined(s: &str) -> Option<PathBuf> {
@@ -120,6 +216,41 @@ mod tests {
         assert_eq!(confined(""), None);
         assert_eq!(confined("."), None);
         assert_eq!(confined("a/.."), None); // collapses to the root itself
+    }
+
+    proptest! {
+        /// The security invariant, as a property: whatever path the
+        /// config author supplies, a `Some(_)` result is always
+        /// root-confined — every component `Normal`, never empty — so
+        /// `root.join(it)` can never escape the tree.
+        #[test]
+        fn confinement_invariant(s in r"[A-Za-z0-9_./\\-]{0,40}") {
+            if let Some(out) = normalize_confined(Path::new(&s)) {
+                prop_assert!(super::is_confined(&out));
+            }
+        }
+
+        /// Normalisation is idempotent: a confined path is a fixed point,
+        /// so re-normalising never changes it (a non-stable normaliser
+        /// would make `equals`/index lookups order-dependent).
+        #[test]
+        fn normalize_confined_is_idempotent(s in r"[A-Za-z0-9_./\\-]{0,40}") {
+            if let Some(out) = normalize_confined(Path::new(&s)) {
+                prop_assert_eq!(normalize_confined(&out), Some(out.clone()));
+            }
+        }
+
+        /// The real implementation agrees with the Kani-proven `model`:
+        /// it returns `Some` with N components exactly when the model
+        /// returns `Some(N)`. This ties the bounded proof to the actual
+        /// `PathBuf`-building code.
+        #[test]
+        fn agrees_with_proven_model(s in r"[A-Za-z0-9_./\\-]{0,40}") {
+            let p = Path::new(&s);
+            let model = super::model::confine_steps(p.components().map(|c| super::model::step_of(&c)));
+            let real = normalize_confined(p).map(|o| o.components().count());
+            prop_assert_eq!(real, model);
+        }
     }
 
     #[cfg(windows)]

--- a/docs/design/formal-methods.md
+++ b/docs/design/formal-methods.md
@@ -1,0 +1,100 @@
+# Design doc: pragmatic formal methods (Phase 5 / WS4)
+
+Status: Implemented (proptest properties + a verified Kani proof + `debug_assert`
+contracts, Phase 5).
+Decisions: ADR-0001 (spec-driven development). WS4 of `spec-driven-development.md`.
+Demand evidence: the v0.12 path-confinement security work added
+`pathsafe::normalize_confined` (a `Some(_)` result must be safe to
+`root.join(..)`). Example-based tests cover the cases someone thought of; a
+property and a bounded proof cover the ones they didn't.
+
+## 1. Problem
+
+Most of alint is a deterministic batch pipeline, not a concurrent protocol, so
+the ROI of heavy formal methods is low and concentrated. But two things are worth
+more than example-based tests:
+
+1. **Behaviour specs that can't drift** — properties that hold for *all* inputs
+   (idempotent normalisation, a confined path never escaping the root), checked
+   in CI on every run.
+2. **A real proof on the security-critical core** — the confinement policy is a
+   trust boundary; "we tested some paths" is weaker than "no bounded input
+   escapes."
+
+Without these, normalisation stability is assumed, and the confinement guarantee
+rests on a handful of hand-picked test strings.
+
+## 2. What we adopt (and what we don't)
+
+Following WS4's tiering:
+
+| Tier | Tool | Decision |
+|---|---|---|
+| Behaviour spec | **`proptest`** | **Adopted** — already a dep; properties added for `normalize_confined` and the `cross_file` normalisers. |
+| Bounded proof | **Kani** | **Adopted** — one verified proof of the confinement policy; a separate, scheduled CI job (not a PR gate). |
+| Runtime contract | **`debug_assert!`** | **Adopted** — the confinement invariant asserted at the function's exit (living documentation + a debug-build tripwire). |
+| Runtime contract | `contracts` crate | **Deferred** — `debug_assert!` covers the few invariants today without a new dependency; migrate toward native compiler contracts (MCP-759) when they stabilise. |
+| UB detection | **Miri** | **Deferred** — the workspace is `#![forbid(unsafe_code)]`, so Miri's primary value (UB in `unsafe`) is near-zero here; revisit if `unsafe` is ever introduced. |
+| Model checking | **Stateright** | **Deferred** — alint's cross-file dispatch is sequential and order-independence is already covered by determinism tests; a Stateright model earns its keep only if the LSP grows an incremental cross-file cache. |
+| Research-grade | Verus / Creusot / Prusti / TLA+ / Loom | **Skip** — ~5:1 proof-to-code for systems/crypto; not justified for a batch linter. "Watch," not "adopt." |
+
+## 3. What shipped
+
+**Properties (`cargo test`, every CI run):**
+
+- `pathsafe`: `confinement_invariant` (a `Some(_)` result is always non-empty and
+  purely `Normal` — safe to `root.join`), `normalize_confined_is_idempotent`, and
+  `agrees_with_proven_model` (the real `PathBuf`-building code matches the bounded
+  model the Kani proof verifies).
+- `cross_file`: `normalize_transforms_are_idempotent` (all of `trim` / `lower` /
+  `semver-major` / `semver-minor`), `apply_normalize_single_equals_transform`, and
+  `semver_minor_yields_a_clean_band` (output is `MAJOR` or `MAJOR.MINOR`, digits
+  only).
+
+**Proof (`cargo kani`, scheduled CI):** `pathsafe::kani_proofs::confine_steps_is_sound`
+proves, for every bounded component sequence, that the confinement policy
+(`model::confine_steps`) is sound — an absolute component always escapes, a
+surviving result has positive depth bounded by its `Normal` count (no phantom
+components), and the `..` arithmetic never underflows or panics. The model is the
+distilled policy; the `agrees_with_proven_model` property ties it to the real
+function so the proof's guarantee transfers.
+
+**Contract (`debug_assert!`):** `normalize_confined` asserts `is_confined(&out)`
+at its exit — the invariant as runtime-checked documentation.
+
+## 4. How to run
+
+- **Properties:** `cargo test -p alint-rules` (they run as ordinary tests).
+- **Proof:** install Kani once (`cargo install --locked kani-verifier && cargo kani
+  setup`), then `cargo kani -p alint-rules --harness confine_steps_is_sound`.
+  `cfg(kani)` is declared in `[workspace.lints.rust]` so the `#[cfg(kani)]`
+  harnesses don't warn in normal builds. CI runs the proofs on a weekly schedule
+  + manual dispatch via `.github/workflows/kani.yml` (the official
+  `model-checking/kani-github-action`), kept off the PR path so model-checking
+  time never blocks a merge.
+
+## 5. Implementation notes
+
+`proptest` added to `alint-rules` `[dev-dependencies]` (already a workspace dep).
+The Kani model (`Step`, `confine_steps`, `step_of`) lives under
+`#[cfg(any(test, kani))]` so it compiles only for tests and proofs — no dead code
+in release. The proof harness is `#[cfg(kani)]`. No production code path changed
+beyond the additive `debug_assert!`. Constitution invariants: none affected.
+
+## 6. Tests
+
+The properties *are* the tests (§3). The proof is verified by `cargo kani`
+locally and on the scheduled CI job. The `agrees_with_proven_model` property is
+the conformance link between the proof and the implementation.
+
+## 7. Open questions
+
+- **Promote `confine_steps` to the real implementation?** Deferred —
+  `normalize_confined` must build the actual `PathBuf`, which the depth-only model
+  can't; keeping them separate (model proven, impl property-checked against it) is
+  the lighter design.
+- **More proofs?** The dispatch-ordering helpers and count arithmetic are
+  candidates if a future bug suggests one; this phase deliberately ships one
+  high-value proof rather than a broad, shallow set.
+- **Stateright for the LSP cache** becomes worthwhile if/when the LSP serves
+  incremental cross-file results from a cache (today it re-runs).

--- a/docs/design/spec-driven-development.md
+++ b/docs/design/spec-driven-development.md
@@ -498,6 +498,18 @@ WS4: Kani job on the pure core; Miri nightly; `contracts` on a few invariants; e
 single Stateright model for cross-file dispatch determinism / LSP cache. This phase is
 genuinely optional and can trail the rest.
 
+*Progress (2026-06-11): shipped, scoped to where it pays. (1) **proptest** properties as the
+always-on behaviour spec: `normalize_confined` confinement + idempotence + model-agreement,
+and the `cross_file` normalisers' idempotence + clean-band shape. (2) A **verified Kani
+proof** of the path-confinement security policy (`confine_steps_is_sound`) — a bounded proof
+that an absolute component always escapes and a surviving path's depth never exceeds its
+`Normal` count, run on a weekly/dispatch CI job (`.github/workflows/kani.yml`, off the PR
+path). (3) A **`debug_assert!`** confinement contract. Miri (deferred: `forbid(unsafe_code)`
+makes it near-zero ROI), the `contracts` crate (deferred: `debug_assert!` suffices; migrate
+to MCP-759 native contracts later), and Stateright (deferred: dispatch is sequential; revisit
+for an LSP incremental cache) are documented with rationale. Research-grade verifiers skipped.
+Spec: `docs/design/formal-methods.md`.*
+
 Each phase is independently shippable and leaves the tree green. The whole program is mostly
 non-user-facing (engine internals, CI, docs pipeline), so it can interleave with feature work
 rather than blocking a release; the natural home is an engineering-foundations track


### PR DESCRIPTION
## What

Phase 5 / WS4 — the **pragmatic formal-methods tier**, scoped to where it pays. Spec + the full adopt/defer/skip rationale: `docs/design/formal-methods.md`.

### proptest properties — the always-on behaviour spec (`cargo test`)
- **`pathsafe`:** `confinement_invariant` (a `Some(_)` from `normalize_confined` is always non-empty + purely `Normal` → safe to `root.join`), `normalize_confined_is_idempotent`, and `agrees_with_proven_model`.
- **`cross_file`:** the normalizers' idempotence (`trim`/`lower`/`semver-major`/`semver-minor`), single-transform == fold, and the `semver-minor` clean-band shape.

### A verified Kani proof — the security-critical core (`cargo kani`)
`confine_steps_is_sound` proves the **path-confinement policy** for every bounded component sequence: an absolute component always escapes, a surviving path's depth is positive and never exceeds its `Normal` count (no phantom components), and the `..` arithmetic never underflows or panics. Verified locally: **`VERIFICATION: SUCCESSFUL`, 350 checks, 0 failures.**

A `#[cfg(any(test, kani))]` `model` distils the policy; the `agrees_with_proven_model` property ties the proof to the real `PathBuf`-building `normalize_confined`, so the bounded guarantee transfers to the actual code.

### A `debug_assert!` contract
`normalize_confined` asserts `is_confined(&out)` at its exit — the invariant as runtime-checked living documentation.

## Why this scope

| | Decision |
|---|---|
| proptest / Kani / `debug_assert` | **Adopted** (above) |
| **Miri** | Deferred — workspace is `#![forbid(unsafe_code)]`, so UB-detection ROI is near-zero; revisit if `unsafe` is introduced |
| **`contracts` crate** | Deferred — `debug_assert!` covers today's invariants without a new dep; migrate to native compiler contracts (MCP-759) later |
| **Stateright** | Deferred — cross-file dispatch is sequential + already determinism-tested; revisit for an LSP incremental cache |
| Verus / Creusot / TLA+ / … | Skipped — research-grade, ~5:1 proof-to-code |

## Wiring / safety

- `proptest` added to `alint-rules` `[dev-dependencies]` (already a workspace dep).
- `cfg(kani)` declared in `[workspace.lints.rust]` so the `#[cfg(kani)]` harnesses don't warn in normal builds; the `model` is `#[cfg(any(test, kani))]` so there's no dead code in release.
- `.github/workflows/kani.yml` runs the proofs **weekly + on dispatch** via the official `kani-github-action`, deliberately **off the PR path** so model-checking time never blocks a merge.
- No production code path changed beyond the additive `debug_assert!`.

## Test plan

- [x] `cargo test -p alint-rules` — 649 pass (incl. the new properties)
- [x] `cargo kani -p alint-rules --harness confine_steps_is_sound` — VERIFICATION: SUCCESSFUL
- [x] `bash ci/scripts/preflight.sh` — all checks passed (fmt · clippy · workspace tests · `cargo doc -D warnings` · dogfood ✓ 41/41)