### PR TITLE
docs(roadmap): note generated_file_fresh mutating mode in the v0.12 blurb

### DIFF
--- a/ci/scripts/detect-changes.sh
+++ b/ci/scripts/detect-changes.sh
@@ -76,10 +76,11 @@ if echo "$CHANGED" | grep -qE '^(crates/alint-bench/|xtask/)'; then
   BENCH=true
 fi
 
-# `facts.json` (repo root) is a generated contract guarded by `gen-facts
-# --check` in the docs job; route it through `docs` so a hand-edit can't skip
-# every gate (the architecture artifacts under docs/ already match here).
-if echo "$CHANGED" | grep -qE '^(docs/|PROPOSAL\.md$|[A-Z_]+\.md$|facts\.json$)'; then
+# `facts.json` and `roadmap.json` (repo root) are generated contracts guarded
+# by `gen-facts --check` / `gen-roadmap --check` in the docs job; route them
+# through `docs` so a hand-edit can't skip every gate (the architecture
+# artifacts under docs/ already match here).
+if echo "$CHANGED" | grep -qE '^(docs/|PROPOSAL\.md$|[A-Z_]+\.md$|(facts|roadmap)\.json$)'; then
   DOCS=true
 fi
 

--- a/docs/design/ROADMAP.md
+++ b/docs/design/ROADMAP.md
@@ -1162,7 +1162,7 @@ carried into the v0.12 cut (per-item status below).**
   `skip-broken-symlinks` / `permissive` modes.
 
 ## v0.12: Real-world coverage expansion (100+ repos) + gap rule kinds
-<!-- roadmap-public: blurb="New kinds file_graph, for_each_match, cross_file, and pair_changed_together, with a path-confinement security cut and the php ruleset." -->
+<!-- roadmap-public: blurb="New kinds file_graph, for_each_match, cross_file, and pair_changed_together, generated_file_fresh mutating mode, a path-confinement security cut, and the php ruleset." -->
 
 **v0.12.0 shipped** (2026-06-07) a large first cut of this scope. New rule kinds that landed: `file_graph` (file-dependency-graph firewalls plus cycle / orphan / dangling-edge checks, the top demand-ranked kind of the 111-repo study), `for_each_match` (a per-line predicate quantifier), `cross_file` (a unifying value-relation kind that subsumes `cross_file_value_equals` and adds `subset` / `superset` / `set_equals` / `identical` / `resolves`), `git_commit_subject_matches`, `changeset_requires_path`, and `pair_changed_together`. Also shipped: `generated_file_fresh`'s in-place `outputs:` mode, markerless `ordered_block`, the `php@v1` bundled ruleset (21 → 22), JSONC-tolerant structured parsing, the `cross_file` `normalize:` promotion, and `import_gate` presets for Scala / Java / Dart / Nix, plus a security cycle that confines every config-declared path to the repo root and fixes a git argument-injection in `since:` reaching back to v0.9.21. Per-item status is tagged inline below. The 100+ repo study (111 repos done) and the still-open gap kinds continue in the v0.12 line.
 

--- a/roadmap.json
+++ b/roadmap.json
@@ -71,7 +71,7 @@
       "version": "0.12",
       "title": "Real-world coverage expansion (100+ repos) + gap rule kinds",
       "kind": "release",
-      "blurb": "New kinds file_graph, for_each_match, cross_file, and pair_changed_together, with a path-confinement security cut and the php ruleset."
+      "blurb": "New kinds file_graph, for_each_match, cross_file, and pair_changed_together, generated_file_fresh mutating mode, a path-confinement security cut, and the php ruleset."
     },
     {
       "version": null,


### PR DESCRIPTION
End-to-end exercise of the `roadmap.json` pipeline (verifying a future roadmap edit flows through), plus a genuine accuracy fix and a CI-routing hardening.

- **v0.12 blurb**: `generated_file_fresh`'s mutating mode shipped in v0.12 but the public blurb omitted it. Edited the `roadmap-public` marker in `ROADMAP.md` and regenerated `roadmap.json`.
- **Gate confirmed**: `gen-roadmap --check` failed ("roadmap.json is stale") before I regenerated, so an un-regenerated edit is a hard CI failure, not silent drift.
- **detect-changes.sh**: route `roadmap.json` through the docs lane (mirroring `facts.json`) so a bare `roadmap.json` edit can't skip the gate.

This should flow: merge -> docs-bundle overlays `roadmap.json` from main -> Cloudflare -> the live /roadmap/ v0.12 node shows the updated blurb.