### PR TITLE
Robust README badges + retry the action install download

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # alint
 
-[![Crates.io](https://img.shields.io/crates/v/alint.svg)](https://crates.io/crates/alint)
+[![Crates.io](https://img.shields.io/github/v/tag/asamarts/alint?sort=semver&label=crates.io)](https://crates.io/crates/alint)
 [![CI](https://github.com/asamarts/alint/actions/workflows/ci.yml/badge.svg)](https://github.com/asamarts/alint/actions/workflows/ci.yml)
-[![License](https://img.shields.io/crates/l/alint.svg)](#license)
+[![License](https://img.shields.io/badge/license-Apache--2.0%20OR%20MIT-blue)](#license)
 
 **Fast, language-agnostic linter for repository structure, files, and content.** Declare the shape your repo should have (required files, filename conventions, content patterns, values inside `package.json` / `Cargo.toml` / GitHub workflows, cross-file relationships) in a single `.alint.yml`. alint enforces it.
 

--- a/action.yml
+++ b/action.yml
@@ -106,7 +106,24 @@ runs:
         fi
         export ALINT_VERSION="$ver"
         echo "alint action: installing '${ver}' (action_ref='${ACTION_REF:-<local>}', install.sh ref='${ref}')"
-        curl -fsSL "https://raw.githubusercontent.com/asamarts/alint/${ref}/install.sh" | bash
+        # Fetch install.sh with retries: raw.githubusercontent.com can return a
+        # transient 403 (rate-limit / CDN edge) that previously failed the action
+        # outright. Portable retry loop (no curl --retry-all-errors version
+        # dependency), up to 3 attempts before giving up.
+        install_url="https://raw.githubusercontent.com/asamarts/alint/${ref}/install.sh"
+        install_sh="${RUNNER_TEMP:-/tmp}/alint-install.sh"
+        for attempt in 1 2 3; do
+          if curl -fsSL "$install_url" -o "$install_sh"; then
+            break
+          fi
+          if [[ "$attempt" -eq 3 ]]; then
+            echo "::error::failed to fetch install.sh from ${install_url} after 3 attempts (transient raw.githubusercontent error, e.g. rate-limit or CDN)" >&2
+            exit 1
+          fi
+          echo "alint action: install.sh fetch failed (attempt ${attempt}/3), retrying in 2s..." >&2
+          sleep 2
+        done
+        bash "$install_sh"
         echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
     - name: Run alint


### PR DESCRIPTION
Fixes the README badges showing invalid and the intermittent Action self-test failure.

The crates.io-sourced badges (crates/v and crates/l via shields.io) render invalid because crates.io's API data-access policy rate-limits shields.io (reproduced: crates/v flips between v0.12.0 and invalid; a direct crates.io call returns 403). The version badge moves to github/v/tag (GitHub tags API, reliable, in lockstep with crates.io publishes), and the license badge to a static badge (Apache-2.0 OR MIT, which is stable). The action's install.sh fetch had no retry and failed the self-test on a transient 403; this adds a portable 3-attempt retry loop.