### PR TITLE
fix(docs): correct schema-invalid config examples; add doc-example gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected config examples that the loader (and the JSON schema) reject:
+  `docs/design/ARCHITECTURE.md` (`query:`/`pattern:` → `path:`/`matches:`,
+  map-keyed `rules:` → a list, a `sha256:`/`path:` `extends` mapping → SRI
+  URL-fragment + bare-string form, phantom `detect:`/`primary_language`/
+  `count_contributors` facts removed, `custom: {command:}` → `argv:`, WASM
+  plugin tier relabelled v0.13 → v0.14) and `docs/rules.md`
+  (`max:` → `max_width`/`max_depth`, `unique_by` `paths:` → `select:`).
+- Added the `agent` format to the README `--format` example block (it listed
+  seven of the eight formats) and removed the stale "Planned rulesets (v0.5)"
+  section from `docs/rules.md` (all five shipped).
+
+### Internal
+
+- New drift gates so the doc-vs-schema and stale-status classes can't recur:
+  `coverage_audit_doc_examples` loads every fenced config example in the
+  hand-written docs through the real config loader, and
+  `coverage_audit_planned_rulesets` fails if a "Planned" section names a
+  ruleset already in `facts.json`.
+
 ## [0.13.0] - 2026-06-17
 
 This release turns the documented surface into generated, drift-proof contracts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,26 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added the `agent` format to the README `--format` example block (it listed
   seven of the eight formats) and removed the stale "Planned rulesets (v0.5)"
   section from `docs/rules.md` (all five shipped).
+- The `*_path_equals` / `*_path_matches` rule reference pages no longer all
+  show `kind: json_path_*`: each page's example now leads with its own kind,
+  and the `*_path_matches` example gained the missing `toml_path_matches`
+  variant.
+- Fixed documentation links that dead-end for a reader browsing on GitHub:
+  a broken `crates/alint-core/src/when.rs` link (now the `when/` module),
+  the `/docs/rules/` cross-links in `ARCHITECTURE.md` (now absolute
+  `https://alint.org` URLs), and a "full reference at alint.org" banner on
+  the GitHub view of `docs/rules.md`.
 
 ### Internal
 
-- New drift gates so the doc-vs-schema and stale-status classes can't recur:
-  `coverage_audit_doc_examples` loads every fenced config example in the
-  hand-written docs through the real config loader, and
-  `coverage_audit_planned_rulesets` fails if a "Planned" section names a
-  ruleset already in `facts.json`.
+- New drift gates so the doc-vs-schema, stale-status, generated-page, and
+  dead-link classes can't recur: `coverage_audit_doc_examples` loads every
+  fenced config example in the hand-written docs through the real config
+  loader; `coverage_audit_planned_rulesets` fails if a "Planned" section
+  names a ruleset already in `facts.json`; `structured_query_pages_lead_with_their_own_kind`
+  asserts each generated structured-query page leads with its own kind; and
+  `coverage_audit_doc_links` checks repo-doc links resolve (no broken
+  relative links, no GitHub-dead root-absolute links).
 
 ## [0.13.0] - 2026-06-17
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ alint check --format github   # GitHub Actions workflow commands
 alint check --format markdown # GFM, suited to PR comments / mkdocs
 alint check --format junit    # JUnit XML, the de-facto CI test report
 alint check --format gitlab   # GitLab Code Quality JSON (Code Climate spec)
+alint check --format agent    # LLM-shaped JSON; agent_instruction + fix_command per violation
 ```
 
 Exit codes: `0` no errors; `1` one or more errors; `2` config error; `3` internal error. Warnings do not fail by default; use `--fail-on-warning` to flip that.

--- a/crates/alint-e2e/tests/coverage_audit_doc_examples.rs
+++ b/crates/alint-e2e/tests/coverage_audit_doc_examples.rs
@@ -1,0 +1,264 @@
+//! Doc-example schema gate (the missing drift gate behind §2 of the
+//! external evaluation).
+//!
+//! Hand-written prose docs restate config syntax in fenced `yaml`
+//! blocks, and nothing validated them — so `docs/design/ARCHITECTURE.md`
+//! and `docs/rules.md` shipped examples the config loader rejects:
+//! `query:`/`pattern:` instead of `path:`/`matches:`, a `sha256:` key
+//! that isn't a schema field, map-keyed `rules:`, phantom facts
+//! (`detect: linguist`), and rule examples using `max:`/`paths:` keys
+//! the rule's own struct denies.
+//!
+//! This gate extracts every fenced `yaml` block from those docs, normalises
+//! it into a loadable `.alint.yml`, and runs it through the SAME path
+//! as `coverage_audit_examples_parse` (`alint_dsl::load` +
+//! `registry.build`) — the exact place unknown-field / missing-field /
+//! wrong-kind errors surface. A doc example that doesn't load fails the
+//! build, so the whole §2 class can't silently reappear.
+//!
+//! Deliberately-invalid teaching snippets are skipped two ways:
+//!   * a `**Wrong:**` / `Wrong:` marker in the few lines above the
+//!     block (the convention `docs/development/CONFIG-AUTHORING.md`
+//!     already uses for its "common mistakes" examples), or
+//!   * an explicit `<!-- alint:ignore-example -->` HTML comment
+//!     immediately before the fence (for one-off future/design shapes).
+//!
+//! Blocks that aren't configs (when-expressions, output samples, shell)
+//! are skipped by classification. The test prints validated/skipped
+//! counts so coverage stays visible.
+
+use std::fmt::Write as _;
+use std::path::PathBuf;
+
+/// Docs whose fenced config examples must load. Scoped to the
+/// drift-prone hand-written docs the evaluation flagged; extend as new
+/// config-bearing prose is added.
+const DOC_FILES: &[&str] = &[
+    "docs/design/ARCHITECTURE.md",
+    "docs/rules.md",
+    "docs/development/CONFIG-AUTHORING.md",
+    "docs/development/rule-authoring.md",
+];
+
+fn repo_root() -> PathBuf {
+    // crates/alint-e2e -> repo root
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+/// One fenced `yaml` block plus enough context to decide intent.
+struct Block {
+    /// 1-based line number of the opening fence (for error messages).
+    start_line: usize,
+    body: String,
+    /// The handful of source lines immediately above the fence.
+    preamble: String,
+}
+
+/// Extract ```yaml / ```yml fenced blocks with their preceding context.
+fn yaml_blocks(text: &str) -> Vec<Block> {
+    let lines: Vec<&str> = text.lines().collect();
+    let mut blocks = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let trimmed = lines[i].trim_start();
+        if trimmed == "```yaml" || trimmed == "```yml" {
+            let start_line = i + 1;
+            let preamble = lines[i.saturating_sub(6)..i].join("\n").to_lowercase();
+            let mut body = String::new();
+            i += 1;
+            while i < lines.len() && lines[i].trim_start() != "```" {
+                body.push_str(lines[i]);
+                body.push('\n');
+                i += 1;
+            }
+            blocks.push(Block {
+                start_line,
+                body,
+                preamble,
+            });
+        }
+        i += 1;
+    }
+    blocks
+}
+
+/// Is this block a deliberate teaching counter-example or a
+/// future/design shape we shouldn't hold to the current schema?
+fn is_deliberately_invalid(b: &Block) -> bool {
+    const MARKERS: &[&str] = &[
+        "wrong:",
+        "alint:ignore-example",
+        "design candidate",
+        "designed shape",
+        "not yet",
+        "roadmap",
+        "future",
+        "won't load",
+        "would fail",
+        "invalid",
+    ];
+    MARKERS.iter().any(|m| b.preamble.contains(m))
+}
+
+/// Normalise a block into a full `.alint.yml` document, or `None` if it
+/// isn't a config example (when-expression, output JSON, shell, ...).
+fn to_config(body: &str) -> Option<String> {
+    // A top-level config key in column 0 marks a (partial) config doc.
+    const TOP_KEYS: &[&str] = &[
+        "version:",
+        "rules:",
+        "extends:",
+        "facts:",
+        "vars:",
+        "templates:",
+        "nested_configs:",
+        "ignore:",
+        "respect_gitignore:",
+        "fix_size_limit:",
+        "allow_out_of_root:",
+    ];
+    let has_top_key = body
+        .lines()
+        .any(|l| TOP_KEYS.iter().any(|k| l.starts_with(k)));
+
+    if has_top_key {
+        // Already (part of) a config. Ensure a version line is present.
+        if body.lines().any(|l| l.starts_with("version:")) {
+            return Some(body.to_string());
+        }
+        return Some(format!("version: 1\n{body}"));
+    }
+
+    // A bare rules sequence (`- id: ... kind: ...`) — the docs/rules.md
+    // shape. Wrap it under `rules:`.
+    let first = body.lines().find(|l| {
+        let t = l.trim();
+        !t.is_empty() && !t.starts_with('#')
+    })?;
+    if first.trim_start().starts_with("- ") && body.contains("kind:") {
+        let indented: String = body
+            .lines()
+            .map(|l| {
+                if l.trim().is_empty() {
+                    String::from("\n")
+                } else {
+                    format!("  {l}\n")
+                }
+            })
+            .collect();
+        return Some(format!("version: 1\nrules:\n{indented}"));
+    }
+    None
+}
+
+/// Inject a synthetic `level: error` into any rule that omits it.
+///
+/// `level` is required by both the schema and the loader, but the docs
+/// deliberately omit it in fragments that illustrate one aspect of a
+/// rule. That brevity is a *separate, benign* convention — not the
+/// wrong-key / phantom-fact / wrong-kind drift class this gate exists
+/// to catch — so we fill a default and let the gate focus on the rest
+/// of the rule shape. A block whose YAML is itself malformed (e.g. the
+/// map-vs-sequence `rules:` bug) won't parse here; we return it
+/// unchanged so the loader still reports the structural error.
+fn inject_default_levels(config: &str) -> String {
+    let Ok(mut doc) = serde_yaml_ng::from_str::<serde_yaml_ng::Value>(config) else {
+        return config.to_string();
+    };
+    if let Some(rules) = doc
+        .get_mut("rules")
+        .and_then(serde_yaml_ng::Value::as_sequence_mut)
+    {
+        for rule in rules.iter_mut() {
+            if let Some(map) = rule.as_mapping_mut() {
+                let key = serde_yaml_ng::Value::String("level".into());
+                map.entry(key)
+                    .or_insert_with(|| serde_yaml_ng::Value::String("error".into()));
+            }
+        }
+    }
+    serde_yaml_ng::to_string(&doc).unwrap_or_else(|_| config.to_string())
+}
+
+#[test]
+fn every_doc_config_example_loads() {
+    let root = repo_root();
+    let registry = alint_rules::builtin_registry();
+    let mut failures: Vec<String> = Vec::new();
+    let mut validated = 0usize;
+    let mut skipped_non_config = 0usize;
+    let mut skipped_deliberate = 0usize;
+    let mut skipped_network = 0usize;
+
+    for rel in DOC_FILES {
+        let path = root.join(rel);
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+
+        for block in yaml_blocks(&text) {
+            if is_deliberately_invalid(&block) {
+                skipped_deliberate += 1;
+                continue;
+            }
+            let Some(config) = to_config(&block.body) else {
+                skipped_non_config += 1;
+                continue;
+            };
+            // `extends:` against an HTTPS URL would resolve over the
+            // network; we can't validate those offline. Bundled
+            // (`alint://`) extends load fine.
+            if config.contains("http://") || config.contains("https://") {
+                skipped_network += 1;
+                continue;
+            }
+
+            let config = inject_default_levels(&config);
+            let loc = format!("{rel}:{}", block.start_line);
+            let dir = tempfile::tempdir().expect("tempdir");
+            std::fs::write(dir.path().join(".alint.yml"), &config).unwrap();
+
+            match alint_dsl::load(&dir.path().join(".alint.yml")) {
+                Ok(cfg) => {
+                    for spec in &cfg.rules {
+                        if matches!(spec.level, alint_core::Level::Off) {
+                            continue;
+                        }
+                        if let Err(e) = registry.build(spec) {
+                            failures
+                                .push(format!("{loc}: rule {:?} fails to build — {e}", spec.id));
+                        }
+                    }
+                    validated += 1;
+                }
+                Err(e) => {
+                    failures.push(format!("{loc}: config does not load — {e}"));
+                }
+            }
+        }
+    }
+
+    eprintln!(
+        "doc-example gate: {validated} validated, \
+         {skipped_non_config} non-config, {skipped_deliberate} deliberate-invalid, \
+         {skipped_network} network-extends skipped"
+    );
+    assert!(
+        validated > 0,
+        "no doc config examples were validated — did the extractor break?"
+    );
+
+    if !failures.is_empty() {
+        let mut msg = format!(
+            "{} doc config example(s) the loader rejects (schema drift).\n\
+             Fix the example, or mark a deliberate counter-example with a \
+             `**Wrong:**` preamble or `<!-- alint:ignore-example -->`.\n\n",
+            failures.len()
+        );
+        for f in &failures {
+            writeln!(msg, "  - {f}").unwrap();
+        }
+        panic!("{msg}");
+    }
+}

--- a/crates/alint-e2e/tests/coverage_audit_doc_links.rs
+++ b/crates/alint-e2e/tests/coverage_audit_doc_links.rs
@@ -1,0 +1,207 @@
+//! Repo-side documentation link integrity (external-evaluation §3.1).
+//!
+//! A reader browsing the docs on GitHub hit two classes of dead link:
+//!
+//!   1. **Broken relative links** — a markdown link to a repo file that
+//!      moved or was misspelt (e.g. `crates/alint-core/src/when.rs`
+//!      after the `when` module became a directory).
+//!   2. **Root-absolute site links** — `](/docs/concepts/…)`. On GitHub
+//!      a `/…` link resolves against `github.com`, not the repo or the
+//!      site, so it dead-ends. These belong to the rendered site at
+//!      alint.org, not to a repo reader.
+//!
+//! This gate enforces both on the actively-maintained docs:
+//!
+//!   * every relative file link resolves to a real path, and
+//!   * no doc introduces a root-absolute `/…` link, EXCEPT the few
+//!     dual-purpose files that are sliced/copied into the alint.org
+//!     site (where `/docs/…` is the correct, resolvable form) and that
+//!     carry a "reading this on GitHub? the full reference is at
+//!     alint.org" banner for repo readers.
+//!
+//! Out of scope (different link-resolution semantics, not browsed as
+//! repo docs): the site-content tree `docs/site/**`, the benchmark
+//! result/▸archive snapshots, and the versioned `docs/design/v*/`
+//! design records.
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+/// Dual-purpose docs that ARE rendered into the alint.org site, where a
+/// root-absolute `/docs/…` cross-link is the correct form. Each must
+/// also tell a GitHub reader where those links resolve (asserted
+/// below). Everything else is a repo-only doc and may not use `/…`.
+const SITE_RENDERED_ALLOWLIST: &[&str] = &["docs/rules.md"];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+/// Is `rel` (a `.md` path, already extension-filtered by the caller) an
+/// actively-maintained doc this gate governs?
+fn is_governed(rel: &str) -> bool {
+    // Site content + historical snapshots have their own link semantics.
+    if rel.starts_with("docs/site/")
+        || rel.starts_with("docs/benchmarks/")
+        || rel.contains("/archive/")
+    {
+        return false;
+    }
+    // Versioned design records: docs/design/v0.9/, v0.12/, ...
+    if rel.starts_with("docs/design/v")
+        && rel
+            .trim_start_matches("docs/design/v")
+            .starts_with(|c: char| c.is_ascii_digit())
+    {
+        return false;
+    }
+    true
+}
+
+fn walk_md(base: &Path, dir: &Path, out: &mut Vec<String>) {
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for e in rd.flatten() {
+        let p = e.path();
+        if p.is_dir() {
+            walk_md(base, &p, out);
+        } else if p.extension().is_some_and(|x| x == "md")
+            && let Ok(rel) = p.strip_prefix(base)
+        {
+            let rel = rel.to_string_lossy().replace('\\', "/");
+            if is_governed(&rel) {
+                out.push(rel);
+            }
+        }
+    }
+}
+
+fn collect_docs(root: &Path) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    // Top-level governance/readme docs.
+    for top in [
+        "README.md",
+        "CONTRIBUTING.md",
+        "SECURITY.md",
+        "GOVERNANCE.md",
+        "CODE_OF_CONDUCT.md",
+        "RELEASING.md",
+    ] {
+        if root.join(top).is_file() {
+            out.push(top.to_string());
+        }
+    }
+    walk_md(root, &root.join("docs"), &mut out);
+    out
+}
+
+/// Markdown links `[text](url)`, returning each url. Skips image/inline
+/// soup edge cases by taking the simplest paren-balanced form.
+fn links(text: &str) -> Vec<String> {
+    let bytes = text.as_bytes();
+    let mut urls = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b']' && i + 1 < bytes.len() && bytes[i + 1] == b'(' {
+            if let Some(end) = text[i + 2..].find(')') {
+                urls.push(text[i + 2..i + 2 + end].trim().to_string());
+                i = i + 2 + end + 1;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    urls
+}
+
+#[test]
+fn repo_doc_links_are_not_dead_on_github() {
+    let root = repo_root();
+    let docs = collect_docs(&root);
+    assert!(!docs.is_empty(), "no governed docs found");
+
+    let mut broken_relative: Vec<String> = Vec::new();
+    let mut root_absolute: Vec<String> = Vec::new();
+    let mut missing_banner: Vec<String> = Vec::new();
+
+    for rel in &docs {
+        let path = root.join(rel);
+        let text = std::fs::read_to_string(&path).unwrap();
+        let allow_site_links = SITE_RENDERED_ALLOWLIST.contains(&rel.as_str());
+
+        if allow_site_links {
+            // Must orient a GitHub reader to the rendered site.
+            let lc = text.to_lowercase();
+            if !(lc.contains("alint.org") && lc.contains("github")) {
+                missing_banner.push(format!(
+                    "{rel}: carries root-absolute /docs links but no \
+                     'reading on GitHub? full reference at alint.org' banner"
+                ));
+            }
+        }
+
+        for url in links(&text) {
+            // Anchors, externals, mail/other schemes: not our concern.
+            if url.starts_with('#') || url.starts_with("mailto:") {
+                continue;
+            }
+            if url.starts_with("http://") || url.starts_with("https://") {
+                continue;
+            }
+            // Scheme-like (e.g. `alint://…`) — not a path.
+            if regexish_scheme(&url) {
+                continue;
+            }
+            if url.starts_with('/') {
+                if !allow_site_links {
+                    root_absolute.push(format!(
+                        "{rel}: ]({url}) — dead on GitHub; use https://alint.org{url}"
+                    ));
+                }
+                continue;
+            }
+            // Relative link: resolve the path part (drop anchor/query).
+            let target = url.split(['#', '?']).next().unwrap_or("");
+            if target.is_empty() || target.contains(' ') {
+                continue; // prose / placeholder, not a real path
+            }
+            let resolved = path.parent().unwrap().join(target);
+            if !resolved.exists() {
+                broken_relative.push(format!("{rel}: ]({url}) — target not found"));
+            }
+        }
+    }
+
+    let mut problems = String::new();
+    for v in [&broken_relative, &root_absolute, &missing_banner] {
+        for line in v {
+            writeln!(problems, "  - {line}").unwrap();
+        }
+    }
+    assert!(
+        broken_relative.is_empty() && root_absolute.is_empty() && missing_banner.is_empty(),
+        "documentation link problems ({} broken relative, {} dead root-absolute, \
+         {} missing banner):\n{problems}",
+        broken_relative.len(),
+        root_absolute.len(),
+        missing_banner.len(),
+    );
+}
+
+/// Does the url begin with a `scheme:` that isn't a path (e.g.
+/// `alint://`, `tel:`)? `http(s)` is handled before this is called.
+fn regexish_scheme(url: &str) -> bool {
+    if let Some(colon) = url.find(':') {
+        let scheme = &url[..colon];
+        !scheme.is_empty()
+            && scheme
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.')
+            && url[colon..].starts_with(":/")
+    } else {
+        false
+    }
+}

--- a/crates/alint-e2e/tests/coverage_audit_planned_rulesets.rs
+++ b/crates/alint-e2e/tests/coverage_audit_planned_rulesets.rs
@@ -1,0 +1,81 @@
+//! Status-drift gate: a ruleset documented as "Planned" must not have
+//! shipped.
+//!
+//! `docs/rules.md` carried a "Planned rulesets (v0.5)" section listing
+//! `python` / `go` / `java` / `compliance/*` as not-yet-shipped long
+//! after all five shipped — the same status-drift class as the public
+//! roadmap mislabelling WASM as the latest release. This gate ties the
+//! claim to the surface area: any `alint://bundled/<name>@v1` that
+//! appears under a heading containing "planned" must NOT be present in
+//! `facts.json`'s `bundled_rulesets` (the shipped catalogue). If it is,
+//! it shipped and the "Planned" copy is stale.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+const DOC_FILES: &[&str] = &["docs/rules.md", "docs/design/ARCHITECTURE.md"];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+/// Shipped ruleset names, e.g. `go`, `compliance/reuse`.
+fn shipped_rulesets() -> BTreeSet<String> {
+    let text = std::fs::read_to_string(repo_root().join("facts.json")).expect("read facts.json");
+    let facts: serde_json::Value = serde_json::from_str(&text).expect("parse facts.json");
+    facts["bundled_rulesets"]
+        .as_array()
+        .expect("bundled_rulesets array")
+        .iter()
+        .filter_map(|v| v.as_str().map(str::to_string))
+        .collect()
+}
+
+/// Pull the `<name>` out of `alint://bundled/<name>@v1`.
+fn ruleset_name(line: &str) -> Option<String> {
+    let start = line.find("alint://bundled/")? + "alint://bundled/".len();
+    let rest = &line[start..];
+    let end = rest.find("@v")?;
+    Some(rest[..end].to_string())
+}
+
+#[test]
+fn no_planned_section_lists_a_shipped_ruleset() {
+    let shipped = shipped_rulesets();
+    let mut stale: Vec<String> = Vec::new();
+
+    for rel in DOC_FILES {
+        let text = std::fs::read_to_string(repo_root().join(rel))
+            .unwrap_or_else(|e| panic!("read {rel}: {e}"));
+
+        // Track whether we're inside a heading section whose title
+        // mentions "planned"; reset at the next heading of the same or
+        // shallower depth (simplest: any new heading line).
+        let mut in_planned = false;
+        for (i, line) in text.lines().enumerate() {
+            if line.starts_with('#') {
+                in_planned = line.to_lowercase().contains("planned");
+                continue;
+            }
+            if in_planned
+                && let Some(name) = ruleset_name(line)
+                && shipped.contains(&name)
+            {
+                stale.push(format!(
+                    "{rel}:{}: `alint://bundled/{name}@v1` is under a \
+                     \"Planned\" heading but is in facts.json \
+                     (it shipped) — update the status copy.",
+                    i + 1
+                ));
+            }
+        }
+    }
+
+    assert!(
+        stale.is_empty(),
+        "stale 'Planned' ruleset claim(s):\n{}",
+        stale.join("\n")
+    );
+}

--- a/docs/design/ARCHITECTURE.md
+++ b/docs/design/ARCHITECTURE.md
@@ -37,7 +37,7 @@ The clarity of these non-goals is itself a feature.
 ## Design principles
 
 1. **The repository tree is the input.** Every rule sees a unified file/directory index. The walk happens once per invocation.
-2. **A small set of composable rule families.** Existence, content, naming, and cross-file were the original shapes; the model has since grown to thirteen families, all built on the same rule record. The [rule reference](/docs/rules/) lists every kind by family.
+2. **A small set of composable rule families.** Existence, content, naming, and cross-file were the original shapes; the model has since grown to thirteen families, all built on the same rule record. The [rule reference](https://alint.org/docs/rules/) lists every kind by family.
 3. **Declarative by default, programmable at the edges.** YAML covers typical rules. A bounded expression language gates rules on facts. A plugin surface (command, later WASM) covers user-defined logic.
 4. **Walk once, evaluate in parallel.** Single-pass walker; shared file index; `rayon` for rule-level parallelism.
 5. **Respect ecosystem defaults.** `.gitignore` is honored by default. YAML is the config format. Case aliases (`PascalCase` / `pascalcase` / `pascal-case`) all parse.
@@ -199,7 +199,7 @@ rules:
 
 ### Rule families
 
-Rules are grouped into thirteen families. Every kind shares the record shape above; what differs is the predicate. Not every kind ships in every release. The full, always-current catalogue, with a one-line summary per kind, lives at [the rule reference](/docs/rules/).
+Rules are grouped into thirteen families. Every kind shares the record shape above; what differs is the predicate. Not every kind ships in every release. The full, always-current catalogue, with a one-line summary per kind, lives at [the rule reference](https://alint.org/docs/rules/).
 
 - **Existence** (`file_exists`, `file_absent`, `dir_exists`, `dir_absent`): a path must, or must not, be present.
 - **Content** (`file_content_matches`, `file_header`, `file_hash`, `file_max_size`, `file_max_lines`, `file_is_text`, `file_shebang`, ...): assertions over a file's bytes or lines.
@@ -532,6 +532,6 @@ A new rule kind typically needs:
 1. A `Rule` impl in `crates/alint-rules/src/<kind>.rs`.
 2. Registration in `register_builtin` in `crates/alint-rules/src/lib.rs`.
 3. Unit tests alongside the impl (snapshot harness in `alint-testkit`).
-4. A docs entry so the kind appears in the [rule reference](/docs/rules/).
+4. A docs entry so the kind appears in the [rule reference](https://alint.org/docs/rules/).
 5. An entry in the Full Example section if the kind is commonly used.
 6. If the primitive shifts from "planned" to "shipped," an update in [ROADMAP.md](./ROADMAP.md).

--- a/docs/design/ARCHITECTURE.md
+++ b/docs/design/ARCHITECTURE.md
@@ -153,9 +153,10 @@ For editor autocomplete, reference the schema via the YAML language server pragm
 version: 1
 
 extends:
-  - url: https://raw.githubusercontent.com/example/rulesets/base.yaml
-    sha256: "a1b2..."           # optional subresource integrity
-  - path: ./team-policy.alint.yml
+  # Optional subresource integrity is a `#sha256-<hex>` URL fragment.
+  - url: "https://raw.githubusercontent.com/example/rulesets/base.yaml#sha256-0000000000000000000000000000000000000000000000000000000000000000"
+  # A local path is a bare string entry.
+  - ./team-policy.alint.yml
 
 ignore:
   - "target/**"
@@ -281,7 +282,7 @@ paths: {include: ["src/**"], exclude: ["**/*.test.*"]}     # explicit pair
 
 Facts are declarative properties of the repository, evaluated once per run and cached. `when` clauses gate rules on facts.
 
-Fact kinds include `any_file_exists`, `all_files_exist`, `file_content_matches`, `detect: linguist` (primary languages), `detect: askalono` (SPDX license), `count_files`, `count_contributors`, `git_branch`, and `custom: {command: [...]}` (shell out, JSON stdout → value).
+Fact kinds are `any_file_exists`, `all_files_exist`, `count_files`, `file_content_matches`, `git_branch`, and `custom: {argv: [...]}` (shell out, stdout → value). Language/license detectors (`detect: linguist`, `detect: askalono`) are deferred — see the planned `alint-facts` crate below.
 
 The `when` expression language is deliberately bounded:
 
@@ -293,9 +294,9 @@ No user-defined functions, no recursion, no I/O. Examples:
 
 ```yaml
 when: facts.has_rust
-when: facts.primary_language in ["Rust", "Go"]
+when: facts.release_branch in ["main", "release"]
 when: facts.has_rust and not facts.is_workspace_member
-when: count_files("**/*.java") > 0
+when: facts.java_file_count > 0
 ```
 
 ### Closest-ancestor scoping (`scope_filter:`, v0.9.6+)
@@ -421,7 +422,7 @@ alint/
 
 **Planned additions (see [ROADMAP.md](./ROADMAP.md)):**
 
-- `crates/alint-plugin/`: WASM plugin host (roadmap v0.13; the tier-1 `command` plugin already lives in `alint-rules`).
+- `crates/alint-plugin/`: WASM plugin host (roadmap v0.14; the tier-1 `command` plugin already lives in `alint-rules`).
 - `crates/alint-facts/`: currently subsumed by `alint-core::facts`; promotion to its own crate is deferred until the language and license detectors (`detect: linguist`, `detect: askalono`) land.
 
 ### Publishing intent (crates.io)
@@ -443,7 +444,7 @@ Unpublished crates still ship inside the binary and can be promoted later. The r
 Two tiers, introduced across the roadmap:
 
 - **`command` rule kind** (shipped). The rule shells out per matched file. Exit code is the verdict; stdout/stderr is the message. Environment variables expose path, rule id, level, vars, and facts. Simple, scriptable, language-agnostic.
-- **`wasm` plugin kind** (roadmap v0.13). Plugins will implement a stable WIT interface, receive file bytes + metadata, and return a structured result. Distributed as `.wasm` blobs referenced by URL with SRI. Sandboxed, deterministic, no network by default (opt-in capability).
+- **`wasm` plugin kind** (roadmap v0.14). Plugins will implement a stable WIT interface, receive file bytes + metadata, and return a structured result. Distributed as `.wasm` blobs referenced by URL with SRI. Sandboxed, deterministic, no network by default (opt-in capability).
 
 Native Rust plugins are deliberately out of scope. Dynamic library loading has ABI stability problems and would lock the plugin ecosystem to Rust. WASM is the long-term answer.
 
@@ -486,20 +487,21 @@ facts:
     any_file_exists: ["benches/**/*.rs"]
 
 rules:
-  # Override an inherited rule.
-  readme-exists:
+  # Override an inherited rule (field-merge by id: the inherited
+  # `oss-readme-exists` keeps its `kind`, this narrows its `paths`).
+  - id: oss-readme-exists
     paths: ["README.md", "README.adoc"]
 
   # Disable an inherited rule.
-  no-todo-comments:
+  - id: rust-sources-snake-case
     level: off
 
   # New rules.
   - id: cargo-members-are-kebab
     kind: toml_path_matches
     paths: "Cargo.toml"
-    query: "$.workspace.members[*]"
-    pattern: "^[a-z][a-z0-9-]+$"
+    path: "$.workspace.members[*]"
+    matches: "^[a-z][a-z0-9-]+$"
     level: error
 
   - id: crates-have-readme

--- a/docs/development/CONFIG-AUTHORING.md
+++ b/docs/development/CONFIG-AUTHORING.md
@@ -86,6 +86,7 @@ both rejected by serde.
 ```yaml
 - id: golangci-lint
   kind: command
+  paths: "**/*.go"
   command: ["golangci-lint", "run", "{dir}/..."]
   timeout: 600                           # ← integer seconds
 ```
@@ -275,6 +276,7 @@ dotted, and other non-identifier keys must use bracket notation —
 in **any** segment, top-level or inside a filter expression.
 
 **Wrong (top-level):**
+<!-- alint:ignore-example -->
 ```yaml
 - id: provider-package-name
   kind: yaml_path_matches
@@ -293,6 +295,7 @@ in **any** segment, top-level or inside a filter expression.
 ```
 
 **Wrong (inside a filter):**
+<!-- alint:ignore-example -->
 ```yaml
 - id: dependabot-actions-grouped
   kind: yaml_path_matches
@@ -761,6 +764,7 @@ istio's per-chart container-image hub is the canonical example.
 JSONPath positions per file. A single shared `path:` can't reach both.
 
 **Wrong (one shared JSONPath misses half the files):**
+<!-- alint:ignore-example -->
 ```yaml
 - id: image-hub-pinned
   kind: cross_file_value_equals
@@ -809,6 +813,7 @@ stitched into one file, helm-chart-rendered output) trip a runtime
 verdict.
 
 **Wrong (rule fires runtime error on multi-doc files):**
+<!-- alint:ignore-example -->
 ```yaml
 - id: release-note-kind-enum
   kind: yaml_path_equals
@@ -824,9 +829,8 @@ that doesn't need YAML parsing):**
 - id: release-note-kind-enum
   kind: file_content_matches
   paths: "releasenotes/notes/*.yaml"
-  pattern: '^kind: (feature|bug-fix|breaking-change|security)$'
-  multiline: true
-  level: warn
+  pattern: '(?m)^kind: (feature|bug-fix|breaking-change|security)$'
+  level: warning
 ```
 
 The v0.10 design candidate is a `multi_doc_mode:` knob: `error` (the
@@ -935,7 +939,7 @@ When writing a new rule, start from the closest pattern below.
 
 ```yaml
 - id: my-rule
-  kind: file_content_matches              # or file_content_forbidden, file_header, file_footer
+  kind: file_header                        # or file_content_matches, file_content_forbidden, file_footer
   paths:
     include: ["src/**/*.py"]
     exclude: ["src/**/_generated/**"]
@@ -944,7 +948,7 @@ When writing a new rule, start from the closest pattern below.
   pattern: '^# Copyright'
   level: error
   message: "Every Python file under src/ must have a copyright header."
-  fix:                                     # optional
+  fix:                                     # optional (file_header / file_create kinds; file_content_matches is check-only)
     file_prepend:
       content: "# Copyright (c) ...\n"
 ```

--- a/docs/development/CONFIG-AUTHORING.md
+++ b/docs/development/CONFIG-AUTHORING.md
@@ -404,7 +404,7 @@ when_iter: 'not iter.path matches "node_modules"'
 (Or — better — use the rule's `paths:` exclude list to filter out
 those paths entirely, before `when_iter:` even fires.)
 
-Source: `crates/alint-core/src/when.rs`.
+Source: `crates/alint-core/src/when/`.
 
 ### 13. `file_content_matches` / `file_content_forbidden`: regex `^` and `$` anchor file-start / file-end by default, NOT line-start / line-end
 
@@ -1242,5 +1242,5 @@ adds a smoke-test fixture audit that closes that gap.
 - [alint.org/docs/rules/](https://alint.org/docs/rules/) — per-rule documentation
 - [`crates/alint-rules/src/<kind>.rs`](../../crates/alint-rules/src/) — canonical schema (the `struct Options` block in each file)
 - [`crates/alint-core/src/config.rs`](../../crates/alint-core/src/config.rs) — top-level `RuleSpec`, `FixSpec`, `NestedRuleSpec` schemas
-- [`crates/alint-core/src/when.rs`](../../crates/alint-core/src/when.rs) — `when:` / `when_iter:` expression language
+- [`crates/alint-core/src/when/`](../../crates/alint-core/src/when/) — `when:` / `when_iter:` expression language
 - [`crates/alint-core/src/scope_filter.rs`](../../crates/alint-core/src/scope_filter.rs) — `scope_filter:` semantics

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -174,7 +174,7 @@ Content SHA-256 must equal the expected digest. Rules-as-tripwire for generated 
 - id: schema-frozen
   kind: file_hash
   paths: "schemas/v1/config.json"
-  sha256: "b7d0...c2e1"   # 64 hex chars
+  sha256: "0000000000000000000000000000000000000000000000000000000000000000"   # 64 hex chars
   level: error
 ```
 
@@ -459,7 +459,7 @@ Cap line length in characters (not bytes — code points). Optional `tab_width` 
 - id: docs-80-col
   kind: line_max_width
   paths: "docs/**/*.md"
-  max: 80
+  max_width: 80
   level: info
 ```
 
@@ -556,13 +556,13 @@ Flag a leading UTF-8 / UTF-16 LE/BE / UTF-32 LE/BE byte-order mark. The fixer st
 
 ### `max_directory_depth`
 
-Tree depth from repo root may not exceed `max`. A shallow depth stops deeply-nested imports and keeps CI path globs sane.
+Tree depth from repo root may not exceed `max_depth`. A shallow depth stops deeply-nested imports and keeps CI path globs sane.
 
 ```yaml
 - id: shallow-tree
   kind: max_directory_depth
   paths: "**"
-  max: 6
+  max_depth: 6
   level: warning
 ```
 
@@ -1305,7 +1305,7 @@ No two files matching `select` may share the value of `key` (a path template; to
 ```yaml
 - id: unique-basenames
   kind: unique_by
-  paths: "src/**/*.rs"
+  select: "src/**/*.rs"
   key: "{stem}"
   level: warning
 ```
@@ -1387,6 +1387,7 @@ Every `fix:` block uses one of these ops. See [ARCHITECTURE.md](design/ARCHITECT
 
 `fix_size_limit` is a top-level config field:
 
+<!-- alint:ignore-example -->
 ```yaml
 version: 1
 fix_size_limit: 1048576   # 1 MiB — the default; `null` disables
@@ -1759,13 +1760,3 @@ At load time, alint walks the tree (respecting `.gitignore` + `ignore:`), picks 
 - Every rule in a nested config must have a path-like scope field (`paths`, `select`, or `primary`). Rules without any (e.g. `no_submodules`, which is hardcoded to repo root) can't be nested.
 - Absolute paths and `..`-prefixed globs are rejected — they'd escape the subtree the config is supposed to confine.
 - Rule-id collisions across configs are rejected with a clear error. Per-subtree overrides aren't supported yet; if you want to disable a root rule under one subtree, use a `when:` gate on the root rule for now.
-
-### Planned rulesets (v0.5)
-
-- `alint://bundled/python@v1` — `pyproject.toml`, no `__pycache__`, no committed venv.
-- `alint://bundled/java@v1` — Maven / Gradle manifest, standard source layout.
-- `alint://bundled/go@v1` — `go.mod`, `go.sum`, no committed `vendor/` without the official workflow.
-- `alint://bundled/compliance/reuse@v1` — FSFE REUSE specification (SPDX headers + `LICENSES/`).
-- `alint://bundled/compliance/apache-2@v1` — Apache 2.0 headers + `NOTICE` file.
-
-Until those ship, you can compose any of them yourself by pairing `extends:` against an HTTPS URL (with SHA-256 SRI) or a local path.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,5 +1,11 @@
 # alint rule catalogue
 
+> **Reading this on GitHub?** This file is the source for the rendered
+> rule reference at <https://alint.org/docs/rules/>, where every rule
+> gets its own page with a generated options table. The root-absolute
+> cross-links below (e.g. `/docs/concepts/...`) resolve there, not on
+> GitHub — open the site for the full, navigable reference.
+
 The full list of rule kinds shipped in alint, organised by family.
 Each rule is one line in your `.alint.yml` under `rules:` — see
 [ARCHITECTURE.md §DSL](design/ARCHITECTURE.md#dsl) for the common

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -351,6 +351,13 @@ Same shape as the `*_equals` variants, but the asserted value is a **regex** mat
   path: "$.Project.ItemGroup.PackageReference[*]['@Version']"
   matches: '^\d'
   level: error
+
+- id: crate-version-is-semver
+  kind: toml_path_matches
+  paths: "crates/*/Cargo.toml"
+  path: "$.package.version"
+  matches: '^\d+\.\d+\.\d+$'
+  level: error
 ```
 
 ### `json_schema_passes`

--- a/xtask/src/docs_export.rs
+++ b/xtask/src/docs_export.rs
@@ -763,6 +763,54 @@ fn rule_meta_description(kind: &str, family_title: &str, body: &str) -> String {
 /// `title` is the bare kind name so URLs and Starlight headings
 /// match what the user types in `.alint.yml`. The page body is
 /// the H3's content plus a "See also" footer for paired rules.
+/// A multi-kind H3 (the structured-query family's `*_path_equals` /
+/// `*_path_matches` groups) shares one example body across every kind's
+/// page — a single block with one rule per kind. Without help, all four
+/// pages lead with the first kind's rule (`json_path_equals`), so they
+/// read like un-edited clones. Bring the rule whose `kind:` matches this
+/// page to the front of the first fenced block so each page leads with
+/// its own kind. No-op for single-rule examples, when the page's kind
+/// isn't a standalone entry, or when it's already first.
+fn lead_example_with_kind(body: &str, kind: &str) -> String {
+    let Some(open) = body.find("```yaml") else {
+        return body.to_string();
+    };
+    let after_fence = open + "```yaml".len();
+    let Some(nl) = body[after_fence..].find('\n') else {
+        return body.to_string();
+    };
+    let content_start = after_fence + nl + 1;
+    let Some(close_rel) = body[content_start..].find("```") else {
+        return body.to_string();
+    };
+    let close = content_start + close_rel;
+
+    // Rule entries are separated by blank lines.
+    let entries: Vec<&str> = body[content_start..close].split("\n\n").collect();
+    if entries.len() < 2 {
+        return body.to_string();
+    }
+    let kind_line = format!("kind: {kind}");
+    let Some(pos) = entries
+        .iter()
+        .position(|e| e.lines().any(|l| l.trim() == kind_line))
+    else {
+        return body.to_string();
+    };
+    if pos == 0 {
+        return body.to_string();
+    }
+    let mut reordered = entries.clone();
+    let chosen = reordered.remove(pos);
+    reordered.insert(0, chosen);
+    format!(
+        "{}{}{}",
+        &body[..content_start],
+        reordered.join("\n\n"),
+        &body[close..]
+    )
+}
+
 // Page-rendering inputs are all distinct scalars/slices; a struct
 // would just relocate the argument list without simplifying callers.
 #[allow(clippy::too_many_arguments)]
@@ -788,7 +836,8 @@ fn emit_rule_page(
     let _ = writeln!(&mut page, "  order: {sidebar_order}");
     let _ = writeln!(&mut page, "---");
     let _ = writeln!(&mut page);
-    page.push_str(body.trim_start_matches('\n'));
+    let body = lead_example_with_kind(body.trim_start_matches('\n'), kind);
+    page.push_str(&body);
     // Authoritative options table, derived from the type-generated
     // JSON Schema (ADR-0001). Injected between the hand-written
     // prose and the "See also" footer so every rule page carries a
@@ -1841,6 +1890,121 @@ fn count_canonical_bundled_rulesets() -> Result<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `lead_example_with_kind` brings the matching-kind rule to the
+    /// front of a multi-variant example, and is a no-op otherwise.
+    #[test]
+    fn lead_example_reorders_multivariant_block() {
+        let body = "\
+```yaml
+- id: a
+  kind: json_path_equals
+  level: error
+
+- id: b
+  kind: yaml_path_equals
+  level: error
+```
+";
+        // yaml page: the yaml rule moves to the front.
+        let out = lead_example_with_kind(body, "yaml_path_equals");
+        let first_kind = out
+            .lines()
+            .find_map(|l| l.trim().strip_prefix("kind: "))
+            .unwrap();
+        assert_eq!(first_kind, "yaml_path_equals");
+        // json page: already first → unchanged.
+        assert_eq!(lead_example_with_kind(body, "json_path_equals"), body);
+        // single-rule example → unchanged.
+        let single = "```yaml\n- id: x\n  kind: file_exists\n```\n";
+        assert_eq!(lead_example_with_kind(single, "file_exists"), single);
+    }
+
+    /// Generate the structured-query rule pages and assert each one's
+    /// first example leads with its OWN kind. Catches the templated-
+    /// clone bug the external evaluation flagged: the four
+    /// `*_path_equals` (and `*_path_matches`) pages all showed
+    /// `kind: json_path_*` because the multi-kind H3's single example
+    /// was fanned out verbatim. Scoped to these families — other
+    /// multi-kind H3s (`for_each_dir`/`for_each_file`, the file_*
+    /// content aliases) deliberately share one example demonstrating
+    /// the group, which reads correctly.
+    #[test]
+    fn structured_query_pages_lead_with_their_own_kind() {
+        const FAMILY_KINDS: &[&str] = &[
+            "json_path_equals",
+            "yaml_path_equals",
+            "toml_path_equals",
+            "xml_path_equals",
+            "json_path_matches",
+            "yaml_path_matches",
+            "toml_path_matches",
+            "xml_path_matches",
+        ];
+        let workspace = crate::bench_release::workspace_root().expect("workspace_root");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        generate_rules_pages(&workspace, tmp.path()).expect("generate rules pages");
+
+        let rules_dir = tmp.path().join("rules");
+        let mut pages: Vec<std::path::PathBuf> = Vec::new();
+        collect_md(&rules_dir, &mut pages);
+        assert!(!pages.is_empty(), "no rule pages were generated");
+
+        let mut checked = 0usize;
+        let mut mismatches: Vec<String> = Vec::new();
+        for page in &pages {
+            let stem = page.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+            if !FAMILY_KINDS.contains(&stem) {
+                continue;
+            }
+            let text = fs::read_to_string(page).unwrap();
+            // First `kind:` inside the first fenced yaml block.
+            let Some(open) = text.find("```yaml") else {
+                continue;
+            };
+            let after = &text[open..];
+            let Some(close) = after[7..].find("```") else {
+                continue;
+            };
+            let block = &after[7..7 + close];
+            let Some(first_kind) = block.lines().find_map(|l| l.trim().strip_prefix("kind: "))
+            else {
+                continue;
+            };
+            checked += 1;
+            if first_kind != stem {
+                mismatches.push(format!(
+                    "{}: first example shows `kind: {first_kind}` but the page is `{stem}`",
+                    page.display()
+                ));
+            }
+        }
+        assert_eq!(
+            checked,
+            FAMILY_KINDS.len(),
+            "expected to check all {} structured-query pages, checked {checked} \
+             (a page or its example went missing)",
+            FAMILY_KINDS.len()
+        );
+        assert!(
+            mismatches.is_empty(),
+            "rule page(s) whose lead example names the wrong kind \
+             (templated-clone regression):\n{}",
+            mismatches.join("\n")
+        );
+    }
+
+    fn collect_md(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+        let Ok(rd) = fs::read_dir(dir) else { return };
+        for entry in rd.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_md(&path, out);
+            } else if path.extension().is_some_and(|e| e == "md") {
+                out.push(path);
+            }
+        }
+    }
 
     /// Pin the `CLI_REFERENCE_SUBCMDS` list against the `enum
     /// Command` variants in `crates/alint/src/main.rs`. If the


### PR DESCRIPTION
Phases 1–2 of the external-evaluation response (`ALINT_CLEAN.md` §2 + §3.1) — the **documentation-correctness** classes, fixed and closed with the gates that were missing. Three commits:

### 1. Schema-invalid config examples (§2) + the `coverage_audit_doc_examples` gate
Hand-written docs restated config syntax in `yaml` examples that **nothing validated**. Fixed ARCHITECTURE.md (map-`rules:`, `query:`/`path:`, phantom facts, `custom argv:`, WASM→v0.14), docs/rules.md (`max:`→`max_width`/`max_depth`, `unique_by select:`, stale "Planned (v0.5)" removed), README `agent` format, CONFIG-AUTHORING.md. The new gate loads **every** fenced config example through the real `alint_dsl::load` + `registry.build` (118 validated/run); it caught the 5 evaluator bugs **+ 8 more**. Plus `coverage_audit_planned_rulesets` (no "Planned" ruleset may already be in facts.json).

### 2. The `*_path_*` templated-clone bug (§2.7) + the `structured_query_pages_lead_with_their_own_kind` gate
The four `*_path_equals` / `*_path_matches` pages all led with `kind: json_path_*` (one shared example fanned out). `emit_rule_page` now reorders so each page leads with its own kind; added the missing `toml_path_matches` example variant. Gate asserts each of the 8 pages leads correctly.

### 3. GitHub-dead doc links (§3.1) + the `coverage_audit_doc_links` gate
A GitHub reader hit dead links: a broken `when.rs` relative link (→ the `when/` module) and root-absolute `/docs/...` links (resolve against github.com). Fixed ARCHITECTURE.md's links to absolute `https://alint.org/...`; docs/rules.md (sliced into the site, where `/docs/...` is correct) gains a "full reference at alint.org" banner. Gate: relative links resolve + no GitHub-dead root-absolute links (allowlisting the sliced dual-purpose files). Verified to fail on a reintroduced dead link.

## Verification
All `alint-e2e` tests, pedantic `ci/scripts/clippy.sh`, `cargo fmt --check`, `docs-export --check`, and `gen-{model,facts}--check` pass.

Note: `[Unreleased]` in CHANGELOG also edited by #80 (Phase 0); trivial reconcile at merge.