### PR TITLE
fix(roadmap): bump WASM plugins to v0.14 (foundations took the 0.13.0 cut)

### DIFF
--- a/docs/design/ROADMAP.md
+++ b/docs/design/ROADMAP.md
@@ -19,7 +19,7 @@ a single LikeC4 model rendered interactively on alint.org (and exported to
 Mermaid for GitHub), and the v0.12.0 path-confinement boundary gains a
 Kani-verified proof. All are generated and regenerate-and-diff gated, and
 alint.org renders its headline counts from `facts.json`. See the
-[Engineering foundations](#engineering-foundations-spec-driven-development)
+[Engineering foundations](#v013-engineering-foundations-spec-driven-development)
 section below.
 
 **v0.12.0** (2026-06-07). The case-study-driven rule-kind expansion paired with
@@ -177,8 +177,9 @@ on it for adoption, they can lint without it.
   dependency allowlist, and the ASF compliance-bundle over-fire
   fix.
 
-- **v0.13, WASM plugins.** Bumped one slot to make room for
-  v0.12. `wasmtime` host, signed plugin registry, blessed
+- **v0.14, WASM plugins.** Bumped again to make room for the
+  engineering-foundations program, which took the v0.13.0 cut.
+  `wasmtime` host, signed plugin registry, blessed
   examples (mock-ratio checker, near-dup detector,
   debug-statement stripper).
 
@@ -1319,12 +1320,13 @@ Design pass: [`asf_bundle_overfire.md`](https://github.com/asamarts/alint/blob/m
   in-place `outputs:` mode to `generated_file_fresh` for that mutating pattern,
   so the kind now covers it directly.
 
-## Engineering foundations: spec-driven development
+## v0.13: Engineering foundations: spec-driven development
 <!-- roadmap-public: blurb="A drift-elimination program on main: schema, facts, and architecture generated and gated, plus a Kani-verified path-confinement proof." -->
 
-A drift-elimination program run on `main` after v0.12 — a foundations track, not a
-user-facing version cut, so it interleaves with the release cadence rather than
-occupying a slot. The premise an anti-drift linter has to honour itself — *alint's
+A drift-elimination program run on `main` after v0.12. Conceived as a foundations
+track interleaved with the release cadence, it grew substantial enough to be cut
+as the v0.13.0 release, so it owns that slot on the timeline. The premise an
+anti-drift linter has to honour itself — *alint's
 own claims can't drift from the tool* — now holds end to end. Six workstreams
 shipped, each artifact regenerate-and-diff gated:
 
@@ -1360,11 +1362,11 @@ two of the project's own drift gates — the site's version-pin consistency chec
 alint's `prose-no-em-dash` rule, dogfooded on the site's prose — caught drift that
 very change introduced, and it was fixed before the next release.
 
-## v0.13: WASM plugins
+## v0.14: WASM plugins
 <!-- roadmap-public: blurb="A wasm plugin kind on a wasmtime host with a stable WIT interface, a filesystem sandbox, and a signed plugin registry." -->
 
-Bumped one slot to make room for the v0.12 real-world-coverage cut;
-otherwise unchanged from the previous post-v0.11 scope.
+Bumped again to make room for the engineering-foundations program, which
+took the v0.13.0 cut; otherwise unchanged from the previous post-v0.11 scope.
 
 - `wasm` plugin kind with a `wasmtime` host, stable WIT
   interface. Plugins receive their config *post-interpolation*

--- a/roadmap.json
+++ b/roadmap.json
@@ -74,13 +74,13 @@
       "blurb": "New kinds file_graph, for_each_match, cross_file, and pair_changed_together, generated_file_fresh mutating mode, a path-confinement security cut, and the php ruleset."
     },
     {
-      "version": null,
+      "version": "0.13",
       "title": "Engineering foundations: spec-driven development",
-      "kind": "foundations",
+      "kind": "release",
       "blurb": "A drift-elimination program on main: schema, facts, and architecture generated and gated, plus a Kani-verified path-confinement proof."
     },
     {
-      "version": "0.13",
+      "version": "0.14",
       "title": "WASM plugins",
       "kind": "release",
       "blurb": "A wasm plugin kind on a wasmtime host with a stable WIT interface, a filesystem sandbox, and a signed plugin registry."


### PR DESCRIPTION
## Problem

The public roadmap assigned the **v0.13 version slot to the still-planned WASM-plugins work**, but the engineering-foundations program is what actually shipped as the v0.13.0 tag. alint.org derives roadmap status by comparing each phase's version to `facts.json`'s released `alint_version` (0.13.0), so the live `/roadmap/` rendered **"WASM plugins -> Latest release"** -- publicly advertising an unshipped feature.

## Fix

- Promote the **Engineering foundations** section to the `v0.13` release phase (it grew substantial enough to be cut as v0.13.0, so it owns that slot) and bump **WASM plugins** to `v0.14`.
- Result: v0.13 derives as **Latest release**, WASM as **Planned**.
- Updated the section heading, its TOC anchor, and the WASM blurb; regenerated `roadmap.json`.

## Why foundations becomes the v0.13 phase (not version-less)

The `released_version_is_a_public_phase` invariant test requires the released major.minor (0.13) to appear as a versioned roadmap-public phase, so the site can mark it. What shipped as v0.13.0 *was* the foundations program, so it honestly owns the 0.13 slot. An earlier draft (WASM->0.14, foundations left version-less) removed the only 0.13 phase and **failed that test** across the CI test suites -- the test had been passing only because the mis-slotted WASM phase happened to sit at 0.13.

## Verification

`gen-roadmap --check` and the full `xtask` suite (83 tests) pass locally.

## Follow-up

alint.org overlays `roadmap.json` from `main` at build time, so the live `/roadmap/` corrects on the next site rebuild -- no alint.org commit needed.