### PR TITLE
ci: make the self-hosted runner reliable (pids-limit + coverage OOM + likec4 gen-mermaid)

### DIFF
--- a/ci/runner/setup.sh
+++ b/ci/runner/setup.sh
@@ -31,6 +31,13 @@ echo "==> Starting runner container: ${CONTAINER_NAME}"
 podman run -d \
     --name "${CONTAINER_NAME}" \
     --restart unless-stopped \
+    `# Raise the PID ceiling well above podman's 2048 default: a parallel` \
+    `# 'cargo llvm-cov --workspace' build spawns thousands of rustc/test` \
+    `# tasks (cgroup-v2 counts threads too) and intermittently exhausted` \
+    `# 2048, starving the runner agent of forks -> it dropped offline` \
+    `# mid-coverage and the job hung. 16384 is 8x headroom, still a` \
+    `# fork-bomb guard. See ci/scripts/coverage.sh.` \
+    --pids-limit 16384 \
     -e GITHUB_REPO_URL="${GITHUB_REPO_URL}" \
     -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
     -e RUNNER_NAME="${RUNNER_NAME:-alint-runner}" \

--- a/ci/scripts/coverage.sh
+++ b/ci/scripts/coverage.sh
@@ -23,6 +23,20 @@ OUT_DIR="${ALINT_COVERAGE_OUT:-target/coverage}"
 # report. `xtask/` excludes the whole xtask crate.
 EXCLUDE_REGEX='xtask/'
 
+# Cap build parallelism to bound peak memory. The instrumented `--workspace`
+# build of the big test crates (proptest + full `-C instrument-coverage`)
+# otherwise OOM-killed rustc (exit 137) on the shared self-hosted CI host when
+# a cold cache forced a full parallel compile under co-tenant load. Half the
+# cores roughly halves peak RSS while keeping the (off-critical-path) coverage
+# build reasonably fast. Override `CARGO_BUILD_JOBS` if you have RAM headroom.
+if [[ -z "${CARGO_BUILD_JOBS:-}" ]]; then
+  _ncpu="$(nproc 2>/dev/null || echo 4)"
+  CARGO_BUILD_JOBS=$(( _ncpu / 2 ))
+  [[ "$CARGO_BUILD_JOBS" -lt 1 ]] && CARGO_BUILD_JOBS=1
+fi
+export CARGO_BUILD_JOBS
+echo "==> CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS} (bounding peak memory)"
+
 if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
   echo "==> Installing cargo-llvm-cov"
   cargo install cargo-llvm-cov --locked

--- a/xtask/src/gen_mermaid.rs
+++ b/xtask/src/gen_mermaid.rs
@@ -104,6 +104,13 @@ fn generate_mmd(root: &Path, out_dir: &Path) -> Result<()> {
             &format!("likec4@{LIKEC4_VERSION}"),
             "gen",
             "mermaid",
+            // Pin the wasm layouter. likec4 auto-detects a container and there
+            // flips `--use-dot` to true (shelling out to a `dot` binary the
+            // slim runner image doesn't ship) — which fails, and would anyway
+            // diverge from the committed wasm-laid-out diagrams. `--no-use-dot`
+            // forces wasm everywhere (local + CI), so the gate is reproducible
+            // and dependency-free. See docs/design/architecture-diagrams.md.
+            "--no-use-dot",
             MODEL_DIR,
             "-o",
         ])


### PR DESCRIPTION
Two coupled fixes to make the self-hosted runner's CI healthy. The first is the request; the second is what the first surfaced.

## 1. Coverage hang — raise the container pids-limit (2048 → 16384)
`cargo-llvm-cov` repeatedly hung the runner (offline mid-job). Root cause: podman's default `--pids-limit=2048`, exhausted by the parallel `cargo llvm-cov --workspace` build (cgroup v2 counts threads). Raised to 16384 in `ci/runner/setup.sh` and **applied to the live runner** (teardown+setup; creds persisted, no re-register). Verified `PidsLimit=16384`; **`cargo-llvm-cov` passed** on the rebuilt runner.

## 2. `gen-mermaid` in the container — pin the wasm layouter (`--no-use-dot`)
Recreating the container for (1) rebuilt the image from the current Containerfile, which installs **Node 22** — flipping on the likec4 `gen-mermaid` gate that had been *skipped* for lack of npx (the long-pending "Node-22 runner rebuild"). It then failed: likec4 **auto-detects a container and defaults `--use-dot` to true**, shelling out to a `dot` binary the slim image doesn't ship → `not found: dot`. Fix: pass `--no-use-dot` in `xtask/gen_mermaid.rs` to pin the **wasm** layouter everywhere — which also matches the committed (wasm-laid-out) diagrams, so no graphviz / image rebuild is needed.

**Verified:** `gen-mermaid --check` green locally (27 diagrams) and likec4 lays out all 40 views via wasm **inside the runner container** (Node 22.23, no dot). This completes the Node-22 enablement: `likec4 validate` + `gen-mermaid --check` are now real CI gates instead of silently skipped.

## Validation
This PR's own CI exercises both on the fixed runner — a green `cargo-llvm-cov` **and** `Docs` here confirms it end-to-end.

## Follow-up (separate)
Add `timeout-minutes:` to `coverage.yml` so any future hang self-fails fast instead of sitting at the 6h default.
