### PR TITLE
ci(detect-changes): treat .gitattributes as a rust change

### DIFF
--- a/ci/scripts/detect-changes.sh
+++ b/ci/scripts/detect-changes.sh
@@ -62,7 +62,12 @@ if echo "$CHANGED" | grep -qE '^editors/'; then
   EDITORS=true
 fi
 
-if echo "$CHANGED" | grep -qE '^(crates/|xtask/|schemas/|\.alint\.yml$)'; then
+# `.gitattributes` controls the checkout line endings of byte-compared
+# fixtures and generated artifacts (snapshots, trycmd literals, the
+# schema, facts.json, crate-graph.md), so a change to it can flip
+# `gen-*-check` / snapshot tests on a CRLF platform — run the rust suite
+# (and, via `rust || docs`, the docs gates) so that's validated.
+if echo "$CHANGED" | grep -qE '^(crates/|xtask/|schemas/|\.alint\.yml$|\.gitattributes$)'; then
   RUST=true
 fi
 


### PR DESCRIPTION
Follow-up to the Windows CRLF fix (#61). `.gitattributes` controls the checkout line endings of byte-compared fixtures and generated artifacts (snapshots, trycmd literals, the schema, `facts.json`, `crate-graph.md`), so a change to it can flip the `gen-*-check` / snapshot tests on a CRLF platform — but it matched no change-class, so a `.gitattributes`-only PR skipped the Test + docs jobs (the #61 fix was validated only by the GitHub-hosted Cross-Platform workflow; the self-hosted Linux suite skipped). Classify it as `rust` so it exercises the test suite (and the docs gates, via `rust || docs`).

Verified: classification logic correct (`.gitattributes` → rust, other patterns unchanged); dogfood ✓ 41/41; preflight green.