### PR TITLE
fix(ci): close the generated-artifact drift-gate bypass + gate fact_predicates (review PR A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,9 +137,16 @@ jobs:
   docs:
     name: Docs
     needs: [changes, fmt]
+    # Runs on `docs` changes too, not just `rust`: docs.sh carries the
+    # gen-{schema,facts,arch} --check and docs-export --check gates, and the
+    # artifacts they guard (facts.json, docs/design/architecture/**, and the
+    # docs bundle from docs/rules.md) live under `docs`/root paths that don't
+    # flip `rust`. Without the `docs` clause, a PR hand-editing a generated
+    # artifact would skip this job and merge stale (the gate bypass the
+    # 2026-06-11 review found).
     if: >-
       !cancelled() && !failure()
-      && needs.changes.outputs.rust == 'true'
+      && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.docs == 'true')
     runs-on: [self-hosted, linux, alint]
     steps:
       - uses: actions/checkout@v6
@@ -147,10 +154,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: ci-docs
-      # Runs on pull_request too (not just push): docs.sh carries the
-      # `gen-schema --check`, `docs-export --check`, and rustdoc gates, which
-      # are load-bearing for schema/parser correctness and must catch drift on a
-      # PR, not only post-merge.
+      # Load-bearing for schema/parser/contract correctness; must catch drift
+      # on a PR, not only post-merge.
       - run: ci/scripts/docs.sh
 
   dogfood:

--- a/ci/scripts/detect-changes.sh
+++ b/ci/scripts/detect-changes.sh
@@ -71,7 +71,10 @@ if echo "$CHANGED" | grep -qE '^(crates/alint-bench/|xtask/)'; then
   BENCH=true
 fi
 
-if echo "$CHANGED" | grep -qE '^(docs/|PROPOSAL\.md$|[A-Z_]+\.md$)'; then
+# `facts.json` (repo root) is a generated contract guarded by `gen-facts
+# --check` in the docs job; route it through `docs` so a hand-edit can't skip
+# every gate (the architecture artifacts under docs/ already match here).
+if echo "$CHANGED" | grep -qE '^(docs/|PROPOSAL\.md$|[A-Z_]+\.md$|facts\.json$)'; then
   DOCS=true
 fi
 

--- a/crates/alint-core/src/facts.rs
+++ b/crates/alint-core/src/facts.rs
@@ -112,6 +112,23 @@ impl FactKind {
             Self::Custom { .. } => "custom",
         }
     }
+
+    /// Every built-in fact-kind name, sorted — the single source of truth
+    /// the `facts.json` contract (xtask `gen-facts`) consumes, so the
+    /// published `fact_predicates` list can't drift from the engine.
+    ///
+    /// MUST list every variant's `name()`. `name()` above is an
+    /// exhaustive match, so adding a `FactKind` variant forces a new arm
+    /// there — add its name here too (the `all_names_covers_every_variant`
+    /// test fails if this list and `name()` disagree).
+    pub const ALL_NAMES: &'static [&'static str] = &[
+        "all_files_exist",
+        "any_file_exists",
+        "count_files",
+        "custom",
+        "file_content_matches",
+        "git_branch",
+    ];
 }
 
 /// Fact-kind body for `custom`. Spawns `argv` as a child process
@@ -335,6 +352,52 @@ mod tests {
 
     fn parse(yaml: &str) -> Vec<FactSpec> {
         serde_yaml_ng::from_str(yaml).unwrap()
+    }
+
+    /// `FactKind::ALL_NAMES` is the source of truth for the `facts.json`
+    /// contract; keep it sorted/unique and in step with `name()`. Each
+    /// variant is built via the public parse path, so a renamed
+    /// discriminator or a name dropped from `ALL_NAMES` fails here. (A
+    /// brand-new variant also forces a `name()` arm — exhaustive match —
+    /// so this list can't silently fall behind.)
+    #[test]
+    fn all_names_is_sorted_unique_and_matches_name() {
+        let mut sorted = FactKind::ALL_NAMES.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            FactKind::ALL_NAMES,
+            sorted.as_slice(),
+            "FactKind::ALL_NAMES must be sorted and de-duplicated"
+        );
+
+        let cases = [
+            ("- id: f\n  any_file_exists: x\n", "any_file_exists"),
+            ("- id: f\n  all_files_exist: [x]\n", "all_files_exist"),
+            ("- id: f\n  count_files: \"**/*\"\n", "count_files"),
+            (
+                "- id: f\n  file_content_matches:\n    paths: x\n    pattern: y\n",
+                "file_content_matches",
+            ),
+            ("- id: f\n  git_branch: {}\n", "git_branch"),
+            ("- id: f\n  custom:\n    argv: [echo, hi]\n", "custom"),
+        ];
+        let mut seen = std::collections::BTreeSet::new();
+        for (yaml, expected) in cases {
+            let specs = parse(yaml);
+            assert_eq!(specs[0].kind.name(), expected, "name() drift for {yaml:?}");
+            assert!(
+                FactKind::ALL_NAMES.contains(&expected),
+                "{expected} is produced by name() but missing from ALL_NAMES"
+            );
+            seen.insert(expected);
+        }
+        let listed: std::collections::BTreeSet<&str> =
+            FactKind::ALL_NAMES.iter().copied().collect();
+        assert_eq!(
+            seen, listed,
+            "ALL_NAMES lists a name no covered variant produces (add a case above or fix ALL_NAMES)"
+        );
     }
 
     #[test]

--- a/docs/adr/0001-adopt-spec-driven-development.md
+++ b/docs/adr/0001-adopt-spec-driven-development.md
@@ -59,6 +59,14 @@ Wherever a CI gate is needed, we prefer an alint rule (for example `generated_fi
 for regenerate-and-diff freshness) over a bespoke script, so alint enforces its own
 spec-driven discipline on itself.
 
+Amendment (2026-06-11): in practice the generator freshness gates shipped as
+`gen-{schema,facts,arch} --check` (CI `docs` job + a cargo test each), not as
+`generated_file_fresh` alint rules. `generated_file_fresh` diffs a command's stdout against
+one file; the generators write files (`gen-schema` writes two), already expose `--check`, and
+dogfooding them would shell `cargo` from inside `alint check .`. The `--check` gates are
+themselves under cargo test, preserving the "alint generator under test" intent without the
+poor fit. See WS1f in `docs/design/spec-driven-development.md` for the full rationale.
+
 ## Consequences
 
 Positive: most drift becomes machine-detectable and auto-fixable; the schema can no

--- a/docs/design/spec-driven-development.md
+++ b/docs/design/spec-driven-development.md
@@ -238,6 +238,18 @@ and guarded by a regenerate-then-diff check. Implement the gate as an alint rule
 itself an alint feature under test. Keep `git diff --exit-code` as the CI backstop. Prefer
 content-diff over any mtime-based staleness check (mtime is unreliable on fresh CI clones).
 
+*Decision (2026-06-11): the gates shipped as `gen-{schema,facts,arch} --check` (run in CI's
+`docs` job via `ci/scripts/docs.sh`) plus a `gen_*_check_passes_on_committed_tree` cargo
+test per generator — content-diff, not mtime. We did NOT dogfood them via
+`generated_file_fresh` because it doesn't fit: that kind diffs a command's stdout against a
+single target, but our generators write files (and `gen-schema` writes two — root + the
+in-crate copy), have a first-class `--check` mode, and would have to shell `cargo` from
+inside `alint check .` — making the dogfood non-self-contained and slow on every push. The
+`--check` gates are themselves under cargo test, so the mechanism is still "an alint
+generator under test," just not routed through an alint rule. The earlier CI-gate bypass
+(artifact-only PRs skipping the `docs` job) was closed in the same review by routing
+`facts.json` + `docs/design/architecture/**` through the `docs` change-class.*
+
 **WS1 net effect:** the schema, the rule reference, the CLI reference, and the public facts
 all become generated, snapshot-pinned, and gated. Drift sources #1, #3, #4 are closed; #2 is
 set up for WS5.

--- a/xtask/src/facts.rs
+++ b/xtask/src/facts.rs
@@ -228,21 +228,15 @@ fn auto_fix_ops_count(root: &Path) -> Result<usize> {
     walk(&root.join("crates/alint-rules/src/fixers"))
 }
 
-/// The `FactSpec::name()` arms in `crates/alint-core/src/facts.rs`,
-/// sorted. A small, stable set kept in lockstep with that match by the
-/// list being short enough to eyeball in review.
+/// The built-in fact-kind names, taken from `alint_core::FactKind::ALL_NAMES`
+/// (the single source of truth, gated against `FactKind::name()` by a test
+/// in alint-core) rather than a copy here — so `facts.json` can't drift from
+/// the engine's fact kinds. `ALL_NAMES` is already sorted; re-sort defensively.
 fn fact_predicates() -> Vec<String> {
-    let mut v: Vec<String> = [
-        "all_files_exist",
-        "any_file_exists",
-        "count_files",
-        "custom",
-        "file_content_matches",
-        "git_branch",
-    ]
-    .iter()
-    .map(|s| (*s).to_string())
-    .collect();
+    let mut v: Vec<String> = alint_core::FactKind::ALL_NAMES
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
     v.sort();
     v
 }


### PR DESCRIPTION
Review follow-up **PR A — anti-drift hardening** (from the 5-phase post-implementation review).

## CI drift-gate bypass (the headline finding)
The `docs` job carries the `gen-{schema,facts,arch} --check` + `docs-export --check` gates but was gated `if: rust == 'true'` — while `facts.json` (repo root) and `docs/design/architecture/**` flip only `docs` (or nothing). So a PR hand-editing a generated artifact **skipped every gate in GitHub CI** and could merge stale; only the bypassable local hook stopped it.
- `detect-changes.sh` routes `facts.json` through the `docs` class.
- the `docs` job now runs on `rust || docs` — fires for those artifacts **and** closes a pre-existing gap (a `docs/rules.md` edit previously skipped `docs-export --check`).

## fact_predicates gate
`facts.json`'s `fact_predicates` was a hardcoded copy in xtask with no gate. Introduced `alint_core::FactKind::ALL_NAMES` (single source of truth, adjacent to the exhaustive `name()`, with a coverage test) and made `gen-facts` consume it. facts.json byte-identical.

## Dogfood decision recorded
WS1f + ADR-0001 now record why the freshness gates shipped as `--check` (CI + cargo test) rather than `generated_file_fresh` (it diffs a command's stdout vs one file; ours write files, gen-schema writes two, and dogfooding would shell cargo from `alint check .`).

Preflight: all checks passed (fmt · clippy · tests · cargo doc · dogfood ✓41/41).