### PR TITLE
feat(roadmap): roadmap.json contract for the drift-proof public /roadmap/ timeline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,10 +25,12 @@ crates/alint/tests/cli/*.toml text eol=lf
 schemas/v1/config.json text eol=lf
 crates/alint-dsl/schemas/v1/config.json text eol=lf
 
-# Generated surface-area contract + crate dependency graph: `gen-facts --check`
-# and `gen-arch --check` (and their xtask tests) byte-compare these against a
-# `\n`-only rendered string — the same CRLF-on-Windows hazard as the schema
-# above. Without these pins the Windows CI job reports them spuriously stale
-# (the failure that started with the facts.json / crate-graph.md commits).
+# Generated contracts + crate dependency graph: `gen-facts --check`,
+# `gen-roadmap --check`, and `gen-arch --check` (and their xtask tests)
+# byte-compare these against a `\n`-only rendered string — the same
+# CRLF-on-Windows hazard as the schema above. Without these pins the Windows
+# CI job reports them spuriously stale (the failure that started with the
+# facts.json / crate-graph.md commits).
 facts.json text eol=lf
+roadmap.json text eol=lf
 docs/design/architecture/crate-graph.md text eol=lf

--- a/.github/workflows/docs-bundle.yml
+++ b/.github/workflows/docs-bundle.yml
@@ -81,14 +81,29 @@ jobs:
           # docs/design/ARCHITECTURE.md and ROADMAP.md are overlaid too: they
           # are living design documents for contributors (the
           # /docs/about/architecture/ and /docs/about/roadmap/ pages) that track
-          # main rather than waiting for the next tag.
+          # main rather than waiting for the next tag. roadmap.json (the
+          # machine-readable phase contract gen-roadmap derives from ROADMAP.md,
+          # which the alint.org /roadmap/ timeline renders) is overlaid with
+          # them so the published plan tracks main; facts.json deliberately is
+          # NOT overlaid, so the surface-area counts stay pinned to the release.
           git fetch --quiet origin main
-          git checkout origin/main -- docs/site/reference docs/design/ARCHITECTURE.md docs/design/ROADMAP.md
+          git checkout origin/main -- docs/site/reference docs/design/ARCHITECTURE.md docs/design/ROADMAP.md roadmap.json
           echo "Overlaid reference + design docs from origin/main ($(git rev-parse --short origin/main))."
 
       - name: Generate docs-bundle/
         run: cargo run -q -p xtask -- docs-export
         # Output lives at target/docs-bundle/.
+
+      - name: Ensure roadmap.json is in the bundle (main-tracked)
+        run: |
+          set -euo pipefail
+          # docs-export copies roadmap.json into the bundle, but the bundle is
+          # built from the release TAG's xtask, which predates that copy step.
+          # roadmap.json was overlaid from main above, so copy it in here to
+          # bridge until the docs-export change ships in a release tag. Once it
+          # does this is idempotent (identical, main-tracked content).
+          cp roadmap.json target/docs-bundle/roadmap.json
+          echo "roadmap.json ($(wc -c < roadmap.json) bytes) overlaid into the bundle."
 
       - name: Refresh cross-version trajectory from main's bench results
         run: |

--- a/ci/scripts/docs.sh
+++ b/ci/scripts/docs.sh
@@ -33,6 +33,14 @@ cargo run -q -p xtask -- gen-schema --check
 echo "==> Running xtask gen-facts --check"
 cargo run -q -p xtask -- gen-facts --check
 
+# `xtask gen-roadmap --check` regenerates roadmap.json (the public-roadmap
+# contract the alint.org /roadmap/ timeline renders) from the marked phase
+# headings in docs/design/ROADMAP.md, and fails if the committed roadmap.json
+# drifted. Run `cargo run -p xtask -- gen-roadmap` to refresh after editing a
+# phase heading or its roadmap-public marker.
+echo "==> Running xtask gen-roadmap --check"
+cargo run -q -p xtask -- gen-roadmap --check
+
 # `xtask gen-arch --check` regenerates the crate dependency graph
 # (docs/design/architecture/crate-graph.md) from `cargo metadata` and fails if
 # it drifted, and verifies the hand-modeled C4 model (workspace.dsl) still

--- a/docs/design/ROADMAP.md
+++ b/docs/design/ROADMAP.md
@@ -215,6 +215,7 @@ v0.5 prioritizes the next rung: tighter monorepo ergonomics
 for workspace-tier and OSS-polyglot adopters.
 
 ## v0.1: MVP (shipped)
+<!-- roadmap-public: blurb="The smallest adoptable scope: the walker, config loader, the core file, content, and naming primitives, and human plus JSON output." -->
 
 The smallest scope that is usefully adoptable.
 
@@ -229,6 +230,7 @@ The smallest scope that is usefully adoptable.
 - ✅ Dogfood `.alint.yml` exercising the tool against its own repo.
 
 ## v0.2: Cross-file and composition (shipped)
+<!-- roadmap-public: blurb="Cross-file primitives like pair and for_each_dir, the facts system, the when expression language, extends with SRI, and the fix subcommand." -->
 
 - Cross-file primitives: ✅ `pair`, ✅ `for_each_dir`, ✅ `for_each_file`, ✅ `every_matching_has`, ✅ `dir_contains`, ✅ `dir_only_contains`, ✅ `unique_by`. **(complete)**
 - Facts system: ✅ `any_file_exists`, ✅ `all_files_exist`, ✅ `count_files`, ✅ `file_content_matches`, ✅ `git_branch`, ✅ `custom` (security-gated; only allowed in the top-level config, never in `extends:`); ⏳ `detect: linguist`, ⏳ `detect: askalono`, both likely v0.5 alongside bundled rulesets.
@@ -241,6 +243,7 @@ The smallest scope that is usefully adoptable.
 - ✅ Official GitHub Action (`action.yml` at repo root; composite action wrapping `install.sh`).
 
 ## v0.3: Hygiene, portable metadata, byte fingerprints (shipped)
+<!-- roadmap-public: blurb="Text and Unicode hygiene, encoding and byte-fingerprint rules, portable-name and Unix-metadata checks, and the first content auto-fixers." -->
 
 The v0.3 cut shifted scope mid-cycle. The originally-planned
 "structured content" family (JSON/YAML/TOML path queries) was
@@ -263,6 +266,7 @@ points in real repos.
 **Deferred to v0.4**: structured-query primitives (`json_path_*`, `yaml_path_*`, `toml_path_*`, `json_schema_passes`), `file_footer`, `file_max_lines`, `file_shebang`, opt-in nested `.alint.yml` discovery for monorepos, `markdown` / `junit` / `gitlab` output formats, `alint facts` subcommand for debugging `when` clauses.
 
 ## v0.4: Bundled rulesets + pre-commit (shipped)
+<!-- roadmap-public: blurb="One-line adoption through bundled rulesets and pre-commit hooks, with the oss-baseline, rust, node, and monorepo sets landing first." -->
 
 Pulled forward from what was v0.5: **bundled rulesets** are the
 single biggest adoption lever, turning "write 20 rules" into
@@ -310,6 +314,7 @@ for v0.5 landed here.
   round out the content family. Catalogue at ~55 rule kinds.
 
 ## v0.5: Monorepo scale + plugins v1 + remaining distribution
+<!-- roadmap-public: blurb="Monorepo ergonomics such as changed mode, scope filters, and workspace overlays, the command plugin tier, and the remaining install channels." -->
 
 The v0.4.x cuts cleared most of the original v0.5 scope (structured-query, ecosystem rulesets, `alint facts`, Docker, Homebrew, first git-aware primitive). What remains, plus new monorepo-scale work surfaced by the 2026-04 monorepo positioning analysis.
 
@@ -464,6 +469,7 @@ built on the existing primitive set, no new rule kinds needed.
   deferred (needs `numeric_sequence` primitive).
 
 ## v0.6: Agent-era bundled rulesets and output
+<!-- roadmap-public: blurb="The agent-hygiene and agent-context bundled rulesets, plus an agent output format for tools that read alint inside a self-correction loop." -->
 
 Two bundled rulesets aimed at the most common AI-coding
 leftovers, plus a new output format for agents consuming alint
@@ -505,6 +511,7 @@ analysis, secret-entropy scanning, AGENTS.md export. All of
 those land in v0.7 or later.
 
 ## v0.7: New rule kinds for agentic problems (shipped)
+<!-- roadmap-public: blurb="Heuristic rule kinds markdown_paths_resolve, commented_out_code, and git_blame_age, with the suggest and export-agents-md subcommands." -->
 
 Targeted rule-kind additions that close the gaps Tier-1
 exposed. Each got a short design doc before implementation
@@ -553,6 +560,7 @@ open questions before code started, then was flipped to
   single source of truth.
 
 ## v0.8: Comprehensive test + bench foundation (shipped)
+<!-- roadmap-public: blurb="The test and benchmark floor: per-kind coverage, cross-platform CI, an 85 percent coverage gate, and nightly mutation testing." -->
 
 Five sub-phases (v0.8.2 → v0.8.5) building the
 test/bench/rot-prevention foundation that engine
@@ -710,6 +718,7 @@ that lets engine work land without regressing user-visible
 behaviour.
 
 ## v0.9: Engine optimization
+<!-- roadmap-public: blurb="Parallel walker, a memory-footprint pass, the per-file dispatch flip, and cross-file fast paths that cut 1M-file runs from minutes to seconds." -->
 
 (Was v0.8 sub-themes 2-4 in the pre-2026-04-28 plan;
 displaced by the v0.8 test/bench foundation. Per-feature
@@ -983,6 +992,7 @@ detail in [CHANGELOG.md](https://github.com/asamarts/alint/blob/main/CHANGELOG.m
   preflight + pre-push hook bundle.
 
 ## v0.10: Case-study coverage push
+<!-- roadmap-public: blurb="Eight case-study-validated rule kinds and the apache/governance and dotnet rulesets, with three pre-release security retirements." -->
 
 The 8 rule kinds + 2 bundled rulesets the case-study
 aggregation demand-validated. Splits out from the original v0.10
@@ -1016,6 +1026,7 @@ in [`examples/README.md`](https://github.com/asamarts/alint/blob/main/examples/R
 and [`docs/development/launch-evidence.md`](https://github.com/asamarts/alint/blob/main/docs/development/launch-evidence.md).
 
 ## v0.11: LSP + DSL polish
+<!-- roadmap-public: blurb="The alint lsp language server with in-editor diagnostics and quick-fixes, scope generalisation, the commit-validation family, and env interpolation." -->
 
 **Shipped in v0.11.0** (2026-05-28): the `alint lsp` language server (the new `alint-lsp` crate) wired across the VS Code, JetBrains, Zed, Neovim, Sublime, Emacs, and Helix integrations, the `git_commit_*` commit-validation family, `scope_filter.changed_since:`, and `{{env.X}}` interpolation. The detail below was the cut's plan; `has_sibling` / `has_descendant` were deferred to v0.12.
 
@@ -1151,6 +1162,7 @@ carried into the v0.12 cut (per-item status below).**
   `skip-broken-symlinks` / `permissive` modes.
 
 ## v0.12: Real-world coverage expansion (100+ repos) + gap rule kinds
+<!-- roadmap-public: blurb="New kinds file_graph, for_each_match, cross_file, and pair_changed_together, with a path-confinement security cut and the php ruleset." -->
 
 **v0.12.0 shipped** (2026-06-07) a large first cut of this scope. New rule kinds that landed: `file_graph` (file-dependency-graph firewalls plus cycle / orphan / dangling-edge checks, the top demand-ranked kind of the 111-repo study), `for_each_match` (a per-line predicate quantifier), `cross_file` (a unifying value-relation kind that subsumes `cross_file_value_equals` and adds `subset` / `superset` / `set_equals` / `identical` / `resolves`), `git_commit_subject_matches`, `changeset_requires_path`, and `pair_changed_together`. Also shipped: `generated_file_fresh`'s in-place `outputs:` mode, markerless `ordered_block`, the `php@v1` bundled ruleset (21 → 22), JSONC-tolerant structured parsing, the `cross_file` `normalize:` promotion, and `import_gate` presets for Scala / Java / Dart / Nix, plus a security cycle that confines every config-declared path to the repo root and fixes a git argument-injection in `since:` reaching back to v0.9.21. Per-item status is tagged inline below. The 100+ repo study (111 repos done) and the still-open gap kinds continue in the v0.12 line.
 
@@ -1305,6 +1317,7 @@ Design pass: [`asf_bundle_overfire.md`](https://github.com/asamarts/alint/blob/m
   so the kind now covers it directly.
 
 ## Engineering foundations: spec-driven development
+<!-- roadmap-public: blurb="A drift-elimination program on main: schema, facts, and architecture generated and gated, plus a Kani-verified path-confinement proof." -->
 
 A drift-elimination program run on `main` after v0.12 — a foundations track, not a
 user-facing version cut, so it interleaves with the release cadence rather than
@@ -1345,6 +1358,7 @@ alint's `prose-no-em-dash` rule, dogfooded on the site's prose — caught drift 
 very change introduced, and it was fixed before the next release.
 
 ## v0.13: WASM plugins
+<!-- roadmap-public: blurb="A wasm plugin kind on a wasmtime host with a stable WIT interface, a filesystem sandbox, and a signed plugin registry." -->
 
 Bumped one slot to make room for the v0.12 real-world-coverage cut;
 otherwise unchanged from the previous post-v0.11 scope.
@@ -1362,6 +1376,7 @@ otherwise unchanged from the previous post-v0.11 scope.
   bundled, to keep the binary lean.
 
 ## v1.0: Stability
+<!-- roadmap-public: blurb="A committed DSL and plugin ABI, a frozen alint-core public API, and a versioned documentation site." -->
 
 - DSL schema committed; semver on `version: 1`.
 - Plugin ABI committed.

--- a/roadmap.json
+++ b/roadmap.json
@@ -1,0 +1,95 @@
+{
+  "format_version": 1,
+  "phases": [
+    {
+      "version": "0.1",
+      "title": "MVP",
+      "kind": "release",
+      "blurb": "The smallest adoptable scope: the walker, config loader, the core file, content, and naming primitives, and human plus JSON output."
+    },
+    {
+      "version": "0.2",
+      "title": "Cross-file and composition",
+      "kind": "release",
+      "blurb": "Cross-file primitives like pair and for_each_dir, the facts system, the when expression language, extends with SRI, and the fix subcommand."
+    },
+    {
+      "version": "0.3",
+      "title": "Hygiene, portable metadata, byte fingerprints",
+      "kind": "release",
+      "blurb": "Text and Unicode hygiene, encoding and byte-fingerprint rules, portable-name and Unix-metadata checks, and the first content auto-fixers."
+    },
+    {
+      "version": "0.4",
+      "title": "Bundled rulesets + pre-commit",
+      "kind": "release",
+      "blurb": "One-line adoption through bundled rulesets and pre-commit hooks, with the oss-baseline, rust, node, and monorepo sets landing first."
+    },
+    {
+      "version": "0.5",
+      "title": "Monorepo scale + plugins v1 + remaining distribution",
+      "kind": "release",
+      "blurb": "Monorepo ergonomics such as changed mode, scope filters, and workspace overlays, the command plugin tier, and the remaining install channels."
+    },
+    {
+      "version": "0.6",
+      "title": "Agent-era bundled rulesets and output",
+      "kind": "release",
+      "blurb": "The agent-hygiene and agent-context bundled rulesets, plus an agent output format for tools that read alint inside a self-correction loop."
+    },
+    {
+      "version": "0.7",
+      "title": "New rule kinds for agentic problems",
+      "kind": "release",
+      "blurb": "Heuristic rule kinds markdown_paths_resolve, commented_out_code, and git_blame_age, with the suggest and export-agents-md subcommands."
+    },
+    {
+      "version": "0.8",
+      "title": "Comprehensive test + bench foundation",
+      "kind": "release",
+      "blurb": "The test and benchmark floor: per-kind coverage, cross-platform CI, an 85 percent coverage gate, and nightly mutation testing."
+    },
+    {
+      "version": "0.9",
+      "title": "Engine optimization",
+      "kind": "release",
+      "blurb": "Parallel walker, a memory-footprint pass, the per-file dispatch flip, and cross-file fast paths that cut 1M-file runs from minutes to seconds."
+    },
+    {
+      "version": "0.10",
+      "title": "Case-study coverage push",
+      "kind": "release",
+      "blurb": "Eight case-study-validated rule kinds and the apache/governance and dotnet rulesets, with three pre-release security retirements."
+    },
+    {
+      "version": "0.11",
+      "title": "LSP + DSL polish",
+      "kind": "release",
+      "blurb": "The alint lsp language server with in-editor diagnostics and quick-fixes, scope generalisation, the commit-validation family, and env interpolation."
+    },
+    {
+      "version": "0.12",
+      "title": "Real-world coverage expansion (100+ repos) + gap rule kinds",
+      "kind": "release",
+      "blurb": "New kinds file_graph, for_each_match, cross_file, and pair_changed_together, with a path-confinement security cut and the php ruleset."
+    },
+    {
+      "version": null,
+      "title": "Engineering foundations: spec-driven development",
+      "kind": "foundations",
+      "blurb": "A drift-elimination program on main: schema, facts, and architecture generated and gated, plus a Kani-verified path-confinement proof."
+    },
+    {
+      "version": "0.13",
+      "title": "WASM plugins",
+      "kind": "release",
+      "blurb": "A wasm plugin kind on a wasmtime host with a stable WIT interface, a filesystem sandbox, and a signed plugin registry."
+    },
+    {
+      "version": "1.0",
+      "title": "Stability",
+      "kind": "release",
+      "blurb": "A committed DSL and plugin ABI, a frozen alint-core public API, and a versioned documentation site."
+    }
+  ]
+}

--- a/xtask/src/docs_export.rs
+++ b/xtask/src/docs_export.rs
@@ -55,6 +55,7 @@ mod docs_paths {
     pub const CHANGELOG: &str = "CHANGELOG.md";
     pub const SCHEMA_JSON: &str = "schemas/v1/config.json";
     pub const FACTS_JSON: &str = "facts.json";
+    pub const ROADMAP_JSON: &str = "roadmap.json";
     pub const CRATE_GRAPH_MD: &str = "docs/design/architecture/crate-graph.md";
     pub const RULESETS_DIR: &str = "crates/alint-dsl/rulesets/v1";
 }
@@ -137,6 +138,23 @@ pub(crate) fn docs_export(out: Option<PathBuf>, check: bool) -> Result<()> {
         format!(
             "copy {} (run `cargo run -p xtask -- gen-facts`)",
             docs_paths::FACTS_JSON
+        )
+    })?;
+
+    // 4b-2. The public-roadmap contract (`roadmap.json`), shipped at the
+    //     bundle root so alint.org's /roadmap/ timeline renders the phase
+    //     list from it. Generated + gated in-repo by `xtask gen-roadmap`.
+    //     Unlike facts.json (pinned to the release tag), docs-bundle.yml
+    //     overlays this from main, so the published plan tracks main while
+    //     the surface-area counts stay pinned to what users can install.
+    fs::copy(
+        workspace.join(docs_paths::ROADMAP_JSON),
+        target_dir.join("roadmap.json"),
+    )
+    .with_context(|| {
+        format!(
+            "copy {} (run `cargo run -p xtask -- gen-roadmap`)",
+            docs_paths::ROADMAP_JSON
         )
     })?;
 

--- a/xtask/src/gen_roadmap.rs
+++ b/xtask/src/gen_roadmap.rs
@@ -1,0 +1,262 @@
+//! `xtask gen-roadmap` — emit `roadmap.json`, the machine-readable
+//! public-roadmap contract the alint.org `/roadmap/` timeline renders.
+//!
+//! Mirrors `gen_facts`: the phase list is derived here from
+//! `docs/design/ROADMAP.md` so the marketing page can't drift from the
+//! canonical roadmap. A public phase is a `## ` heading immediately
+//! followed by a `<!-- roadmap-public: blurb="..." -->` marker; the
+//! version and title come from the heading, the one-line blurb from the
+//! marker.
+//!
+//! Status (shipped vs planned) is deliberately NOT stored. alint.org
+//! derives it by comparing each phase's version to `facts.json`'s released
+//! `alint_version`, so the timeline always agrees with the displayed
+//! latest release. `roadmap.json` tracks `main` (the docs-bundle overlays
+//! it from main alongside `ROADMAP.md`), whereas `facts.json` stays pinned
+//! to the release tag — the same split the pipeline already draws between
+//! the living plan and the released surface area.
+//!
+//! `run(false)` rewrites the file, `run(true)` content-diffs the committed
+//! copy and fails on drift. Carries no volatile fields so it commits
+//! cleanly and gates on content. The no-AI-signal invariant (no em dashes
+//! or smart quotes in any title or blurb) is enforced by a test HERE
+//! because alint.org's prose lint deliberately ignores the synced
+//! `public/_alint/**` contract — the alint repo owns what feeds it.
+
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+
+/// Bumped when the `roadmap.json` shape changes so the alint.org consumer
+/// can pin the schema it understands (mirrors `facts.json`).
+const FORMAT_VERSION: u32 = 1;
+const ROADMAP_DOC: &str = "docs/design/ROADMAP.md";
+
+#[derive(Serialize)]
+struct Roadmap {
+    format_version: u32,
+    phases: Vec<Phase>,
+}
+
+#[derive(Serialize)]
+struct Phase {
+    /// `"0.12"`, `"1.0"`, etc., or `null` for a version-less milestone
+    /// (the spec-driven-development foundations track).
+    version: Option<String>,
+    title: String,
+    /// `"release"` for a versioned cut, `"foundations"` for the
+    /// version-less engineering-foundations track.
+    kind: String,
+    blurb: String,
+}
+
+fn roadmap_path() -> Result<PathBuf> {
+    Ok(crate::workspace_root()?.join("roadmap.json"))
+}
+
+fn build_roadmap() -> Result<Roadmap> {
+    let root = crate::workspace_root()?;
+    let path = root.join(ROADMAP_DOC);
+    let md = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    let phases = parse_phases(&md)?;
+    if phases.is_empty() {
+        bail!(
+            "no `roadmap-public` markers found in {ROADMAP_DOC}; the public \
+             roadmap would be empty"
+        );
+    }
+    Ok(Roadmap {
+        format_version: FORMAT_VERSION,
+        phases,
+    })
+}
+
+/// Public phases in document order. Each is a `## ` heading whose
+/// following `<!-- roadmap-public: blurb="..." -->` marker opts it in.
+fn parse_phases(md: &str) -> Result<Vec<Phase>> {
+    let mut phases = Vec::new();
+    let mut current_heading: Option<String> = None;
+    for line in md.lines() {
+        let trimmed = line.trim_end();
+        if let Some(h) = trimmed.strip_prefix("## ") {
+            current_heading = Some(h.trim().to_string());
+        } else if let Some(blurb) = parse_marker(trimmed) {
+            let heading = current_heading.clone().with_context(|| {
+                format!("`roadmap-public` marker with no preceding `## ` heading: {trimmed}")
+            })?;
+            phases.push(heading_to_phase(&heading, blurb));
+        }
+    }
+    Ok(phases)
+}
+
+/// `<!-- roadmap-public: blurb="<text>" -->` → `<text>`.
+fn parse_marker(line: &str) -> Option<String> {
+    let rest = line.trim().strip_prefix("<!-- roadmap-public:")?;
+    let after = rest.trim_start().strip_prefix("blurb=\"")?;
+    let end = after.find('"')?;
+    Some(after[..end].to_string())
+}
+
+/// `v0.12: Real-world coverage (shipped)` → versioned phase;
+/// `Engineering foundations: spec-driven development` → version-less.
+fn heading_to_phase(heading: &str, blurb: String) -> Phase {
+    if let Some(rest) = heading.strip_prefix('v') {
+        if let Some(colon) = rest.find(':') {
+            let ver = &rest[..colon];
+            if !ver.is_empty()
+                && ver.contains('.')
+                && ver.chars().all(|c| c.is_ascii_digit() || c == '.')
+            {
+                let raw = rest[colon + 1..].trim();
+                let title = raw.strip_suffix("(shipped)").map_or(raw, str::trim_end);
+                return Phase {
+                    version: Some(ver.to_string()),
+                    title: title.to_string(),
+                    kind: "release".to_string(),
+                    blurb,
+                };
+            }
+        }
+    }
+    Phase {
+        version: None,
+        title: heading.trim().to_string(),
+        kind: "foundations".to_string(),
+        blurb,
+    }
+}
+
+/// Pretty JSON plus a trailing newline (git-friendly, byte-compared by
+/// `--check`).
+fn render(roadmap: &Roadmap) -> Result<String> {
+    let mut s = serde_json::to_string_pretty(roadmap).context("serialize roadmap.json")?;
+    s.push('\n');
+    Ok(s)
+}
+
+pub fn run(check: bool) -> Result<()> {
+    let roadmap = build_roadmap()?;
+    let rendered = render(&roadmap)?;
+    let path = roadmap_path()?;
+
+    if check {
+        let committed =
+            fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+        if committed != rendered {
+            bail!(
+                "roadmap.json is stale. Run `cargo run -p xtask -- gen-roadmap` to \
+                 regenerate and commit the result."
+            );
+        }
+        println!("roadmap.json is up to date");
+        return Ok(());
+    }
+
+    fs::write(&path, &rendered).with_context(|| format!("write {}", path.display()))?;
+    println!("wrote roadmap.json");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `roadmap.json` must be regenerated and committed when the roadmap
+    /// changes — `--check` is what CI + preflight run.
+    #[test]
+    fn gen_roadmap_check_passes_on_committed_tree() {
+        run(true).expect("gen-roadmap --check should pass on the committed tree");
+    }
+
+    /// No AI-content signals (em dashes, en dashes, smart quotes) in any
+    /// title or blurb. Enforced here because alint.org's prose lint ignores
+    /// the synced `public/_alint/**` contract, so the source owns it. Also
+    /// guards against an empty field.
+    #[test]
+    fn no_ai_content_signals_in_any_field() {
+        const FORBIDDEN: &[char] = &[
+            '\u{2014}', // em dash
+            '\u{2013}', // en dash
+            '\u{2018}', '\u{2019}', // single curly quotes
+            '\u{201C}', '\u{201D}', // double curly quotes
+        ];
+        let roadmap = build_roadmap().expect("build roadmap");
+        for p in &roadmap.phases {
+            for (field, val) in [("title", &p.title), ("blurb", &p.blurb)] {
+                assert!(
+                    !val.contains(FORBIDDEN),
+                    "phase {:?} {field} carries an em dash / en dash / smart quote \
+                     (AI-content signal): {val:?}",
+                    p.version
+                );
+                assert!(
+                    !val.contains("&mdash;"),
+                    "phase {:?} {field} carries &mdash;: {val:?}",
+                    p.version
+                );
+                assert!(
+                    !val.is_empty(),
+                    "phase {:?} has an empty {field}",
+                    p.version
+                );
+            }
+        }
+    }
+
+    /// alint.org derives shipped/planned by comparing each phase's version
+    /// to `facts.json`'s released version, so the released version itself
+    /// must be a public phase. Catches shipping a release whose `##`
+    /// heading was never given a `roadmap-public` marker.
+    #[test]
+    fn released_version_is_a_public_phase() {
+        let v = env!("CARGO_PKG_VERSION"); // workspace version, e.g. "0.12.0"
+        let mut it = v.split('.');
+        let major_minor = format!(
+            "{}.{}",
+            it.next().expect("major"),
+            it.next().expect("minor")
+        );
+        let roadmap = build_roadmap().expect("build roadmap");
+        assert!(
+            roadmap
+                .phases
+                .iter()
+                .any(|p| p.version.as_deref() == Some(major_minor.as_str())),
+            "released version {major_minor} is not a roadmap-public phase; add a \
+             `<!-- roadmap-public: ... -->` marker under its `## ` heading in {ROADMAP_DOC}"
+        );
+    }
+
+    /// Versioned phases appear in non-decreasing version order (document
+    /// order is timeline order); the version-less foundations entry is
+    /// skipped. Every phase carries a kind.
+    #[test]
+    fn versioned_phases_are_monotonic() {
+        let roadmap = build_roadmap().expect("build roadmap");
+        let key = |p: &Phase| -> Option<(u32, u32)> {
+            let v = p.version.as_ref()?;
+            let mut it = v.split('.');
+            Some((it.next()?.parse().ok()?, it.next()?.parse().ok()?))
+        };
+        let mut last: Option<(u32, u32)> = None;
+        for p in &roadmap.phases {
+            assert!(
+                p.kind == "release" || p.kind == "foundations",
+                "unexpected kind {:?}",
+                p.kind
+            );
+            if let Some(k) = key(p) {
+                if let Some(prev) = last {
+                    assert!(
+                        k >= prev,
+                        "phase versions out of order: {prev:?} then {k:?}"
+                    );
+                }
+                last = Some(k);
+            }
+        }
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -25,6 +25,8 @@
 //!   `Options` structs (schemars); `--check` gates drift.
 //! - `gen-facts`          — regenerate `facts.json` (the surface-area contract)
 //!   from canonical sources; `--check` gates drift.
+//! - `gen-roadmap`        — regenerate `roadmap.json` (the public-roadmap
+//!   contract) from `docs/design/ROADMAP.md`; `--check` gates drift.
 //! - `gen-arch`           — regenerate the crate dependency graph from
 //!   `cargo metadata` + check the C4 model; `--check` gates drift.
 
@@ -39,6 +41,7 @@ mod bench;
 mod bench_release;
 mod docs_export;
 mod facts;
+mod gen_roadmap;
 mod gen_schema;
 mod roadmap_generator;
 mod rule_options_table;
@@ -258,6 +261,12 @@ enum Commands {
         #[arg(long)]
         check: bool,
     },
+    /// Regenerate `roadmap.json` (the public-roadmap contract) from ROADMAP.md.
+    GenRoadmap {
+        /// Verify the committed `roadmap.json` is up to date instead of rewriting it.
+        #[arg(long)]
+        check: bool,
+    },
     /// Regenerate the crate dependency graph from `cargo metadata` + gate the C4 model.
     GenArch {
         /// Verify the committed crate graph + C4 model instead of rewriting.
@@ -327,6 +336,7 @@ fn main() -> Result<()> {
         }
         Commands::GenSchema { check } => gen_schema::run(check),
         Commands::GenFacts { check } => facts::run(check),
+        Commands::GenRoadmap { check } => gen_roadmap::run(check),
         Commands::GenArch { check } => arch::run(check),
     }
 }

--- a/xtask/src/roadmap_generator.rs
+++ b/xtask/src/roadmap_generator.rs
@@ -110,6 +110,14 @@ fn elide_internal_blocks(content: &str) -> Result<String> {
             continue;
         }
 
+        // Drop the machine-readable `roadmap-public` markers that feed
+        // `xtask gen-roadmap`. They are invisible HTML comments, but
+        // stripping them keeps the published /docs/about/roadmap/ source
+        // clean. Inside a code fence they stay literal (handled above).
+        if trimmed.starts_with("<!-- roadmap-public:") {
+            continue;
+        }
+
         let has_start = line.contains(MARKER_START);
         let has_end = line.contains(MARKER_END);
 
@@ -362,5 +370,23 @@ mod tests {
         let a = transform(input, "T").unwrap();
         let b = transform(input, "T").unwrap();
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn roadmap_public_markers_are_stripped() {
+        // The `roadmap-public` markers feed `xtask gen-roadmap`; they must
+        // not leak into the published /docs/about/roadmap/ page. The
+        // heading they annotate stays.
+        let input = "# T\n\
+                     \n\
+                     ## v0.12: Coverage\n\
+                     <!-- roadmap-public: blurb=\"New kinds and a security cut.\" -->\n\
+                     \n\
+                     Body.\n";
+        let result = transform(input, "T").unwrap();
+        assert!(result.contains("## v0.12: Coverage"));
+        assert!(result.contains("Body."));
+        assert!(!result.contains("roadmap-public"));
+        assert!(!result.contains("blurb="));
     }
 }


### PR DESCRIPTION
**Workstream A** of the `/roadmap/` rebuild (the alint.org page drifted badly: v0.10/v0.11 shown as upcoming though shipped, v0.12 shown as WASM though it shipped as the rule-kind+security cut and WASM moved to v0.13).

This lands the machine-readable contract the rebuilt page renders from, so it can no longer drift:

- **`xtask gen-roadmap`** derives `roadmap.json` from the `## ` phase headings in `docs/design/ROADMAP.md` that carry a `<!-- roadmap-public: blurb=... -->` marker (15 milestones, v0.1 through v1.0). Mirrors `gen-facts`; `--check` gates drift.
- **Status is derived, not stored** — alint.org compares each phase version to `facts.json`'s released `alint_version`, so the timeline always agrees with the displayed latest release.
- **No-AI-signal invariant** (no em dashes / smart quotes in any title or blurb) is enforced by a test here, since alint.org's prose lint ignores the synced `public/_alint/**` contract.
- Wired `gen-roadmap --check` into `ci/scripts/docs.sh`; LF-pinned `roadmap.json`; `docs-export` ships it; the public-roadmap renderer strips the markers so `/docs/about/roadmap/` stays clean.
- `docs-bundle.yml` overlays `roadmap.json` from main alongside `ROADMAP.md` (plan tracks main; counts stay release-pinned), with a bridge step until the `docs-export` change reaches a release tag.

Verified locally: `gen-roadmap --check`, `docs-export --check`, the gen_roadmap + roadmap_generator tests, `fmt`, `clippy -D warnings`, and dogfood all green. Workstream B (the alint.org page rewrite) follows once this merges and the docs-bundle rebuilds.