### PR TITLE
chore(ci,docs): SHA-pin bench docker actions, refresh stale pins + release docs

### DIFF
--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -89,6 +89,6 @@ jobs:
           # CLI understands the repo's current `.alint.yml` —
           # bump when adding rule kinds the pinned version won't
           # recognize. Convention: track the previous minor
-          # (i.e. when HEAD is 0.9.X+1, this sits at v0.9.X) so
+          # (i.e. when HEAD is 0.X+1, this sits at v0.X) so
           # the test catches CLI/.alint.yml drift one release out.
-          version: v0.9.21
+          version: v0.12.0

--- a/.github/workflows/bench-docker.yml
+++ b/.github/workflows/bench-docker.yml
@@ -50,11 +50,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: docker/setup-qemu-action@v4.1.0
-      - uses: docker/setup-buildx-action@v4.1.0
+      # SHA-pinned per supply-chain hardening (matches release.yml).
+      # Dependabot raises a PR on any docker/* major-version bump; keep
+      # the `# vX.Y.Z` comment so it can track the pin.
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: log in to ghcr.io
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -89,7 +92,7 @@ jobs:
           printf 'tags=%s\n' "${tags[*]}" >>"$GITHUB_OUTPUT"
 
       - name: build + push
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: bench
           file: bench/Dockerfile

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -91,7 +91,7 @@ points are explicit.
 
 | Workflow | Triggered by | What it does | Time |
 |---|---|---|---|
-| `ci.yml` | tag + main pushes | fmt + clippy + test + doc + dogfood. Self-hosted Linux. | ~5 min |
+| `ci.yml` | tag + main pushes | fmt + clippy + test + doc + dogfood, plus audit, deny, build, bench-smoke, examples, shell-tests, editors, and the advisory perf-gate. Self-hosted Linux. | ~5 min |
 | `release.yml` | tag push only | preflight gate → cross-platform build matrix → GitHub Release → ghcr.io Docker → npm → Homebrew tap → crates.io → VS Code Marketplace + Open VSX → JetBrains Marketplace. | ~15-25 min |
 | `docs-bundle.yml` | tag + main pushes | `xtask docs-export` → push refreshed bundle to `docs-bundle` branch → Cloudflare deploy hook → alint.org rebuilds. The sibling `check-pins.yml` workflow in the alint.org repo (PR + push + daily cron) asserts alint.org's three install-pin sites reference the latest tag from this release; fires automatically. | ~3-5 min |
 | `bench-docker.yml` | tag pushes | Build + push `ghcr.io/asamarts/alint-bench:<tag>` (the reproducible competitive-bench environment). | ~5 min |
@@ -176,12 +176,15 @@ Helix / Eclipse are docs-only (config snippets): nothing to publish.
 
 ## Bench-record review (the human gate)
 
-> **Regression detection is now the deterministic `perf-gate` CI job**
+> **Regression detection is the deterministic `perf-gate` CI job**
 > (`ci/scripts/det-perf-gate.sh`, per-PR; design:
 > [`docs/design/deterministic-perf-gating.md`](docs/design/deterministic-perf-gating.md)).
 > It compares Valgrind instruction/cache/branch counts PR-vs-merge-base and is
 > **load-immune**, so it catches regressions deterministically where wall-clock
-> `bench-scale` cannot. The 2026-06 investigation proved the contaminated shared
+> `bench-scale` cannot. It runs **advisory today** (`DET_PERF_ADVISORY=1` in
+> `ci.yml`: it annotates but cannot fail the build, and is excluded from the
+> `summary` gate); flip it to enforcing by setting `DET_PERF_ADVISORY=0` and
+> adding `perf-gate` to `summary.needs`. The 2026-06 investigation proved the contaminated shared
 > runner makes wall-clock regression %s unreliable (v0.11.1 AND v0.12.0 both
 > contaminated; see
 > [`docs/benchmarks/investigations/2026-06-v0.12-perf-validation/`](docs/benchmarks/investigations/2026-06-v0.12-perf-validation/)).
@@ -277,8 +280,8 @@ HISTORY.md (the cross-version table is release-tag-only).
 contains a critical bug:
 
 1. Yank from crates.io via `cargo yank --version <x.y.z> -p alint`
-   (and the workspace member crates: `alint-core`, `alint-dsl`,
-   `alint-rules`, `alint-output`).
+   (and every published library crate, per `ci/scripts/publish-crates.sh`:
+   `alint-core`, `alint-rules`, `alint-output`, `alint-dsl`, `alint-lsp`).
 2. Mark the npm package as `npm deprecate "@asamarts/alint@<x.y.z>"
    "Yanked: <reason>; upgrade to <x.y.z+1>"`.
 3. Delete the GitHub Release (the asset tarballs stay accessible via

--- a/docs/design/facts-json.md
+++ b/docs/design/facts-json.md
@@ -42,7 +42,7 @@ volatile fields, so it is committed and content-diff gated like the schema.
 ```json
 {
   "format_version": 1,
-  "alint_version": "0.12.0",
+  "alint_version": "0.13.0",
   "counts": {
     "rule_kinds": 89,
     "families": 13,

--- a/editors/zed/Cargo.lock
+++ b/editors/zed/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "alint-zed"
-version = "0.10.2"
+version = "0.13.0"
 dependencies = [
  "zed_extension_api",
 ]

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alint-zed"
-version = "0.10.2"
+version = "0.13.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0 OR MIT"

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "alint"
 name = "alint"
-version = "0.10.2"
+version = "0.13.0"
 schema_version = 1
 authors = ["alint contributors"]
 description = "Repository-structure linting (alint) in Zed via the alint language server."


### PR DESCRIPTION
Hygiene fixes surfaced by a two-repo audit (all low-risk, no engine changes):

- **`bench-docker.yml`** — SHA-pin the four `docker/*` actions to the exact SHAs `release.yml` already uses. Both workflows push images to ghcr with `packages: write`; release.yml was supply-chain-hardened, this one was still on mutable tags.
- **`action-selftest.yml`** — bump the "previous minor" pin from the long-stale `v0.9.21` to `v0.12.0`, so the CLI-vs-`.alint.yml` drift self-test exercises a recent release again. (v0.13 added no rule kinds, so v0.12.0's CLI parses the current `.alint.yml`.)
- **`RELEASING.md`** — add `alint-lsp` to the yank crate list (the publish set is **six** crates per `publish-crates.sh`, the docs listed four); correct the "what fires on the tag push" `ci.yml` job list; note `perf-gate` is **advisory today** (`DET_PERF_ADVISORY=1`), not yet enforcing.
- **`docs/design/facts-json.md`** — fix the illustrative example's `alint_version` (`0.12.0` → `0.13.0`) to match its own 0.13-era counts.
- **`editors/zed`** — bump the standalone extension `0.10.2` → `0.13.0` (manifest + Cargo.toml + lockfile) to align with the workspace.

## Verification
`actionlint`-clean YAML (parses), docker SHAs verified identical across both workflows, no em-dashes introduced (dogfooded `prose-no-em-dash`), zed lockfile regenerated.