### PR TITLE
fix(cross_file): make SemverMajor normalization idempotent

### DIFF
--- a/crates/alint-rules/proptest-regressions/cross_file.txt
+++ b/crates/alint-rules/proptest-regressions/cross_file.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 9d3a284368ff58b4c0569b9fd3735771dcb19be19ee2c49d3768efe8f9b5816d # shrinks to s = "0 ."

--- a/crates/alint-rules/src/cross_file.rs
+++ b/crates/alint-rules/src/cross_file.rs
@@ -140,14 +140,20 @@ impl Normalize {
             Self::None => v.to_string(),
             Self::Trim => v.trim().to_string(),
             Self::Lower => v.trim().to_lowercase(),
-            // Unchanged released behaviour: leading token, leading
-            // non-digits stripped.
+            // Leading `.`-token, leading non-digits stripped. The trailing
+            // `trim_end` keeps normalisation idempotent: `trim()` runs before
+            // the split, so the pre-`.` token can still carry trailing
+            // whitespace (e.g. `"0 ."` -> token `"0 "`) that a second pass
+            // would strip — found by `normalize_transforms_are_idempotent`.
+            // (Trailing non-whitespace like `-dev` is intentionally kept, so
+            // released behaviour is unchanged for real version strings.)
             Self::SemverMajor => v
                 .trim()
                 .split('.')
                 .next()
                 .unwrap_or("")
                 .trim_start_matches(|c: char| !c.is_ascii_digit())
+                .trim_end()
                 .to_string(),
             Self::SemverMinor => semver_minor(v),
         }
@@ -1241,6 +1247,17 @@ mod tests {
         let v = eval(&r, root, &idx);
         assert_eq!(v.len(), 1);
         assert!(v[0].message.contains("exactly one value"));
+    }
+
+    #[test]
+    fn semver_major_is_idempotent_on_trailing_space_token() {
+        // Regression (found by normalize_transforms_are_idempotent): `trim()`
+        // runs before `split('.')`, so the pre-`.` token can carry trailing
+        // whitespace (`"0 ."` -> token `"0 "`). Without the trailing `trim_end`
+        // the first pass returned `"0 "` and a second pass `"0"` — not stable.
+        assert_eq!(Normalize::SemverMajor.apply("0 ."), "0");
+        let once = Normalize::SemverMajor.apply("0 .");
+        assert_eq!(Normalize::SemverMajor.apply(&once), once);
     }
 
     #[test]


### PR DESCRIPTION
The `normalize_transforms_are_idempotent` proptest (added in the Phase 5 formal-methods work) **found a real bug**: `Normalize::SemverMajor` calls `trim()` *before* `split('.')`, so the token before the first `.` can carry trailing whitespace — `"0 ."` → token `"0 "` → result `"0 "`, while a second pass yields `"0"`. Normalization that isn't a fixed point makes `cross_file` `equals` comparisons depend on how many times it ran.

Fix: `trim_end()` the result — the spurious trailing whitespace is removed; trailing non-whitespace like `-dev` is intentionally kept, so released behaviour is unchanged for real version strings. Added an explicit unit regression + committed the proptest seed (`proptest-regressions/cross_file.txt`) so `"0 ."` is always replayed.

The property test earning its keep — the example tests and the manual fuzz both missed this. Preflight green; proptest passes deterministically (3× + the pinned seed).