### PR TITLE
ci(coverage): add timeout-minutes (90) to coverage.yml

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,6 +24,13 @@ jobs:
   coverage:
     name: cargo-llvm-cov
     runs-on: [self-hosted, linux, alint]
+    # Self-fail fast if the runner ever hangs again, instead of sitting at the
+    # 360-min GitHub default and holding the single self-hosted runner. 90 min
+    # comfortably covers a cold-cache, parallelism-capped instrumented build
+    # (typical warm runs finish in minutes); well under bench's 360 / mutants'
+    # 240. The pids-limit + CARGO_BUILD_JOBS fixes should keep hangs from
+    # recurring — this is the belt-and-suspenders net.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
The final follow-up from the runner-reliability work (#90). `coverage.yml` had no `timeout-minutes`, so a hung `cargo-llvm-cov` sat at GitHub's 360-min default and held the single self-hosted runner. Adds a 90-min cap — comfortably above a cold-cache, parallelism-capped instrumented build (warm runs finish in minutes), well under bench's 360 / mutants' 240. The pids-limit + `CARGO_BUILD_JOBS` fixes should prevent hangs recurring; this is the belt-and-suspenders net. This PR's own coverage run validates the workflow + the new cap.