### PR TITLE
feat(core): Violation.baseline_key + &Violation fingerprint wrapper (slice 2)

### DIFF
--- a/crates/alint-core/src/baseline.rs
+++ b/crates/alint-core/src/baseline.rs
@@ -16,6 +16,8 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use crate::rule::Violation;
+
 /// The baseline file format this binary reads and writes. A file with
 /// any other version is rejected (§3.9): a newer file may use a
 /// fingerprint scheme this binary computes differently, so silently
@@ -65,6 +67,23 @@ pub fn violation_fingerprint(
         hasher.update(component);
     }
     to_hex(&hasher.finalize())
+}
+
+/// Fingerprint a [`Violation`] directly (a convenience over
+/// [`violation_fingerprint`] that reads the violation's fields). `rule_id`
+/// is passed separately because it lives on the owning `RuleResult`, not
+/// the violation. `file_bytes` is the violation's file content, consulted
+/// only for the line-content discriminator.
+#[must_use]
+pub fn fingerprint(rule_id: &str, v: &Violation, file_bytes: Option<&[u8]>) -> String {
+    violation_fingerprint(
+        rule_id,
+        v.path.as_deref(),
+        v.line,
+        v.baseline_key.as_deref(),
+        &v.message,
+        file_bytes,
+    )
 }
 
 /// Normalise a path to a stable, forward-slashed string so a fingerprint
@@ -454,6 +473,40 @@ mod tests {
             Baseline::load(&bad_entry),
             Err(BaselineError::Parse { what: "entry", .. })
         ));
+    }
+
+    #[test]
+    fn fingerprint_violation_wrapper_reads_fields_incl_baseline_key() {
+        use std::path::Path as P;
+        // Wrapper agrees with the decomposed call for a line violation.
+        let v = Violation::new("msg")
+            .with_path(P::new("a.rs"))
+            .with_location(2, 1);
+        let bytes = b"x\nbad\ny";
+        assert_eq!(
+            fingerprint("r", &v, Some(bytes)),
+            fp("r", Some("a.rs"), Some(2), None, "msg", Some(bytes))
+        );
+        // A baseline_key overrides the line content.
+        let keyed = Violation::new("msg")
+            .with_path(P::new("a.rs"))
+            .with_location(2, 1)
+            .with_baseline_key("$.license");
+        assert_eq!(
+            fingerprint("r", &keyed, Some(bytes)),
+            fp(
+                "r",
+                Some("a.rs"),
+                Some(2),
+                Some("$.license"),
+                "msg",
+                Some(bytes)
+            )
+        );
+        assert_ne!(
+            fingerprint("r", &keyed, Some(bytes)),
+            fingerprint("r", &v, Some(bytes))
+        );
     }
 
     #[test]

--- a/crates/alint-core/src/rule.rs
+++ b/crates/alint-core/src/rule.rs
@@ -35,6 +35,15 @@ pub struct Violation {
     /// into [`RuleResult::notes`] at result-assembly time, so the flag
     /// never reaches a formatter and pass/fail logic is unaffected.
     pub is_note: bool,
+    /// Optional stable structural identity for baseline fingerprinting
+    /// ([`crate::baseline`]). A rule sets this when its violation is not
+    /// uniquely identified by `(path, offending-line content)` — e.g. a
+    /// structured-query rule (the JSONPath/value), a cross-file rule (the
+    /// sorted involved paths), or a first-offender / threshold rule (the
+    /// path). `None` (the default) means "use the offending line's
+    /// content" (see [`crate::baseline::violation_fingerprint`]). It
+    /// never affects rendering or pass/fail.
+    pub baseline_key: Option<Cow<'static, str>>,
 }
 
 impl Violation {
@@ -45,6 +54,7 @@ impl Violation {
             line: None,
             column: None,
             is_note: false,
+            baseline_key: None,
         }
     }
 
@@ -74,6 +84,15 @@ impl Violation {
     pub fn with_location(mut self, line: usize, column: usize) -> Self {
         self.line = Some(line);
         self.column = Some(column);
+        self
+    }
+
+    /// Set the baseline fingerprint key — the rule's stable structural
+    /// identity for this violation. See [`Violation::baseline_key`] and
+    /// [`crate::baseline::violation_fingerprint`].
+    #[must_use]
+    pub fn with_baseline_key(mut self, key: impl Into<Cow<'static, str>>) -> Self {
+        self.baseline_key = Some(key.into());
         self
     }
 }

--- a/crates/alint-lsp/src/lib.rs
+++ b/crates/alint-lsp/src/lib.rs
@@ -854,6 +854,7 @@ mod tests {
             line,
             column,
             is_note: false,
+            baseline_key: None,
         }
     }
 

--- a/crates/alint-output/src/github.rs
+++ b/crates/alint-output/src/github.rs
@@ -134,6 +134,7 @@ mod tests {
                     line: Some(12),
                     column: Some(4),
                     is_note: false,
+                    baseline_key: None,
                 }],
                 notes: Vec::new(),
                 is_fixable: false,

--- a/crates/alint-output/src/gitlab.rs
+++ b/crates/alint-output/src/gitlab.rs
@@ -180,6 +180,7 @@ mod tests {
                     line: Some(12),
                     column: Some(4),
                     is_note: false,
+                    baseline_key: None,
                 }],
             )],
         };
@@ -266,6 +267,7 @@ mod tests {
                     line: Some(0),
                     column: None,
                     is_note: false,
+                    baseline_key: None,
                 }],
             )],
         };
@@ -285,6 +287,7 @@ mod tests {
                     line: Some(7),
                     column: None,
                     is_note: false,
+                    baseline_key: None,
                 }],
             )],
         };
@@ -313,6 +316,7 @@ mod tests {
                     line: Some(line),
                     column: None,
                     is_note: false,
+                    baseline_key: None,
                 }],
             )],
         };
@@ -363,6 +367,7 @@ mod tests {
                     line: Some(1),
                     column: None,
                     is_note: false,
+                    baseline_key: None,
                 }],
             )],
         };

--- a/crates/alint-output/src/junit.rs
+++ b/crates/alint-output/src/junit.rs
@@ -247,6 +247,7 @@ mod tests {
                     line: Some(12),
                     column: Some(4),
                     is_note: false,
+                    baseline_key: None,
                 }],
             )],
         };
@@ -304,6 +305,7 @@ mod tests {
                     line: None,
                     column: None,
                     is_note: false,
+                    baseline_key: None,
                 }],
             )],
         };
@@ -326,6 +328,7 @@ mod tests {
                     line: None,
                     column: None,
                     is_note: false,
+                    baseline_key: None,
                 }],
             )],
         };
@@ -346,6 +349,7 @@ mod tests {
                     line: None,
                     column: None,
                     is_note: false,
+                    baseline_key: None,
                 }],
             )],
         };

--- a/crates/alint-output/src/markdown.rs
+++ b/crates/alint-output/src/markdown.rs
@@ -363,6 +363,7 @@ mod tests {
                     line: Some(12),
                     column: Some(4),
                     is_note: false,
+                    baseline_key: None,
                 }],
             )],
         };
@@ -385,6 +386,7 @@ mod tests {
                         line: None,
                         column: None,
                         is_note: false,
+                        baseline_key: None,
                     }],
                 ),
                 rule(
@@ -396,6 +398,7 @@ mod tests {
                         line: None,
                         column: None,
                         is_note: false,
+                        baseline_key: None,
                     }],
                 ),
             ],
@@ -523,6 +526,7 @@ mod tests {
                     line: Some(7),
                     column: None,
                     is_note: false,
+                    baseline_key: None,
                 }],
             )],
         };
@@ -539,6 +543,7 @@ mod tests {
             line: Some(1),
             column: Some(1),
             is_note: false,
+            baseline_key: None,
         };
         let v2 = Violation {
             path: Some(Path::new("a.rs").into()),
@@ -546,6 +551,7 @@ mod tests {
             line: Some(2),
             column: Some(1),
             is_note: false,
+            baseline_key: None,
         };
         let r1 = Report {
             results: vec![rule("r1", Level::Error, vec![v1.clone(), v2.clone()])],
@@ -578,6 +584,7 @@ mod tests {
                             line: Some(1),
                             column: None,
                             is_note: false,
+                            baseline_key: None,
                         },
                         status: FixStatus::Applied("removed 3 trailing spaces".into()),
                     },
@@ -588,6 +595,7 @@ mod tests {
                             line: None,
                             column: None,
                             is_note: false,
+                            baseline_key: None,
                         },
                         status: FixStatus::Unfixable,
                     },

--- a/crates/alint-output/src/sarif.rs
+++ b/crates/alint-output/src/sarif.rs
@@ -283,6 +283,7 @@ mod tests {
                     line: Some(7),
                     column: Some(3),
                     is_note: false,
+                    baseline_key: None,
                 }],
                 notes: Vec::new(),
                 is_fixable: false,


### PR DESCRIPTION
Slice 2 of **baseline mode** ([ADR-0006](https://github.com/asamarts/alint/blob/main/docs/adr/0006-baseline-suppression.md)). Pure plumbing — **still not wired into `check`/`fix`, zero behavior change.**

- **`Violation.baseline_key: Option<Cow<'static, str>>`** (+ `with_baseline_key` builder, `None` default) — a rule's declaration of its violation's stable structural identity, consumed by the fingerprint when line content isn't a sufficient discriminator. Never affects rendering or pass/fail.
- **`baseline::fingerprint(rule_id, &Violation, file_bytes)`** — convenience over the decomposed `violation_fingerprint`; unit-tested to agree with it and to honour `baseline_key` precedence over line content.
- Mechanically added `baseline_key: None` to the **20** `Violation { .. }` struct literals in test code (alint-output, alint-lsp). Production rules use the builder and are untouched.

## Next (slice 3)
The per-rule key audit — `structured_query` (JSONPath/value), threshold & first-offender rules (path), cross-file kinds (sorted involved paths) set `baseline_key` — plus a coverage-drift gate that forces every new kind to classify itself.

## Gates
Pedantic `ci/scripts/clippy.sh`, `cargo fmt --check`, `RUSTDOCFLAGS=-D warnings cargo doc`, full workspace tests — all pass.