### PR TITLE
fix(arch): distinguish runtime vs dev/build crate dependencies (review PR C)

### DIFF
--- a/docs/design/architecture-as-code.md
+++ b/docs/design/architecture-as-code.md
@@ -48,9 +48,13 @@ linking the generated graph, the C4 model, and `docs/adr/`. The live
 themselves workspace members, and renders:
 
 - A `graph TD` Mermaid block: one node per crate (id = name with `-`→`_`,
-  label = crate name; the binary and `xtask` annotated), one edge `A --> B` per
-  "A depends on B". Nodes and edges sorted for determinism.
-- A table sorted by `(tier, name)`, where **tier** = longest dependency chain to
+  label = crate name). A solid edge `A --> B` is a normal (runtime)
+  dependency; a dashed edge `A -.-> B` is dev/build-only (test harnesses,
+  tooling). Distinguishing them keeps the architecture honest — the previous
+  version drew test-only edges as production ones — and avoids orphaning the
+  pure-test crates (e.g. `alint-e2e`, whose deps are all dev). Nodes and edges
+  sorted for determinism.
+- A table sorted by `(tier, name)`, where **tier** = longest *runtime*-dependency chain to
   a leaf (`alint-core` = 0). The role text is the crate's Cargo `description`.
 
 `gen-arch` (no flag) rewrites `crate-graph.md`; `gen-arch --check` regenerates
@@ -107,8 +111,10 @@ In `xtask` (`arch.rs` `#[cfg(test)]`):
 
 - `gen_arch_check_passes_on_committed_tree` — `run(true)` succeeds on the
   committed `crate-graph.md` (freshness; mirrors the schema/facts tests).
-- `workspace_graph_is_acyclic` — DFS cycle check over the extracted edges.
-- `alint_core_is_a_dependency_sink` — `alint-core` has no intra-workspace deps.
+- `workspace_graph_is_acyclic` — DFS cycle check over the runtime (normal)
+  edges. (Dev/build edges are excluded: a normal+dev cycle is legal in Cargo,
+  so checking all edges could bail spuriously.)
+- `alint_core_is_a_dependency_sink` — `alint-core` has no runtime intra-workspace deps.
 - `workspace_dsl_components_match_cargo_metadata` — the C4 model's crate set
   equals the workspace-member set.
 

--- a/docs/design/architecture/crate-graph.md
+++ b/docs/design/architecture/crate-graph.md
@@ -4,9 +4,9 @@
      Edit the crates' Cargo.toml and regenerate; `gen-arch --check` gates it. -->
 
 The intra-workspace dependency edges of alint's Cargo workspace, extracted from
-`cargo metadata`. `alint-core` is the foundation (no workspace dependencies); the
-`alint` binary and `xtask` sit at the top. An edge `A --> B` means crate A depends
-on crate B.
+`cargo metadata`. A solid edge `A --> B` is a normal (runtime) dependency; a dashed
+edge `A -.-> B` is dev/build-only (test harnesses, tooling). `alint-core` is the
+foundation (no runtime dependencies); the tiers below count runtime edges only.
 
 ```mermaid
 graph TD
@@ -30,11 +30,6 @@ graph TD
     alint_bench --> alint_output
     alint_bench --> alint_rules
     alint_dsl --> alint_core
-    alint_dsl --> alint_rules
-    alint_e2e --> alint_core
-    alint_e2e --> alint_dsl
-    alint_e2e --> alint_rules
-    alint_e2e --> alint_testkit
     alint_lsp --> alint_core
     alint_lsp --> alint_dsl
     alint_lsp --> alint_rules
@@ -45,23 +40,28 @@ graph TD
     alint_testkit --> alint_rules
     xtask --> alint_bench
     xtask --> alint_core
-    xtask --> alint_dsl
     xtask --> alint_rules
+    alint_dsl -.-> alint_rules
+    alint_e2e -.-> alint_core
+    alint_e2e -.-> alint_dsl
+    alint_e2e -.-> alint_rules
+    alint_e2e -.-> alint_testkit
+    xtask -.-> alint_dsl
 ```
 
 ## Crates by tier
 
-Tier = longest dependency chain to the foundation (`alint-core` = 0).
+Tier = longest runtime-dependency chain to the foundation (`alint-core` = 0); dev/build-only edges don't count.
 
 | Tier | Crate | Role |
 |---|---|---|
 | 0 | `alint-core` | Core types and execution engine for the alint language-agnostic repository linter. |
+| 0 | `alint-e2e` | Internal: end-to-end scenario tests for alint. Not a library. |
+| 1 | `alint-dsl` | Internal: YAML DSL loader for alint configuration files. Not a stable public API. |
 | 1 | `alint-output` | Internal: output formatters for alint reports (human, json, ...). Not a stable public API. |
 | 1 | `alint-rules` | Internal: built-in rule implementations for alint. Not a stable public API. |
-| 2 | `alint-dsl` | Internal: YAML DSL loader for alint configuration files. Not a stable public API. |
-| 3 | `alint-bench` | Benchmark harness and deterministic fixture generator for alint |
-| 3 | `alint-lsp` | Internal: Language Server Protocol server for alint. Not a stable public API. |
-| 3 | `alint-testkit` | Internal: end-to-end scenario fixtures + tree-spec utilities for alint's own tests. Not a stable public API. |
-| 4 | `alint` | Language-agnostic linter for repository structure, file existence, filename conventions, and file content rules. |
-| 4 | `alint-e2e` | Internal: end-to-end scenario tests for alint. Not a library. |
-| 4 | `xtask` | Cargo-xtask helpers for alint (bench, release, etc.) |
+| 2 | `alint-bench` | Benchmark harness and deterministic fixture generator for alint |
+| 2 | `alint-lsp` | Internal: Language Server Protocol server for alint. Not a stable public API. |
+| 2 | `alint-testkit` | Internal: end-to-end scenario fixtures + tree-spec utilities for alint's own tests. Not a stable public API. |
+| 3 | `alint` | Language-agnostic linter for repository structure, file existence, filename conventions, and file content rules. |
+| 3 | `xtask` | Cargo-xtask helpers for alint (bench, release, etc.) |

--- a/docs/design/architecture/workspace.dsl
+++ b/docs/design/architecture/workspace.dsl
@@ -72,7 +72,8 @@ workspace "alint" "Language-agnostic repository linter" {
         comp_alint -> comp_output "Renders reports"
         comp_alint -> comp_lsp "Starts the server (`alint lsp`)"
         comp_dsl -> comp_core "Builds the config AST"
-        comp_dsl -> comp_rules "Resolves rule kinds"
+        # (alint-dsl depends on alint-rules only in tests — a dev-dependency,
+        #  not a runtime relationship; see crate-graph.md's dashed edge.)
         comp_rules -> comp_core "Implements the Rule trait"
         comp_output -> comp_core "Formats the engine's Report"
         comp_lsp -> comp_core "Runs the engine"

--- a/xtask/src/arch.rs
+++ b/xtask/src/arch.rs
@@ -31,8 +31,13 @@ const WORKSPACE_DSL: &str = "docs/design/architecture/workspace.dsl";
 struct Crate {
     name: String,
     description: String,
-    /// Sorted, de-duplicated workspace-member dependency names.
+    /// Sorted normal (runtime) intra-workspace dependency names — the
+    /// production architecture; the tier + acyclic computations use these.
     deps: Vec<String>,
+    /// Sorted dev/build-only intra-workspace dependency names (test
+    /// harnesses, xtask's test deps). Rendered as dashed edges; excluded
+    /// from tiers and the cycle check (a normal+dev cycle is legal in Cargo).
+    dev_deps: Vec<String>,
 }
 
 #[derive(Deserialize)]
@@ -51,6 +56,10 @@ struct Package {
 #[derive(Deserialize)]
 struct MetaDep {
     name: String,
+    /// `null` for a normal (runtime) dependency; `"dev"` / `"build"`
+    /// otherwise. `cargo metadata` lists the same dep once per kind.
+    #[serde(default)]
+    kind: Option<String>,
 }
 
 /// `cargo metadata --no-deps`, reduced to workspace crates and the
@@ -74,17 +83,28 @@ fn workspace_crates(root: &Path) -> Result<Vec<Crate>> {
         .packages
         .iter()
         .map(|p| {
-            let mut deps: BTreeSet<String> = p
-                .dependencies
-                .iter()
-                .map(|d| d.name.clone())
-                .filter(|n| members.contains(n))
-                .collect();
-            deps.remove(&p.name); // a crate never lists itself, but be safe
+            let mut deps: BTreeSet<String> = BTreeSet::new();
+            let mut dev_deps: BTreeSet<String> = BTreeSet::new();
+            for d in &p.dependencies {
+                // Self-edges never occur, but guard; and only workspace members.
+                if d.name == p.name || !members.contains(&d.name) {
+                    continue;
+                }
+                if d.kind.is_none() {
+                    deps.insert(d.name.clone());
+                } else {
+                    dev_deps.insert(d.name.clone());
+                }
+            }
+            // A dep listed as both normal and dev counts as normal (runtime).
+            for n in &deps {
+                dev_deps.remove(n);
+            }
             Crate {
                 name: p.name.clone(),
                 description: p.description.clone().unwrap_or_default(),
                 deps: deps.into_iter().collect(),
+                dev_deps: dev_deps.into_iter().collect(),
             }
         })
         .collect();
@@ -146,13 +166,16 @@ fn render_crate_graph(crates: &[Crate]) -> String {
     );
     let _ = writeln!(
         &mut out,
-        "`cargo metadata`. `alint-core` is the foundation (no workspace dependencies); the"
+        "`cargo metadata`. A solid edge `A --> B` is a normal (runtime) dependency; a dashed"
     );
     let _ = writeln!(
         &mut out,
-        "`alint` binary and `xtask` sit at the top. An edge `A --> B` means crate A depends"
+        "edge `A -.-> B` is dev/build-only (test harnesses, tooling). `alint-core` is the"
     );
-    let _ = writeln!(&mut out, "on crate B.");
+    let _ = writeln!(
+        &mut out,
+        "foundation (no runtime dependencies); the tiers below count runtime edges only."
+    );
     let _ = writeln!(&mut out);
 
     let _ = writeln!(&mut out, "```mermaid");
@@ -160,9 +183,17 @@ fn render_crate_graph(crates: &[Crate]) -> String {
     for c in crates {
         let _ = writeln!(&mut out, "    {}[\"{}\"]", node_id(&c.name), c.name);
     }
+    // Normal (runtime) dependency edges — solid.
     for c in crates {
         for dep in &c.deps {
             let _ = writeln!(&mut out, "    {} --> {}", node_id(&c.name), node_id(dep));
+        }
+    }
+    // Dev/build-only edges — dashed, so the architecture (solid) reads clean
+    // while the full structure stays visible (test crates aren't orphaned).
+    for c in crates {
+        for dep in &c.dev_deps {
+            let _ = writeln!(&mut out, "    {} -.-> {}", node_id(&c.name), node_id(dep));
         }
     }
     let _ = writeln!(&mut out, "```");
@@ -172,7 +203,8 @@ fn render_crate_graph(crates: &[Crate]) -> String {
     let _ = writeln!(&mut out);
     let _ = writeln!(
         &mut out,
-        "Tier = longest dependency chain to the foundation (`alint-core` = 0)."
+        "Tier = longest runtime-dependency chain to the foundation (`alint-core` = 0); \
+         dev/build-only edges don't count."
     );
     let _ = writeln!(&mut out);
     let _ = writeln!(&mut out, "| Tier | Crate | Role |");


### PR DESCRIPTION
Review follow-up **PR C — Phase 4 correctness**. The crate graph dropped `cargo metadata`'s dependency `kind`, so dev/build edges rendered identically to production ones — and the C4 model asserted one as a runtime relationship that's test-only.

- `MetaDep` now reads `kind`; the graph renders **normal (runtime)** deps as solid `-->` and **dev/build-only** deps as dashed `-.->`, with a legend. Tiers + the acyclic check use runtime deps only (a normal+dev cycle is *legal* in Cargo, so the old all-edges check could bail spuriously).
- Net: `alint-dsl → alint-rules`, `xtask → alint-dsl`, and all of `alint-e2e`'s edges are dev-only → now dashed; **`alint-dsl` drops tier 2 → 1** (no runtime dep on alint-rules). Test crates aren't orphaned — their dev edges still show, dashed.
- `workspace.dsl`: removed the mislabeled `comp_dsl → comp_rules "Resolves rule kinds"` edge.

gen-arch --check green; 55 xtask tests; clippy clean; preflight green.