### PR TITLE
fix(ci): pin facts.json + crate-graph.md to LF (fixes Windows gen-*-check)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,3 +24,11 @@ crates/alint/tests/cli/*.toml text eol=lf
 # on Windows would spuriously report the schema as stale.
 schemas/v1/config.json text eol=lf
 crates/alint-dsl/schemas/v1/config.json text eol=lf
+
+# Generated surface-area contract + crate dependency graph: `gen-facts --check`
+# and `gen-arch --check` (and their xtask tests) byte-compare these against a
+# `\n`-only rendered string — the same CRLF-on-Windows hazard as the schema
+# above. Without these pins the Windows CI job reports them spuriously stale
+# (the failure that started with the facts.json / crate-graph.md commits).
+facts.json text eol=lf
+docs/design/architecture/crate-graph.md text eol=lf


### PR DESCRIPTION
## Investigation
The **Cross-Platform / windows-latest** job has failed on every merge since the **facts.json (Phase 3)** and **crate-graph.md (Phase 4)** commits (green on Phase 2). The two failing tests:
- `facts::tests::gen_facts_check_passes_on_committed_tree` — "facts.json is stale"
- `arch::tests::gen_arch_check_passes_on_committed_tree` — "crate-graph.md is stale"

## Root cause
`.gitattributes` pins `schemas/v1/config.json` to LF (Phase 1) precisely so `gen-schema --check` doesn't false-positive on Windows — but the two newer generated artifacts were never added. With `core.autocrlf=true` (Windows default) git checks them out as CRLF, and the `--check` tests byte-compare the committed file against a `\n`-only rendered string → spurious "stale". macOS/Linux (no autocrlf) pass.

## Fix
Extend the same LF pin to `facts.json` + `docs/design/architecture/crate-graph.md`. The in-repo bytes are already LF (`git ls-files --eol` → `i/lf`), so this only changes Windows checkout; no content change, gen-facts/gen-arch --check still green on Linux. **Holding the merge until this PR's Windows job confirms green.**