### PR TITLE
fix(action): set sarif-file output even when the check finds violations

### DIFF
--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -53,6 +53,11 @@ jobs:
         uses: ./
         with:
           format: sarif
+        # Tolerate a non-zero exit: when the linted tree has violations the
+        # check exits non-zero, but action.yml captures the exit code and still
+        # sets `sarif-file`, and this job only asserts the SARIF file is
+        # produced + valid JSON. Repo-cleanliness is asserted by the
+        # `action-default` job, not here.
         continue-on-error: true
       - name: verify SARIF file exists and parses as JSON
         run: |

--- a/action.yml
+++ b/action.yml
@@ -142,8 +142,18 @@ runs:
 
         if [ "$ALINT_FORMAT" = "sarif" ]; then
           out="${RUNNER_TEMP:-/tmp}/alint.sarif"
-          "$ALINT_BIN" "${cli_args[@]}" check "$ALINT_PATH" ${extra[@]+"${extra[@]}"} > "$out"
+          # A non-zero `alint check` (violations found) is a NORMAL SARIF
+          # outcome: the file is still written, and a SARIF consumer wants the
+          # path precisely when there ARE violations (to upload to code
+          # scanning). Capture the exit code with `|| rc=$?` so the
+          # `sarif-file` output is set REGARDLESS, then propagate the real
+          # exit. Without this, `set -e` aborts the step before the output is
+          # set whenever the check is non-zero, leaving consumers (and the
+          # action self-test's `test -f`) an empty path.
+          rc=0
+          "$ALINT_BIN" "${cli_args[@]}" check "$ALINT_PATH" ${extra[@]+"${extra[@]}"} > "$out" || rc=$?
           echo "sarif-file=$out" >> "$GITHUB_OUTPUT"
+          exit "$rc"
         else
           "$ALINT_BIN" "${cli_args[@]}" check "$ALINT_PATH" ${extra[@]+"${extra[@]}"}
         fi


### PR DESCRIPTION
Fixes the intermittent **"sarif output"** action-selftest failure (the flaky `sarif-file` empty output) we hit while merging the review PRs.

**Root cause** (a `set -e` ordering trap):
```
"$ALINT_BIN" ... check ... > "$out"      # line 145
echo "sarif-file=$out" >> "$GITHUB_OUTPUT"  # line 146 — skipped if 145 is non-zero
```
With `set -euo pipefail`, a non-zero `alint check` (violations found) aborts the step at line 145, so `sarif-file` is never set. The self-test's `continue-on-error: true` masks the aborted step as "success", and the next step's `test -f ""` then fails on the empty path. It's intermittent because the sarif job and the no-`continue-on-error` `action-default` job run on **separate runners**, so a rare non-deterministic violation trips the trap on one without failing the other. It's also just wrong: a SARIF consumer wants the path *precisely when there are violations* (to upload to code scanning).

**Fix:** capture the exit code (`|| rc=$?`), set `sarif-file` unconditionally, then `exit "$rc"`. The action self-test exercises this on every PR, so this PR is its own end-to-end test. Also documented the self-test's `continue-on-error` intent.

Verified: YAML parses, `bash -n` clean.