### PR TITLE
fix(review): close gaps from the two-repo review (alint side)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,9 @@ jobs:
       && needs.changes.outputs.rust == 'true'
     runs-on: [self-hosted, linux, alint]
     env:
+      # Advisory: a perf regression annotates but does not fail the job. When
+      # flipping this to "0" (enforcing), also add `perf-gate` to the `summary`
+      # job's `needs:` so a failed gate is reflected in the aggregate Summary.
       DET_PERF_ADVISORY: "1"
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -44,7 +44,7 @@ jobs:
           MANUAL: ${{ github.event.inputs.crate }}
         run: |
           set -euo pipefail
-          CRATES=(alint-core alint-dsl alint-rules alint-output alint alint-bench alint-testkit alint-e2e)
+          CRATES=(alint-core alint-dsl alint-rules alint-output alint alint-lsp alint-bench alint-testkit alint-e2e)
           if [ -n "${MANUAL:-}" ]; then
             TARGET="$MANUAL"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,21 @@ jobs:
       RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
+      - name: verify tag matches workspace version
+        # release.yml triggers only on `push: tags: ["v*"]`, so
+        # GITHUB_REF_NAME is the tag. Fail fast if the tag doesn't match the
+        # Cargo.toml version publish-crates.sh reads, otherwise a forgotten
+        # bump-version.sh ships a split-brain release (crates.io no-ops on the
+        # already-published version while npm/Docker/GH-Release ship the tag).
+        run: |
+          set -euo pipefail
+          TAG_VER="${GITHUB_REF_NAME#v}"
+          CARGO_VER="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
+          if [ "$TAG_VER" != "$CARGO_VER" ]; then
+            echo "::error::release tag ${GITHUB_REF_NAME} (=> ${TAG_VER}) != Cargo.toml version ${CARGO_VER}. Run ci/scripts/bump-version.sh and re-tag the bumped commit." >&2
+            exit 1
+          fi
+          echo "tag ${GITHUB_REF_NAME} matches Cargo.toml version ${CARGO_VER}."
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt,clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   into the docs bundle at a stable URL, so the README, docs, and alint.org render
   these numbers from one source instead of restating them in prose. Generated and
   drift-gated by `xtask gen-facts --check`.
+- **`roadmap.json` — a machine-readable public-roadmap contract.** A generated,
+  committed phase list (version, title, kind, and a one-line blurb) parsed from
+  the `roadmap-public` markers in `docs/design/ROADMAP.md` and shipped into the
+  docs bundle, so alint.org's `/roadmap/` page renders a data-driven timeline
+  instead of a hand-maintained one (status is derived by the consumer from the
+  released version). Generated and drift-gated by `xtask gen-roadmap --check`,
+  which also forbids AI-content signals (em dashes, smart quotes) in the
+  published blurbs.
 
 ### Changed
 

--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,8 @@ inputs:
     description: |
       alint version to install: a release tag like `v0.1.0`, or
       `latest`. Leave unset to install the release matching the tag
-      the action itself is pinned to — e.g. `uses: asamarts/alint@v0.10.0`
-      installs v0.10.0, so pinning the action pins the binary. Falls
+      the action itself is pinned to — e.g. `uses: asamarts/alint@v0.12.0`
+      installs v0.12.0, so pinning the action pins the binary. Falls
       back to `latest` when the action is pinned to a branch or SHA.
     required: false
     default: ""
@@ -59,7 +59,7 @@ runs:
         ALINT_VERSION: ${{ inputs.version }}
         INSTALL_DIR: ${{ runner.temp }}/alint-bin
         # Pin install.sh to whichever ref the consumer pinned the
-        # action to (e.g. `asamarts/alint@v0.10.0`). Without this,
+        # action to (e.g. `asamarts/alint@v0.12.0`). Without this,
         # `main`'s install.sh would be fetched on every run — a
         # change to that script affects every action consumer
         # regardless of the version they pinned.
@@ -82,7 +82,7 @@ runs:
         set -euo pipefail
         if [[ -z "${ACTION_REF:-}" ]]; then
           if [[ "${SOURCE_REPO}" != "asamarts/alint" ]]; then
-            echo "::error::action_ref is empty but the action is running outside asamarts/alint (${SOURCE_REPO}). Pin the action to a tag, e.g. uses: asamarts/alint@v0.10.0" >&2
+            echo "::error::action_ref is empty but the action is running outside asamarts/alint (${SOURCE_REPO}). Pin the action to a tag, e.g. uses: asamarts/alint@v0.12.0" >&2
             exit 1
           fi
           ref="main"

--- a/crates/alint-core/src/git.rs
+++ b/crates/alint-core/src/git.rs
@@ -91,17 +91,25 @@ pub fn collect_changed_paths(root: &Path, base: Option<&str>) -> Option<HashSet<
     // status. Both emit NUL-separated output so paths with
     // newlines / non-UTF-8 bytes round-trip.
     let output = match base {
-        Some(base) => Command::new("git")
-            .arg("-C")
-            .arg(root)
-            .args(["diff", "--name-only", "--relative", "-z"])
-            // `--end-of-options` so a `base`/`since` starting with `-`
-            // can't be parsed as a git OPTION (e.g. `--output=…`, which
-            // would write/truncate an arbitrary file).
-            .arg("--end-of-options")
-            .arg(format!("{base}...HEAD"))
-            .output()
-            .ok()?,
+        Some(base) => {
+            // Defense-in-depth, matching `diff_name_only`: reject a `base`
+            // starting with `-` explicitly (treat as "no changed-set"), in
+            // addition to the `--end-of-options` guard below.
+            if base.starts_with('-') {
+                return None;
+            }
+            Command::new("git")
+                .arg("-C")
+                .arg(root)
+                .args(["diff", "--name-only", "--relative", "-z"])
+                // `--end-of-options` so a `base`/`since` starting with `-`
+                // can't be parsed as a git OPTION (e.g. `--output=…`, which
+                // would write/truncate an arbitrary file).
+                .arg("--end-of-options")
+                .arg(format!("{base}...HEAD"))
+                .output()
+                .ok()?
+        }
         None => Command::new("git")
             .arg("-C")
             .arg(root)

--- a/crates/alint-rules/src/cross_file.rs
+++ b/crates/alint-rules/src/cross_file.rs
@@ -362,7 +362,10 @@ impl CrossFileRule {
             Err(crate::io::ReadCapError::TooLarge(n)) => {
                 out.push(Self::violation(
                     src,
-                    &format!("source file is too large to analyze ({n} bytes; 256 MiB cap)"),
+                    &format!(
+                        "source file is too large to analyze ({})",
+                        crate::io::over_cap(n)
+                    ),
                 ));
                 return None;
             }
@@ -529,7 +532,10 @@ impl CrossFileRule {
                 Err(crate::io::ReadCapError::TooLarge(n)) => {
                     out.push(Self::violation(
                         &target,
-                        &format!("target file is too large to analyze ({n} bytes; 256 MiB cap)"),
+                        &format!(
+                            "target file is too large to analyze ({})",
+                            crate::io::over_cap(n)
+                        ),
                     ));
                     continue;
                 }
@@ -659,7 +665,10 @@ impl CrossFileRule {
                 // just unanalysable).
                 out.push(Self::violation(
                     target,
-                    &format!("target file is too large to analyze ({n} bytes; 256 MiB cap)"),
+                    &format!(
+                        "target file is too large to analyze ({})",
+                        crate::io::over_cap(n)
+                    ),
                 ));
                 return None;
             }
@@ -758,7 +767,10 @@ fn skip_header(bytes: &[u8], n: usize) -> &[u8] {
 fn read_cap_reason(what: &str, e: &crate::io::ReadCapError) -> String {
     match e {
         crate::io::ReadCapError::TooLarge(n) => {
-            format!("{what} is too large to analyze ({n} bytes; 256 MiB cap)")
+            format!(
+                "{what} is too large to analyze ({})",
+                crate::io::over_cap(*n)
+            )
         }
         crate::io::ReadCapError::Io(e) => format!("{what} is unreadable: {e}"),
     }

--- a/crates/alint-rules/src/file_graph.rs
+++ b/crates/alint-rules/src/file_graph.rs
@@ -425,7 +425,7 @@ impl FileGraphRule {
             Err(crate::io::ReadCapError::TooLarge(n)) => {
                 out.push(Self::node_violation(
                     node,
-                    &format!("is too large to analyze ({n} bytes; 256 MiB cap)"),
+                    &format!("is too large to analyze ({})", crate::io::over_cap(n)),
                 ));
                 return Vec::new();
             }
@@ -597,7 +597,7 @@ impl FileGraphRule {
 fn read_cap_reason(e: &crate::io::ReadCapError) -> String {
     match e {
         crate::io::ReadCapError::TooLarge(n) => {
-            format!("is too large to analyze ({n} bytes; 256 MiB cap)")
+            format!("is too large to analyze ({})", crate::io::over_cap(*n))
         }
         crate::io::ReadCapError::Io(e) => format!("could not be read: {e}"),
     }

--- a/docs/site/getting-started/quickstart.md
+++ b/docs/site/getting-started/quickstart.md
@@ -45,7 +45,7 @@ Exit codes: `0` no errors; `1` one or more errors; `2` config error; `3` interna
 
 ## Where to next
 
-- [Bundled Rulesets](/docs/bundled-rulesets/) — nineteen one-line baselines covering Rust, Python, Go, Node, Java, monorepos, GitHub Actions hardening, agent hygiene, license compliance, and more.
+- [Bundled Rulesets](/docs/bundled-rulesets/) — 22 one-line baselines covering Rust, Python, Go, Node, Java, monorepos, GitHub Actions hardening, agent hygiene, license compliance, and more.
 - [Cookbook](/docs/cookbook/) — copy-pasteable patterns for real-world repo-maintenance tasks.
 - [Configuration](/docs/configuration/) — full `.alint.yml` field reference.
 - [Concepts](/docs/concepts/) — the rule model, scopes, when-expressions, composition.

--- a/xtask/src/gen_roadmap.rs
+++ b/xtask/src/gen_roadmap.rs
@@ -56,6 +56,41 @@ fn roadmap_path() -> Result<PathBuf> {
     Ok(crate::workspace_root()?.join("roadmap.json"))
 }
 
+/// AI-content signals forbidden in any title or blurb. Enforced in
+/// `build_roadmap` (so `gen-roadmap --check` catches them on the docs-only CI
+/// lane, which never runs `cargo test`) because alint.org's prose lint
+/// deliberately ignores the synced `public/_alint/**` contract — the source
+/// owns this invariant.
+const FORBIDDEN_SIGNALS: &[char] = &[
+    '\u{2014}', // em dash
+    '\u{2013}', // en dash
+    '\u{2018}', '\u{2019}', // single curly quotes
+    '\u{201C}', '\u{201D}', // double curly quotes
+];
+
+/// Reject empty fields and any AI-content signal (em / en dash, smart quote,
+/// `&mdash;`) in a phase title or blurb.
+fn validate_no_ai_signals(phases: &[Phase]) -> Result<()> {
+    for p in phases {
+        for (field, val) in [("title", &p.title), ("blurb", &p.blurb)] {
+            if val.is_empty() {
+                bail!("phase {:?} has an empty {field}", p.version);
+            }
+            if let Some(c) = val.chars().find(|c| FORBIDDEN_SIGNALS.contains(c)) {
+                bail!(
+                    "phase {:?} {field} carries an AI-content signal {c:?} (em / en dash \
+                     or smart quote): {val:?}. Use plain ASCII punctuation.",
+                    p.version
+                );
+            }
+            if val.contains("&mdash;") {
+                bail!("phase {:?} {field} carries `&mdash;`: {val:?}", p.version);
+            }
+        }
+    }
+    Ok(())
+}
+
 fn build_roadmap() -> Result<Roadmap> {
     let root = crate::workspace_root()?;
     let path = root.join(ROADMAP_DOC);
@@ -67,6 +102,7 @@ fn build_roadmap() -> Result<Roadmap> {
              roadmap would be empty"
         );
     }
+    validate_no_ai_signals(&phases)?;
     Ok(Roadmap {
         format_version: FORMAT_VERSION,
         phases,
@@ -86,7 +122,7 @@ fn parse_phases(md: &str) -> Result<Vec<Phase>> {
             let heading = current_heading.clone().with_context(|| {
                 format!("`roadmap-public` marker with no preceding `## ` heading: {trimmed}")
             })?;
-            phases.push(heading_to_phase(&heading, blurb));
+            phases.push(heading_to_phase(&heading, blurb)?);
         }
     }
     Ok(phases)
@@ -102,31 +138,48 @@ fn parse_marker(line: &str) -> Option<String> {
 
 /// `v0.12: Real-world coverage (shipped)` → versioned phase;
 /// `Engineering foundations: spec-driven development` → version-less.
-fn heading_to_phase(heading: &str, blurb: String) -> Phase {
+fn heading_to_phase(heading: &str, blurb: String) -> Result<Phase> {
+    // Versioned release heading: `v<major>.<minor>: <title>`. Treated as
+    // versioned only when it starts with `v` + a digit and has a colon. A
+    // version-looking heading whose version is NOT exactly two numeric
+    // components (a 3-part patch like `v0.9.11`, or a typo like `v0..1`) is
+    // rejected: the public roadmap is minor-version granular and the site
+    // keys status on major.minor, so a patch would silently collide with its
+    // minor.
     if let Some(rest) = heading.strip_prefix('v') {
-        if let Some(colon) = rest.find(':') {
-            let ver = &rest[..colon];
-            if !ver.is_empty()
-                && ver.contains('.')
-                && ver.chars().all(|c| c.is_ascii_digit() || c == '.')
-            {
+        if rest.starts_with(|c: char| c.is_ascii_digit()) {
+            if let Some(colon) = rest.find(':') {
+                let ver = &rest[..colon];
+                let parts: Vec<&str> = ver.split('.').collect();
+                let is_major_minor = parts.len() == 2
+                    && parts
+                        .iter()
+                        .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()));
+                if !is_major_minor {
+                    bail!(
+                        "roadmap-public heading {heading:?} has version {ver:?}; public \
+                         phases must be major.minor (e.g. `v0.12`). Do not put a \
+                         roadmap-public marker on a patch or malformed version."
+                    );
+                }
                 let raw = rest[colon + 1..].trim();
                 let title = raw.strip_suffix("(shipped)").map_or(raw, str::trim_end);
-                return Phase {
+                return Ok(Phase {
                     version: Some(ver.to_string()),
                     title: title.to_string(),
                     kind: "release".to_string(),
                     blurb,
-                };
+                });
             }
         }
     }
-    Phase {
+    // Version-less named milestone (e.g. the engineering-foundations track).
+    Ok(Phase {
         version: None,
         title: heading.trim().to_string(),
         kind: "foundations".to_string(),
         blurb,
-    }
+    })
 }
 
 /// Pretty JSON plus a trailing newline (git-friendly, byte-compared by
@@ -171,39 +224,73 @@ mod tests {
         run(true).expect("gen-roadmap --check should pass on the committed tree");
     }
 
-    /// No AI-content signals (em dashes, en dashes, smart quotes) in any
-    /// title or blurb. Enforced here because alint.org's prose lint ignores
-    /// the synced `public/_alint/**` contract, so the source owns it. Also
-    /// guards against an empty field.
+    /// `validate_no_ai_signals` (wired into `build_roadmap`, so it runs on the
+    /// docs-only `gen-roadmap --check` lane that never runs `cargo test`)
+    /// rejects em dashes, smart quotes, `&mdash;`, and empty fields, and
+    /// accepts clean ASCII. The committed tree being clean is covered by
+    /// `gen_roadmap_check_passes_on_committed_tree` (which calls `build_roadmap`).
     #[test]
-    fn no_ai_content_signals_in_any_field() {
-        const FORBIDDEN: &[char] = &[
-            '\u{2014}', // em dash
-            '\u{2013}', // en dash
-            '\u{2018}', '\u{2019}', // single curly quotes
-            '\u{201C}', '\u{201D}', // double curly quotes
-        ];
-        let roadmap = build_roadmap().expect("build roadmap");
-        for p in &roadmap.phases {
-            for (field, val) in [("title", &p.title), ("blurb", &p.blurb)] {
-                assert!(
-                    !val.contains(FORBIDDEN),
-                    "phase {:?} {field} carries an em dash / en dash / smart quote \
-                     (AI-content signal): {val:?}",
-                    p.version
-                );
-                assert!(
-                    !val.contains("&mdash;"),
-                    "phase {:?} {field} carries &mdash;: {val:?}",
-                    p.version
-                );
-                assert!(
-                    !val.is_empty(),
-                    "phase {:?} has an empty {field}",
-                    p.version
-                );
-            }
-        }
+    fn validate_rejects_ai_signals_and_empty() {
+        let mk = |title: &str, blurb: &str| Phase {
+            version: Some("0.1".to_string()),
+            title: title.to_string(),
+            kind: "release".to_string(),
+            blurb: blurb.to_string(),
+        };
+        assert!(validate_no_ai_signals(&[mk("MVP", "A clean ASCII blurb.")]).is_ok());
+        assert!(validate_no_ai_signals(&[mk("MVP", "an em dash \u{2014} here")]).is_err());
+        assert!(validate_no_ai_signals(&[mk("a \u{201C}smart\u{201D} title", "ok")]).is_err());
+        assert!(validate_no_ai_signals(&[mk("MVP", "an en dash \u{2013} here")]).is_err());
+        assert!(validate_no_ai_signals(&[mk("MVP", "and &mdash; entity")]).is_err());
+        assert!(validate_no_ai_signals(&[mk("", "empty title")]).is_err());
+        assert!(validate_no_ai_signals(&[mk("MVP", "")]).is_err());
+    }
+
+    /// `parse_phases` extracts versioned releases and the version-less
+    /// foundations milestone, strips the `(shipped)` suffix, and keeps
+    /// document order — driven by synthetic markdown, not the live file.
+    #[test]
+    fn parse_phases_handles_release_foundations_and_shipped_suffix() {
+        let md = r#"## v0.1: MVP (shipped)
+<!-- roadmap-public: blurb="first" -->
+
+## Engineering foundations: spec-driven development
+<!-- roadmap-public: blurb="second" -->
+
+## v0.13: WASM plugins
+<!-- roadmap-public: blurb="third" -->
+"#;
+        let phases = parse_phases(md).expect("parse");
+        assert_eq!(phases.len(), 3);
+        assert_eq!(phases[0].version.as_deref(), Some("0.1"));
+        assert_eq!(phases[0].title, "MVP"); // (shipped) stripped
+        assert_eq!(phases[0].kind, "release");
+        assert_eq!(phases[1].version, None);
+        assert_eq!(phases[1].kind, "foundations");
+        assert_eq!(
+            phases[1].title,
+            "Engineering foundations: spec-driven development"
+        );
+        assert_eq!(phases[2].version.as_deref(), Some("0.13"));
+        assert_eq!(phases[2].blurb, "third");
+    }
+
+    /// A `roadmap-public` marker with no preceding `## ` heading is an error.
+    #[test]
+    fn parse_phases_rejects_marker_without_heading() {
+        let md = "some prose\n<!-- roadmap-public: blurb=\"orphan\" -->\n";
+        assert!(parse_phases(md).is_err());
+    }
+
+    /// A versioned heading whose version is not exactly major.minor (a 3-part
+    /// patch, or malformed) is rejected, so it can't silently collide with its
+    /// minor on the site or render garbage. Version-less names are fine.
+    #[test]
+    fn heading_to_phase_rejects_non_major_minor_version() {
+        assert!(heading_to_phase("v0.9.11: patch", "b".to_string()).is_err());
+        assert!(heading_to_phase("v0..1: broken", "b".to_string()).is_err());
+        assert!(heading_to_phase("v0.12: ok", "b".to_string()).is_ok());
+        assert!(heading_to_phase("Engineering foundations: x", "b".to_string()).is_ok());
     }
 
     /// alint.org derives shipped/planned by comparing each phase's version


### PR DESCRIPTION
Batch of fixes from a thorough review of both repos. **alint side** (the alint.org side follows in a separate PR).

**High**
- **gen-roadmap no-AI-signal enforcement moved into `run()`** — it lived only in a `#[cfg(test)]` test, which the docs-only CI lane (rust-gated Test/Dogfood) never runs, so an em dash in a roadmap blurb could reach the live `/roadmap/` page. Now `gen-roadmap --check` (which the DOCS lane runs) enforces it.
- **release.yml tag-vs-Cargo.toml guard** — a forgotten `bump-version.sh` would otherwise ship a split-brain release (crates.io no-ops on the old version; npm/Docker/GH-Release ship the tag).

**Medium**
- **mutants.yml**: add `alint-lsp` (the array was mod-8 over 9 crates, so the v0.11 LSP server was never mutation-tested).
- **CHANGELOG [Unreleased]**: record the `roadmap.json`/`gen-roadmap` contract (its sibling `facts.json` had an entry; this didn't).
- **alint-rules**: route the 6 hardcoded `256 MiB cap` messages through `io::over_cap()`.
- **gen-roadmap parser**: reject non-major.minor version headings + synthetic-input unit tests.

**Low**: `git` `collect_changed_paths` `-`-prefix reject (defense-in-depth); `action.yml` `@v0.10.0`->`@v0.12.0`; quickstart "nineteen"->22; a perf-gate-enforcing reminder comment.

Verified locally: fmt, `clippy -D warnings`, `gen-roadmap`/`gen-facts --check`, the affected unit tests, and dogfood (41/41).