### PR TITLE
fix(cli): honor --format on list/explain; add --only; agent fix_command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `--only <RULE_ID>` on `check` and `fix` (repeatable): restrict the run to the
+  named rule id(s) from the effective config. An id that matches no loaded rule
+  is an error, so typos fail loudly. This is the command the `agent` output
+  format emits per fixable violation (`alint fix --only <rule-id>`), which
+  previously named a flag that did not exist.
+- `fix_command` field on `check --format agent` violations: the exact argv
+  (e.g. `["fix", "--only", "<id>"]`) to auto-fix a single violation, present
+  iff `fix_available`. Lets an agent run the fix programmatically instead of
+  parsing the command out of the English `agent_instruction`.
+
+### Fixed
+
+- `alint list --format json` and `alint explain <id> --format json` now emit a
+  stable JSON envelope (a rule inventory and a single-rule shape) instead of
+  silently printing the human output with a success exit code. An unsupported
+  `--format` for these commands is now an explicit error rather than a silent
+  human fall-through.
+- The `agent` output format no longer instructs agents to run
+  `alint fix --only <id>` when no such flag existed; `--only` now exists, and a
+  regression test parses every command the agent format emits against the real
+  CLI so a dead command can't reappear.
+
 ## [0.13.0] - 2026-06-17
 
 This release turns the documented surface into generated, drift-proof contracts.

--- a/crates/alint-output/src/agent.rs
+++ b/crates/alint-output/src/agent.rs
@@ -71,6 +71,14 @@ struct AgentViolation<'a> {
     /// availability, and policy URL — see `build_agent_instruction`.
     agent_instruction: String,
     fix_available: bool,
+    /// Exact argv (after the `alint` program name) an agent can run to
+    /// auto-fix this single violation, present iff `fix_available`.
+    /// Lets an agent execute the fix programmatically instead of
+    /// parsing the command out of the English `agent_instruction` —
+    /// and is checked by a CLI-parse regression test, so it can never
+    /// name a flag the binary doesn't accept.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fix_command: Option<Vec<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     policy_url: Option<&'a str>,
 }
@@ -104,6 +112,9 @@ pub fn write_agent(report: &Report, w: &mut dyn Write) -> std::io::Result<()> {
                 human_message: v.message.as_ref(),
                 agent_instruction: build_agent_instruction(r, v),
                 fix_available: r.is_fixable,
+                fix_command: r
+                    .is_fixable
+                    .then(|| vec!["fix", "--only", r.rule_id.as_ref()]),
                 policy_url: r.policy_url.as_deref(),
             });
         }

--- a/crates/alint/src/main.rs
+++ b/crates/alint/src/main.rs
@@ -154,6 +154,12 @@ enum Command {
         /// `--changed`.
         #[arg(long, value_name = "REF")]
         base: Option<String>,
+        /// Restrict the run to the named rule id(s) from the
+        /// effective config (repeatable). Other rules are skipped
+        /// entirely. An id that matches no loaded rule is an error,
+        /// so typos fail loudly rather than silently linting nothing.
+        #[arg(long, value_name = "RULE_ID")]
+        only: Vec<String>,
     },
     /// List all rules loaded from the effective config.
     List,
@@ -178,6 +184,13 @@ enum Command {
         /// Base ref for `--changed`. Implies `--changed`.
         #[arg(long, value_name = "REF")]
         base: Option<String>,
+        /// Restrict the fix pass to the named rule id(s) from the
+        /// effective config (repeatable). This is the command the
+        /// `agent` output format emits per fixable violation
+        /// (`alint fix --only <rule-id>`). An id that matches no
+        /// loaded rule is an error.
+        #[arg(long, value_name = "RULE_ID")]
+        only: Vec<String>,
     },
     /// Evaluate every `facts:` entry in the effective config and
     /// print the resolved value. Debugging aid for `when:` clauses.
@@ -406,13 +419,15 @@ fn run(mut cli: Cli) -> Result<ExitCode> {
         path: PathBuf::from("."),
         changed: false,
         base: None,
+        only: Vec::new(),
     });
     match command {
         Command::Check {
             path,
             changed,
             base,
-        } => cmd_check(&path, &ChangedMode::new(changed, base), &cli),
+            only,
+        } => cmd_check(&path, &ChangedMode::new(changed, base), &only, &cli),
         Command::List => cmd_list(&cli),
         Command::Explain { rule_id } => cmd_explain(&rule_id, &cli),
         Command::Fix {
@@ -420,7 +435,14 @@ fn run(mut cli: Cli) -> Result<ExitCode> {
             dry_run,
             changed,
             base,
-        } => cmd_fix(&path, dry_run, &ChangedMode::new(changed, base), &cli),
+            only,
+        } => cmd_fix(
+            &path,
+            dry_run,
+            &ChangedMode::new(changed, base),
+            &only,
+            &cli,
+        ),
         Command::Facts { path } => cmd_facts(&path, &cli),
         Command::Init { path, monorepo } => cmd_init(&path, monorepo),
         Command::ExportAgentsMd {
@@ -620,10 +642,46 @@ impl ChangedMode {
     }
 }
 
-fn cmd_check(path: &Path, changed: &ChangedMode, cli: &Cli) -> Result<ExitCode> {
+/// Filter loaded rule entries to the ids named in `--only` (a no-op
+/// when `only` is empty). Every `--only` id must match a loaded rule;
+/// an unmatched id is an error so a typo fails loudly instead of
+/// silently selecting nothing. Shared by `check` and `fix`.
+fn apply_only_filter(
+    entries: Vec<alint_core::RuleEntry>,
+    only: &[String],
+) -> Result<Vec<alint_core::RuleEntry>> {
+    if only.is_empty() {
+        return Ok(entries);
+    }
+    let wanted: std::collections::HashSet<&str> = only.iter().map(String::as_str).collect();
+    let present: std::collections::HashSet<&str> = entries.iter().map(|e| e.rule.id()).collect();
+    let mut missing: Vec<&str> = wanted
+        .iter()
+        .copied()
+        .filter(|id| !present.contains(id))
+        .collect();
+    if !missing.is_empty() {
+        missing.sort_unstable();
+        bail!(
+            "no rule with id {} found in the effective config (passed via --only)",
+            missing
+                .iter()
+                .map(|id| format!("{id:?}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    Ok(entries
+        .into_iter()
+        .filter(|e| wanted.contains(e.rule.id()))
+        .collect())
+}
+
+fn cmd_check(path: &Path, changed: &ChangedMode, only: &[String], cli: &Cli) -> Result<ExitCode> {
     let loaded = load_rules(path, cli)?;
-    let rule_count = loaded.entries.len();
-    let mut engine = Engine::from_entries(loaded.entries, loaded.registry)
+    let entries = apply_only_filter(loaded.entries, only)?;
+    let rule_count = entries.len();
+    let mut engine = Engine::from_entries(entries, loaded.registry)
         .with_facts(loaded.facts)
         .with_vars(loaded.vars);
     if let Some(set) = changed.resolve(path)? {
@@ -694,9 +752,16 @@ fn report_notes_to_stderr(report: &alint_core::Report, show_notes: bool) {
     }
 }
 
-fn cmd_fix(path: &Path, dry_run: bool, changed: &ChangedMode, cli: &Cli) -> Result<ExitCode> {
+fn cmd_fix(
+    path: &Path,
+    dry_run: bool,
+    changed: &ChangedMode,
+    only: &[String],
+    cli: &Cli,
+) -> Result<ExitCode> {
     let loaded = load_rules(path, cli)?;
-    let mut engine = Engine::from_entries(loaded.entries, loaded.registry)
+    let entries = apply_only_filter(loaded.entries, only)?;
+    let mut engine = Engine::from_entries(entries, loaded.registry)
         .with_facts(loaded.facts)
         .with_vars(loaded.vars)
         .with_fix_size_limit(loaded.fix_size_limit);
@@ -741,6 +806,21 @@ fn cmd_list(cli: &Cli) -> Result<ExitCode> {
     use alint_output::style;
 
     let loaded = load_rules(Path::new("."), cli)?;
+
+    // `list` honours --format for machine consumers: `json` emits a
+    // stable rule-inventory envelope (the effective rule set, post
+    // extends/overrides). Any other machine format is an explicit
+    // error rather than a silent fall-through to human output.
+    let format: Format = cli.format.parse().map_err(|e: String| anyhow::anyhow!(e))?;
+    match format {
+        Format::Human => {}
+        Format::Json => return list_json(&loaded),
+        _ => bail!(
+            "`alint list` supports only `--format human` or `--format json` (got {:?})",
+            cli.format
+        ),
+    }
+
     let (mut out, opts) = render_env(cli)?;
     if loaded.entries.is_empty() {
         writeln!(out, "(no rules loaded from config)")?;
@@ -776,6 +856,30 @@ fn cmd_list(cli: &Cli) -> Result<ExitCode> {
         }
         writeln!(out)?;
     }
+    out.flush().ok();
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Stable machine-readable rule inventory for `alint list --format json`.
+/// Carries the effective rule set (after `extends:`/overrides) so fleet
+/// tooling can diff "what rules are effective here" across repos. The
+/// `schema_version` mirrors the `check --format json` envelope.
+fn list_json(loaded: &LoadedConfig) -> Result<ExitCode> {
+    let rules: Vec<serde_json::Value> = loaded
+        .entries
+        .iter()
+        .map(|entry| {
+            serde_json::json!({
+                "id": entry.rule.id(),
+                "level": entry.rule.level().as_str(),
+                "policy_url": entry.rule.policy_url(),
+                "conditional": entry.when.is_some(),
+            })
+        })
+        .collect();
+    let doc = serde_json::json!({ "schema_version": 1, "rules": rules });
+    let mut out = std::io::stdout().lock();
+    writeln!(out, "{}", serde_json::to_string_pretty(&doc)?)?;
     out.flush().ok();
     Ok(ExitCode::SUCCESS)
 }
@@ -910,6 +1014,20 @@ fn cmd_explain(rule_id: &str, cli: &Cli) -> Result<ExitCode> {
         bail!("no rule with id {rule_id:?} found in the effective config");
     };
     let rule = &entry.rule;
+
+    // `explain` honours --format for machine consumers, matching `list`:
+    // `json` emits the rule's wire-shape; any other machine format is an
+    // explicit error rather than silently printing the human block.
+    let format: Format = cli.format.parse().map_err(|e: String| anyhow::anyhow!(e))?;
+    match format {
+        Format::Human => {}
+        Format::Json => return explain_json(entry),
+        _ => bail!(
+            "`alint explain` supports only `--format human` or `--format json` (got {:?})",
+            cli.format
+        ),
+    }
+
     let (mut out, opts) = render_env(cli)?;
     let dim = style::DIM;
     let docs = style::DOCS;
@@ -939,9 +1057,25 @@ fn cmd_explain(rule_id: &str, cli: &Cli) -> Result<ExitCode> {
     // v0.9.20: dropped the `debug: {rule:?}` line. The internal Debug
     // repr dumped per-rule-kind state (regex automaton, compiled
     // matchers, etc.) — useful for alint developers, noise for end
-    // users (24+ KB for some rule kinds). Use `--format json` on
-    // `alint check` if you need the wire-shape, or read the rule's
+    // users (24+ KB for some rule kinds). Use `--format json` (here or
+    // on `alint check`) if you need the wire-shape, or read the rule's
     // YAML config block.
+    Ok(ExitCode::SUCCESS)
+}
+
+/// Machine-readable single-rule shape for `alint explain <id> --format
+/// json`. Parallels each entry of the `list --format json` inventory.
+fn explain_json(entry: &alint_core::RuleEntry) -> Result<ExitCode> {
+    let doc = serde_json::json!({
+        "schema_version": 1,
+        "id": entry.rule.id(),
+        "level": entry.rule.level().as_str(),
+        "policy_url": entry.rule.policy_url(),
+        "conditional": entry.when.is_some(),
+    });
+    let mut out = std::io::stdout().lock();
+    writeln!(out, "{}", serde_json::to_string_pretty(&doc)?)?;
+    out.flush().ok();
     Ok(ExitCode::SUCCESS)
 }
 

--- a/crates/alint/tests/cli/help-check.stdout
+++ b/crates/alint/tests/cli/help-check.stdout
@@ -11,6 +11,7 @@ Options:
       --base <REF>       Base ref for `--changed` (uses three-dot `<base>...HEAD`, i.e. merge-base diff). Implies `--changed`
   -f, --format <FORMAT>  Output format [default: human]
       --no-gitignore     Disable .gitignore handling (overrides config)
+      --only <RULE_ID>   Restrict the run to the named rule id(s) from the effective config (repeatable). Other rules are skipped entirely. An id that matches no loaded rule is an error, so typos fail loudly rather than silently linting nothing
       --fail-on-warning  Treat warnings as errors for exit-code purposes
       --show-notes       List informational notes (non-violation findings, e.g. entries a rule skipped rather than failed on) in full on stderr. By default only a one-line count is shown
       --color <WHEN>     When to emit ANSI color codes in human output. `auto` (the default) inspects TTY + `NO_COLOR` + `CLICOLOR_FORCE`. Only affects the `human` format; `json` / `sarif` / `github` / `markdown` / `junit` / `gitlab` / `agent` are always plain bytes [default: auto] [possible values: auto, always, never]

--- a/crates/alint/tests/cli/help-fix.stdout
+++ b/crates/alint/tests/cli/help-fix.stdout
@@ -13,6 +13,7 @@ Options:
       --base <REF>       Base ref for `--changed`. Implies `--changed`
       --no-gitignore     Disable .gitignore handling (overrides config)
       --fail-on-warning  Treat warnings as errors for exit-code purposes
+      --only <RULE_ID>   Restrict the fix pass to the named rule id(s) from the effective config (repeatable). This is the command the `agent` output format emits per fixable violation (`alint fix --only <rule-id>`). An id that matches no loaded rule is an error
       --show-notes       List informational notes (non-violation findings, e.g. entries a rule skipped rather than failed on) in full on stderr. By default only a one-line count is shown
       --color <WHEN>     When to emit ANSI color codes in human output. `auto` (the default) inspects TTY + `NO_COLOR` + `CLICOLOR_FORCE`. Only affects the `human` format; `json` / `sarif` / `github` / `markdown` / `junit` / `gitlab` / `agent` are always plain bytes [default: auto] [possible values: auto, always, never]
       --ascii            Force ASCII glyphs in human output (e.g. `x` instead of `✗`). Auto-enabled when `TERM=dumb`

--- a/crates/alint/tests/cli_format_contract.rs
+++ b/crates/alint/tests/cli_format_contract.rs
@@ -1,0 +1,211 @@
+//! CLI output-contract gates — two regression classes that shipped
+//! broken in 0.13.0 and must never silently reappear:
+//!
+//! * **G1a — `--format json` is never a silent no-op.** `alint list`
+//!   and `alint explain` advertised the global `--format` flag but
+//!   ignored it, printing the *human* rule list with a *success* exit
+//!   code — so automation built on `list --format json` silently got
+//!   colourised text. The invariant: for every subcommand that emits
+//!   to stdout, `--format json` must yield parseable JSON OR exit
+//!   non-zero. It may never print non-JSON to stdout *and* exit 0.
+//!
+//! * **G1b — the `agent` format only emits runnable commands.** The
+//!   agent format told agents to run `alint fix --only <id>`, a flag
+//!   that did not exist (`fix`/`check` rejected `--only` with exit 2).
+//!   The invariant: every command the agent format emits — the
+//!   structured `fix_command` argv *and* any `` `alint …` `` command
+//!   inside an `agent_instruction` — must parse against the real CLI.
+//!
+//! Both gates drive the actual binary (`CARGO_BIN_EXE_alint`) so they
+//! exercise the same clap surface and renderers users hit.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn alint_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_alint"))
+}
+
+/// A throwaway repo that loads real rules (extends the bundled
+/// `oss-baseline`) and contains a fixable violation (a file with no
+/// trailing newline), so `check`/`fix`/`agent` all have something to
+/// say.
+fn fixture() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join(".alint.yml"),
+        "version: 1\nextends:\n  - alint://bundled/oss-baseline@v1\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("bad.md"), "no trailing newline").unwrap();
+    dir
+}
+
+fn run(dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(alint_bin())
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("spawn alint")
+}
+
+// ─── G1a — `--format json` is never a silent human no-op ────────────
+
+/// Every subcommand that writes a report to stdout. `explain` needs a
+/// rule id, injected at call time. `fix` runs `--dry-run` so the gate
+/// never mutates the fixture.
+const JSON_STDOUT_SUBCOMMANDS: &[&[&str]] = &[
+    &["check"],
+    &["list"],
+    &["fix", "--dry-run"],
+    &["facts"],
+    &["suggest"],
+    &["validate-config"],
+    // explain is appended with a concrete id below.
+];
+
+#[test]
+fn format_json_is_never_a_silent_human_fallthrough() {
+    let dir = fixture();
+
+    // Discover a real rule id from the (now-JSON) list inventory so
+    // `explain` is exercised against an id that exists.
+    let list = run(dir.path(), &["list", "--format", "json"]);
+    let list_json: serde_json::Value =
+        serde_json::from_slice(&list.stdout).expect("list --format json must be JSON");
+    let some_id = list_json["rules"][0]["id"]
+        .as_str()
+        .expect("at least one rule in the fixture")
+        .to_string();
+
+    let mut cases: Vec<Vec<String>> = JSON_STDOUT_SUBCOMMANDS
+        .iter()
+        .map(|c| c.iter().map(|s| (*s).to_string()).collect())
+        .collect();
+    cases.push(vec!["explain".into(), some_id]);
+
+    for case in &cases {
+        let mut args: Vec<&str> = case.iter().map(String::as_str).collect();
+        args.push("--format");
+        args.push("json");
+        let out = run(dir.path(), &args);
+
+        // The silent-failure signature is: exit 0 with non-JSON on
+        // stdout. Honouring the flag (valid JSON) or rejecting it
+        // (non-zero exit) are both acceptable; printing human text
+        // and claiming success is not.
+        if out.status.success() {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            if stdout.trim().is_empty() {
+                continue; // nothing emitted is fine (e.g. no findings)
+            }
+            assert!(
+                serde_json::from_slice::<serde_json::Value>(&out.stdout).is_ok(),
+                "`alint {} --format json` exited 0 but stdout was not JSON \
+                 (silent --format no-op regression). stdout begins:\n{}",
+                case.join(" "),
+                &stdout.chars().take(200).collect::<String>(),
+            );
+        }
+    }
+}
+
+// ─── G1b — the agent format only emits commands the CLI accepts ─────
+
+/// Pull `` `alint …` `` commands out of an `agent_instruction` string:
+/// the substring between a backtick-quoted `alint ` and the next
+/// backtick, returned as argv (program name dropped).
+fn alint_commands_in(prose: &str) -> Vec<Vec<String>> {
+    let mut cmds = Vec::new();
+    let mut rest = prose;
+    while let Some(start) = rest.find("`alint ") {
+        let after = &rest[start + 1..]; // skip the opening backtick
+        if let Some(end) = after.find('`') {
+            let cmd = &after[..end];
+            let argv: Vec<String> = cmd
+                .split_whitespace()
+                .skip(1) // drop "alint"
+                .map(str::to_string)
+                .collect();
+            if !argv.is_empty() {
+                cmds.push(argv);
+            }
+            rest = &after[end + 1..];
+        } else {
+            break;
+        }
+    }
+    cmds
+}
+
+/// Assert an argv parses against the real CLI: a clap parse failure
+/// exits 2 with "unexpected argument" / "error:" on stderr. Append
+/// `--dry-run` so a `fix` command never writes during the check.
+fn assert_parses(dir: &Path, argv: &[String]) {
+    let mut invocation: Vec<&str> = argv.iter().map(String::as_str).collect();
+    if argv.first().map(String::as_str) == Some("fix") {
+        invocation.push("--dry-run");
+    }
+    let out = run(dir, &invocation);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.code() != Some(2) && !stderr.contains("unexpected argument"),
+        "agent format emitted a command the CLI rejects: `alint {}`\n\
+         exit={:?}\nstderr: {}",
+        argv.join(" "),
+        out.status.code(),
+        stderr.trim(),
+    );
+}
+
+#[test]
+fn agent_format_only_emits_runnable_commands() {
+    let dir = fixture();
+    let out = run(dir.path(), &["check", "--format", "agent"]);
+    let report: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("agent format is JSON");
+    let violations = report["violations"].as_array().expect("violations array");
+
+    let mut checked_fix_command = false;
+    let mut checked_prose = false;
+
+    for v in violations {
+        // 1. The structured fix_command argv must parse.
+        if let Some(cmd) = v["fix_command"].as_array() {
+            let argv: Vec<String> = cmd
+                .iter()
+                .map(|s| s.as_str().expect("argv element is a string").to_string())
+                .collect();
+            assert_parses(dir.path(), &argv);
+            checked_fix_command = true;
+
+            // And it must agree with fix_available.
+            assert_eq!(
+                v["fix_available"].as_bool(),
+                Some(true),
+                "fix_command present but fix_available is not true: {v}"
+            );
+        }
+
+        // 2. Any `alint …` command embedded in the prose must parse
+        //    too — prose drift can't reintroduce a dead command.
+        if let Some(instr) = v["agent_instruction"].as_str() {
+            for argv in alint_commands_in(instr) {
+                assert_parses(dir.path(), &argv);
+                checked_prose = true;
+            }
+        }
+    }
+
+    // The fixture is constructed to contain a fixable violation, so
+    // both code paths must actually have run — otherwise the gate is
+    // vacuously green.
+    assert!(
+        checked_fix_command,
+        "fixture produced no fixable violation; gate did not exercise fix_command"
+    );
+    assert!(
+        checked_prose,
+        "fixture produced no agent_instruction with an `alint …` command"
+    );
+}

--- a/crates/alint/tests/snapshots/cli-flags.txt
+++ b/crates/alint/tests/snapshots/cli-flags.txt
@@ -26,6 +26,7 @@
   --fail-on-warning
   --no-docs
   --no-gitignore
+  --only <RULE_ID>
   --progress <WHEN>
   --show-notes
   --width <COLS>
@@ -74,6 +75,7 @@
   --fail-on-warning
   --no-docs
   --no-gitignore
+  --only <RULE_ID>
   --progress <WHEN>
   --show-notes
   --width <COLS>

--- a/docs/site/reference/output-formats/agent.md
+++ b/docs/site/reference/output-formats/agent.md
@@ -57,7 +57,8 @@ A report is a single JSON object. This example has three violations: one path-bo
       "file": "src/config.ts",
       "human_message": "File does not end with a newline.",
       "agent_instruction": "warning: File does not end with a newline. To resolve: edit src/config.ts — or run `alint fix --only final-newline` to apply the auto-fix.",
-      "fix_available": true
+      "fix_available": true,
+      "fix_command": ["fix", "--only", "final-newline"]
     },
     {
       "rule_id": "lockfiles-only-one",
@@ -98,6 +99,7 @@ A report is a single JSON object. This example has three violations: one path-bo
 | `human_message` | string | yes | The rule's message verbatim. Mirror of `message` in `--format json`. |
 | `agent_instruction` | string | yes | Templated remediation phrasing (see below). |
 | `fix_available` | boolean | yes | `true` when the source rule declares an autofix. |
+| `fix_command` | array of strings | no | Present iff `fix_available`. Exact argv (after `alint`) to auto-fix this one violation — e.g. `["fix", "--only", "final-newline"]`. Run it programmatically instead of parsing the command out of `agent_instruction`. |
 | `file` | string | no | Repo-relative path. Absent for tree-wide (cross-file) violations. |
 | `line` | integer | no | 1-based line, when the rule reports one. |
 | `column` | integer | no | 1-based column, when the rule reports one. |


### PR DESCRIPTION
Phase 0 of the response to the external-evaluation findings (`ALINT_CLEAN.md`): the three **firsthand-reproduced CLI bugs**, fixed as one class with regression gates so they can't silently reappear.

## Bugs fixed (all reproduced on 0.13.0)

| | Before | After |
|---|---|---|
| `list --format json` / `explain --format json` | human output, **exit 0** (silent failure) | stable JSON envelope; unsupported `--format` is an explicit error |
| `agent` format emits `alint fix --only <id>` | `fix --only` → **exit 2**, flag didn't exist | `--only <RULE_ID>` added to `check`+`fix`; the emitted command is now real |
| agents must parse English to find the command | command only in prose | structured `fix_command` argv (`["fix","--only","<id>"]`) added |

## Gates (prevent re-introduction) — `crates/alint/tests/cli_format_contract.rs`

- **G1a:** for every stdout-emitting subcommand, `--format json` must yield parseable JSON **or** exit non-zero — never non-JSON with exit 0 (the silent-failure signature).
- **G1b:** every command the agent format emits — the `fix_command` argv **and** any `` `alint …` `` command inside an `agent_instruction` — must parse against the real CLI. A dead command fails the build.

## Also

- `--only` errors loudly on an id that matches no loaded rule (typos don't silently lint nothing).
- Refreshed the `cli-flags` inventory + `help-check`/`help-fix` snapshots; documented `fix_command` in the agent output-format reference; CHANGELOG `[Unreleased]`.

## Verification

`cargo test --workspace` (incl. the 2 new gates), `cargo fmt --check`, pedantic `ci/scripts/clippy.sh`, `RUSTDOCFLAGS=-D warnings cargo doc`, and `gen-{schema,facts,roadmap} --check` all pass.

Part of a 4-PR sequence (Phases 0–3) closing the evaluator's bug + doc-drift classes.