### PR TITLE
feat(baseline): mark (not remove) baselined findings in SARIF + JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   never from an `extends:`'d or nested config — so a published ruleset can't
   choose what the gate suppresses, and a config key pointing at a missing file is
   the same hard error as a missing `--baseline` (never a silent ungated run).
-  (Per-format SARIF suppression marking is the remaining follow-up; see
-  `docs/design/baseline.md` / ADR-0006.)
+  For **SARIF**, baselined findings are *marked, not removed* — re-emitted with
+  `suppressions: [{ kind: "external" }]` + `baselineState: "unchanged"` +
+  `partialFingerprints`, so GitHub Code Scanning dismisses (rather than
+  closes-then-reopens) the alert; live findings carry `baselineState: "new"` + a
+  fingerprint for run-to-run correlation. The `json` envelope gains a
+  `baselined_suppressed` count (and the suppressed list under `--show-baselined`).
+  See `docs/design/baseline.md` / ADR-0006.
 - `--only <RULE_ID>` on `check` and `fix` (repeatable): restrict the run to the
   named rule id(s) from the effective config. An id that matches no loaded rule
   is an error, so typos fail loudly. This is the command the `agent` output

--- a/crates/alint-core/src/baseline.rs
+++ b/crates/alint-core/src/baseline.rs
@@ -293,6 +293,10 @@ pub struct FingerprintedViolation {
 pub struct SuppressedViolation {
     pub rule_id: std::sync::Arc<str>,
     pub violation: Violation,
+    /// The matched baseline fingerprint — emitted as SARIF
+    /// `partialFingerprints` so Code Scanning correlation aligns with the
+    /// baseline.
+    pub fingerprint: String,
 }
 
 /// The result of applying a baseline to a [`Report`].
@@ -300,9 +304,8 @@ pub struct SuppressedViolation {
 pub struct AppliedBaseline {
     /// The report with baselined violations removed — only **new**
     /// violations remain, so the exit code and the primary formatter
-    /// output reflect the delta. (Per-format "mark not remove" — keeping
-    /// suppressed results in SARIF — is wired in a later slice using
-    /// [`Self::suppressed`].)
+    /// output reflect the delta. SARIF re-emits the suppressed findings
+    /// "marked not removed" (see [`Self::suppressed`] + [`Self::live_fingerprints`]).
     pub live: Report,
     /// Every suppressed violation (for `--show-baselined` / SARIF marking).
     pub suppressed: Vec<SuppressedViolation>,
@@ -313,6 +316,11 @@ pub struct AppliedBaseline {
     pub stale: Vec<BaselineEntry>,
     /// Total suppressed occurrences (sum across all fingerprints).
     pub suppressed_total: u64,
+    /// Fingerprints of the **live** violations, parallel to
+    /// [`live`](Self::live)`.results` (outer) and each result's `violations`
+    /// (inner, in the same deterministic order `apply` emits them). Lets SARIF
+    /// stamp `partialFingerprints` on new findings without recomputing them.
+    pub live_fingerprints: Vec<Vec<String>>,
 }
 
 /// Apply a baseline to a report: suppress up to each fingerprint's
@@ -341,6 +349,7 @@ where
     let mut suppressed = Vec::new();
     let mut suppressed_total = 0u64;
     let mut live_results = Vec::with_capacity(report.results.len());
+    let mut live_fingerprints: Vec<Vec<String>> = Vec::with_capacity(report.results.len());
 
     for result in &report.results {
         // Stable match order so suppression is deterministic regardless
@@ -349,6 +358,7 @@ where
         ordered.sort_by(|a, b| order_key(a).cmp(&order_key(b)));
 
         let mut live = Vec::new();
+        let mut live_fps = Vec::new();
         for v in ordered {
             let fp = fingerprint_of(&result.rule_id, v);
             if let Some(count) = remaining.get_mut(fp.as_str()).filter(|c| **c > 0) {
@@ -357,15 +367,18 @@ where
                 suppressed.push(SuppressedViolation {
                     rule_id: result.rule_id.clone(),
                     violation: v.clone(),
+                    fingerprint: fp,
                 });
             } else {
                 live.push(v.clone());
+                live_fps.push(fp);
             }
         }
 
         let mut r = result.clone();
         r.violations = live;
         live_results.push(r);
+        live_fingerprints.push(live_fps);
     }
 
     let stale = baseline
@@ -387,6 +400,7 @@ where
         suppressed,
         stale,
         suppressed_total,
+        live_fingerprints,
     }
 }
 

--- a/crates/alint-output/src/json.rs
+++ b/crates/alint-output/src/json.rs
@@ -4,11 +4,18 @@ use std::path::Path;
 use alint_core::{FixReport, FixStatus, Level, Report};
 use serde::Serialize;
 
+use crate::BaselineMarks;
+
 #[derive(Serialize)]
 struct JsonReport<'a> {
     schema_version: u32,
     summary: Summary,
     results: Vec<JsonResult<'a>>,
+    /// The baselined (suppressed) findings, included only under
+    /// `--show-baselined`; omitted otherwise so non-baseline output stays
+    /// byte-identical.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    baselined: Option<Vec<JsonBaselined<'a>>>,
 }
 
 #[derive(Serialize)]
@@ -18,6 +25,24 @@ struct Summary {
     total_violations: usize,
     has_errors: bool,
     has_warnings: bool,
+    /// Occurrences suppressed by the baseline this run, when one is in effect.
+    /// Absent without `--baseline` so the envelope is unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    baselined_suppressed: Option<u64>,
+}
+
+/// A baselined finding in the JSON envelope's `baselined` list.
+#[derive(Serialize)]
+struct JsonBaselined<'a> {
+    id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<&'a Path>,
+    message: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    line: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    column: Option<usize>,
+    fingerprint: &'a str,
 }
 
 #[derive(Serialize)]
@@ -51,12 +76,25 @@ struct JsonViolation<'a> {
 }
 
 pub fn write_json(report: &Report, w: &mut dyn Write) -> std::io::Result<()> {
+    write_json_with_baseline(report, None, false, w)
+}
+
+/// JSON with baseline awareness: the summary gains a `baselined_suppressed`
+/// count, and (under `show_baselined`) the envelope gains a `baselined` list of
+/// the suppressed findings. Without a baseline the envelope is byte-identical.
+pub fn write_json_with_baseline(
+    report: &Report,
+    baseline: Option<&BaselineMarks>,
+    show_baselined: bool,
+    w: &mut dyn Write,
+) -> std::io::Result<()> {
     let summary = Summary {
         failing_rules: report.failing_rules(),
         passing_rules: report.passing_rules(),
         total_violations: report.total_violations(),
         has_errors: report.has_errors(),
         has_warnings: report.has_warnings(),
+        baselined_suppressed: baseline.map(|b| b.suppressed_total),
     };
     let results: Vec<JsonResult<'_>> = report
         .results
@@ -89,10 +127,32 @@ pub fn write_json(report: &Report, w: &mut dyn Write) -> std::io::Result<()> {
                 .collect(),
         })
         .collect();
+    let baselined = if show_baselined {
+        baseline.map(|b| {
+            report
+                .results
+                .iter()
+                .zip(&b.per_result)
+                .flat_map(|(rr, m)| {
+                    m.suppressed.iter().map(move |sf| JsonBaselined {
+                        id: rr.rule_id.as_ref(),
+                        path: sf.violation.path.as_deref(),
+                        message: sf.violation.message.as_ref(),
+                        line: sf.violation.line,
+                        column: sf.violation.column,
+                        fingerprint: sf.fingerprint.as_str(),
+                    })
+                })
+                .collect()
+        })
+    } else {
+        None
+    };
     let out = JsonReport {
         schema_version: 1,
         summary,
         results,
+        baselined,
     };
     serde_json::to_writer_pretty(&mut *w, &out)?;
     writeln!(w)?;
@@ -221,5 +281,58 @@ mod tests {
             !out.contains("\"notes\""),
             "empty notes must be omitted: {out}"
         );
+    }
+
+    #[test]
+    fn baseline_adds_suppressed_count_and_list() {
+        use crate::{BaselineMarks, ResultMarks, SuppressedFinding};
+        let r = RuleResult::new(
+            "no-todo".into(),
+            Level::Error,
+            None,
+            vec![Violation::new("new")],
+            false,
+        );
+        let report = Report { results: vec![r] };
+        let marks = BaselineMarks {
+            per_result: vec![ResultMarks {
+                live_fingerprints: vec!["fp-live".into()],
+                suppressed: vec![SuppressedFinding {
+                    violation: Violation::new("old"),
+                    fingerprint: "fp-supp".into(),
+                }],
+            }],
+            suppressed_total: 1,
+        };
+        let mut buf = Vec::new();
+        write_json_with_baseline(&report, Some(&marks), true, &mut buf).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+        assert_eq!(v["summary"]["baselined_suppressed"], 1);
+        let baselined = v["baselined"].as_array().unwrap();
+        assert_eq!(baselined.len(), 1);
+        assert_eq!(baselined[0]["id"], "no-todo");
+        assert_eq!(baselined[0]["message"], "old");
+        assert_eq!(baselined[0]["fingerprint"], "fp-supp");
+
+        // Without `--show-baselined` the list is omitted but the count stays.
+        let mut buf2 = Vec::new();
+        write_json_with_baseline(&report, Some(&marks), false, &mut buf2).unwrap();
+        let v2: serde_json::Value = serde_json::from_slice(&buf2).unwrap();
+        assert_eq!(v2["summary"]["baselined_suppressed"], 1);
+        assert!(v2.get("baselined").is_none());
+    }
+
+    #[test]
+    fn no_baseline_omits_suppressed_fields() {
+        let r = RuleResult::new(
+            "r".into(),
+            Level::Error,
+            None,
+            vec![Violation::new("v")],
+            false,
+        );
+        let out = render(&Report { results: vec![r] });
+        assert!(!out.contains("baselined_suppressed"), "{out}");
+        assert!(!out.contains("\"baselined\""), "{out}");
     }
 }

--- a/crates/alint-output/src/lib.rs
+++ b/crates/alint-output/src/lib.rs
@@ -20,11 +20,44 @@ pub use agent::write_agent;
 pub use github::write_github;
 pub use gitlab::write_gitlab;
 pub use human::{wrap_message, write_fix_human, write_human};
-pub use json::{write_fix_json, write_json};
+pub use json::{write_fix_json, write_json, write_json_with_baseline};
 pub use junit::write_junit;
 pub use markdown::{write_fix_markdown, write_markdown};
-pub use sarif::write_sarif;
+pub use sarif::{write_sarif, write_sarif_with_baseline};
 pub use style::{ColorChoice, GlyphSet, HumanOptions};
+
+/// Per-result baseline output, threaded into the SARIF and JSON emitters so
+/// they render baselined findings "marked, not removed" (SARIF) or counted
+/// (JSON). Built by the CLI from [`alint_core::baseline::apply`]; the
+/// [`per_result`](Self::per_result) vector is parallel to the live report's
+/// `results`. Only the SARIF and JSON formatters consult it; the rest ignore
+/// the baseline entirely and emit only the live (new) findings.
+#[derive(Debug, Clone, Default)]
+pub struct BaselineMarks {
+    /// One entry per `Report.results`, in the same index/order.
+    pub per_result: Vec<ResultMarks>,
+    /// Total suppressed occurrences across all rules (for the JSON envelope).
+    pub suppressed_total: u64,
+}
+
+/// The baseline marks for one rule's result.
+#[derive(Debug, Clone, Default)]
+pub struct ResultMarks {
+    /// The fingerprint of each LIVE violation, parallel to the result's
+    /// `violations` (so SARIF can stamp `partialFingerprints` on new findings).
+    pub live_fingerprints: Vec<String>,
+    /// The baselined (suppressed) findings of this rule, each with its
+    /// fingerprint — re-emitted by SARIF as dismissed (`suppressions`).
+    pub suppressed: Vec<SuppressedFinding>,
+}
+
+/// A baselined finding carried to the formatters: the violation plus its
+/// matched baseline fingerprint.
+#[derive(Debug, Clone)]
+pub struct SuppressedFinding {
+    pub violation: alint_core::Violation,
+    pub fingerprint: String,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Format {

--- a/crates/alint-output/src/sarif.rs
+++ b/crates/alint-output/src/sarif.rs
@@ -8,23 +8,45 @@
 //! a subset of SARIF 2.1.0 — just enough that GitHub renders the findings
 //! in the Security → Code scanning tab.
 
+use std::collections::BTreeMap;
 use std::io::Write;
 
-use alint_core::{Level, Report};
+use alint_core::{Level, Report, Violation};
 use serde::Serialize;
 
+use crate::{BaselineMarks, ResultMarks};
+
+/// `partialFingerprints` key carrying alint's baseline fingerprint, so GitHub
+/// Code Scanning's alert correlation aligns with the baseline.
+const FINGERPRINT_KEY: &str = "alint/v1";
+
 pub fn write_sarif(report: &Report, w: &mut dyn Write) -> std::io::Result<()> {
-    let sarif = build_sarif(report);
+    write_sarif_with_baseline(report, None, w)
+}
+
+/// SARIF with baseline awareness. When `baseline` is supplied (a baseline is in
+/// effect), every **live** finding gains `baselineState: "new"` +
+/// `partialFingerprints`, and each **baselined** finding is re-emitted — not
+/// dropped — with `suppressions: [{ "kind": "external" }]` +
+/// `baselineState: "unchanged"`, so GitHub Code Scanning keeps the alert
+/// dismissed-not-fixed (no close/reopen flapping). Without a baseline the
+/// output is unchanged.
+pub fn write_sarif_with_baseline(
+    report: &Report,
+    baseline: Option<&BaselineMarks>,
+    w: &mut dyn Write,
+) -> std::io::Result<()> {
+    let sarif = build_sarif(report, baseline);
     serde_json::to_writer_pretty(&mut *w, &sarif)?;
     writeln!(w)?;
     Ok(())
 }
 
-fn build_sarif(report: &Report) -> Sarif {
+fn build_sarif(report: &Report, baseline: Option<&BaselineMarks>) -> Sarif {
     let mut rules = Vec::with_capacity(report.results.len());
     let mut results = Vec::new();
 
-    for rr in &report.results {
+    for (idx, rr) in report.results.iter().enumerate() {
         rules.push(SarifRule {
             id: rr.rule_id.to_string(),
             short_description: SarifText {
@@ -33,35 +55,28 @@ fn build_sarif(report: &Report) -> Sarif {
             help_uri: rr.policy_url.as_deref().map(str::to_string),
         });
 
-        for v in &rr.violations {
-            let region = if v.line.is_some() || v.column.is_some() {
-                Some(SarifRegion {
-                    start_line: v.line,
-                    start_column: v.column,
-                })
-            } else {
-                None
-            };
-            let locations = if let Some(path) = &v.path {
-                vec![SarifLocation {
-                    physical_location: SarifPhysicalLocation {
-                        artifact_location: SarifArtifactLocation {
-                            uri: path.display().to_string(),
-                        },
-                        region,
-                    },
-                }]
-            } else {
-                Vec::new()
-            };
-            results.push(SarifResult {
-                rule_id: rr.rule_id.to_string(),
-                level: level_to_sarif(rr.level),
-                message: SarifText {
-                    text: v.message.to_string(),
-                },
-                locations,
-            });
+        let marks: Option<&ResultMarks> = baseline.and_then(|b| b.per_result.get(idx));
+
+        // Live (new) findings — drive the exit code; tagged `new` under a baseline.
+        for (vi, v) in rr.violations.iter().enumerate() {
+            let mut res = base_result(rr.rule_id.as_ref(), rr.level, v);
+            if let Some(fp) = marks.and_then(|m| m.live_fingerprints.get(vi)) {
+                res.baseline_state = Some("new");
+                res.partial_fingerprints = Some(fingerprint_map(fp));
+            }
+            results.push(res);
+        }
+
+        // Baselined findings — marked, not removed, so Code Scanning dismisses
+        // (rather than closes-then-reopens) the alert.
+        if let Some(m) = marks {
+            for sf in &m.suppressed {
+                let mut res = base_result(rr.rule_id.as_ref(), rr.level, &sf.violation);
+                res.suppressions = vec![SarifSuppression { kind: "external" }];
+                res.baseline_state = Some("unchanged");
+                res.partial_fingerprints = Some(fingerprint_map(&sf.fingerprint));
+                results.push(res);
+            }
         }
     }
 
@@ -89,6 +104,47 @@ fn level_to_sarif(l: Level) -> &'static str {
         Level::Info => "note",
         Level::Off => "none",
     }
+}
+
+/// A SARIF result with the shared fields filled in (no baseline annotations).
+fn base_result(rule_id: &str, level: Level, v: &Violation) -> SarifResult {
+    let region = if v.line.is_some() || v.column.is_some() {
+        Some(SarifRegion {
+            start_line: v.line,
+            start_column: v.column,
+        })
+    } else {
+        None
+    };
+    let locations = if let Some(path) = &v.path {
+        vec![SarifLocation {
+            physical_location: SarifPhysicalLocation {
+                artifact_location: SarifArtifactLocation {
+                    uri: path.display().to_string(),
+                },
+                region,
+            },
+        }]
+    } else {
+        Vec::new()
+    };
+    SarifResult {
+        rule_id: rule_id.to_string(),
+        level: level_to_sarif(level),
+        message: SarifText {
+            text: v.message.to_string(),
+        },
+        locations,
+        suppressions: Vec::new(),
+        baseline_state: None,
+        partial_fingerprints: None,
+    }
+}
+
+fn fingerprint_map(fp: &str) -> BTreeMap<&'static str, String> {
+    let mut m = BTreeMap::new();
+    m.insert(FINGERPRINT_KEY, fp.to_string());
+    m
 }
 
 // ─── SARIF serde types ───────────────────────────────────────────────
@@ -142,6 +198,26 @@ struct SarifResult {
     level: &'static str,
     message: SarifText,
     locations: Vec<SarifLocation>,
+    /// `[{ "kind": "external" }]` for a baselined finding; empty otherwise.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    suppressions: Vec<SarifSuppression>,
+    /// `"new"` for a live finding under a baseline, `"unchanged"` for a
+    /// baselined one; absent when no baseline is in effect.
+    #[serde(rename = "baselineState", skip_serializing_if = "Option::is_none")]
+    baseline_state: Option<&'static str>,
+    /// The alint baseline fingerprint, for Code Scanning alert correlation.
+    #[serde(
+        rename = "partialFingerprints",
+        skip_serializing_if = "Option::is_none"
+    )]
+    partial_fingerprints: Option<BTreeMap<&'static str, String>>,
+}
+
+/// A SARIF `suppression` — alint emits `kind: "external"` for findings
+/// dismissed by the committed baseline file.
+#[derive(Serialize)]
+struct SarifSuppression {
+    kind: &'static str,
 }
 
 #[derive(Serialize)]
@@ -311,5 +387,72 @@ mod tests {
         let v = render(&report);
         let locs = v["runs"][0]["results"][0]["locations"].as_array().unwrap();
         assert!(locs.is_empty());
+    }
+
+    #[test]
+    fn baseline_marks_suppressed_and_tags_live_findings() {
+        use crate::{BaselineMarks, ResultMarks, SuppressedFinding};
+        let report = Report {
+            results: vec![RuleResult {
+                rule_id: "no-todo".into(),
+                level: Level::Error,
+                policy_url: None,
+                violations: vec![Violation::new("new TODO").with_path(Path::new("b.txt"))],
+                notes: Vec::new(),
+                is_fixable: false,
+            }],
+        };
+        let marks = BaselineMarks {
+            per_result: vec![ResultMarks {
+                live_fingerprints: vec!["fp-live".into()],
+                suppressed: vec![SuppressedFinding {
+                    violation: Violation::new("old TODO").with_path(Path::new("a.txt")),
+                    fingerprint: "fp-supp".into(),
+                }],
+            }],
+            suppressed_total: 1,
+        };
+        let mut buf = Vec::new();
+        write_sarif_with_baseline(&report, Some(&marks), &mut buf).unwrap();
+        let v: Value = serde_json::from_slice(&buf).unwrap();
+        let results = v["runs"][0]["results"].as_array().unwrap();
+        assert_eq!(
+            results.len(),
+            2,
+            "live + suppressed both emitted (marked, not removed)"
+        );
+
+        // The live (new) finding is tagged but not suppressed.
+        let live = &results[0];
+        assert_eq!(live["message"]["text"], "new TODO");
+        assert_eq!(live["baselineState"], "new");
+        assert_eq!(live["partialFingerprints"]["alint/v1"], "fp-live");
+        assert!(live.get("suppressions").is_none());
+
+        // The baselined finding is re-emitted, marked dismissed-not-fixed.
+        let supp = &results[1];
+        assert_eq!(supp["message"]["text"], "old TODO");
+        assert_eq!(supp["baselineState"], "unchanged");
+        assert_eq!(supp["suppressions"][0]["kind"], "external");
+        assert_eq!(supp["partialFingerprints"]["alint/v1"], "fp-supp");
+    }
+
+    #[test]
+    fn no_baseline_leaves_results_unannotated() {
+        let report = Report {
+            results: vec![RuleResult {
+                rule_id: "r".into(),
+                level: Level::Error,
+                policy_url: None,
+                violations: vec![Violation::new("v").with_path(Path::new("f"))],
+                notes: Vec::new(),
+                is_fixable: false,
+            }],
+        };
+        let v = render(&report); // write_sarif — no baseline
+        let r = &v["runs"][0]["results"][0];
+        assert!(r.get("baselineState").is_none());
+        assert!(r.get("suppressions").is_none());
+        assert!(r.get("partialFingerprints").is_none());
     }
 }

--- a/crates/alint/src/main.rs
+++ b/crates/alint/src/main.rs
@@ -759,7 +759,7 @@ fn cmd_check(path: &Path, changed: &ChangedMode, only: &[String], cli: &Cli) -> 
     // recorded violations, leaving only new ones to format + gate on.
     let mut strict_stale_fail = false;
     let effective_baseline = cli.baseline.clone().or(config_baseline);
-    let report = if let Some(baseline_path) = &effective_baseline {
+    let (report, baseline_marks) = if let Some(baseline_path) = &effective_baseline {
         let baseline = load_baseline(baseline_path)?;
         let mut reader = FileReader::new(path);
         let applied =
@@ -768,16 +768,30 @@ fn cmd_check(path: &Path, changed: &ChangedMode, only: &[String], cli: &Cli) -> 
         if cli.strict_baseline && !applied.stale.is_empty() {
             strict_stale_fail = true;
         }
-        applied.live
+        let marks = build_baseline_marks(&applied);
+        (applied.live, Some(marks))
     } else {
-        report
+        (report, None)
     };
 
     let format: Format = cli.format.parse().map_err(|e: String| anyhow::anyhow!(e))?;
     let (mut out, opts) = render_env(cli)?;
-    format
-        .write_with_options(&report, &mut out, opts)
-        .context("writing output")?;
+    // SARIF and JSON render baselined findings (marked / counted) so Code
+    // Scanning dismisses rather than re-opens them; every other format ignores
+    // the baseline and emits only the live (new) findings.
+    match (format, baseline_marks.as_ref()) {
+        (Format::Sarif, Some(marks)) => {
+            alint_output::write_sarif_with_baseline(&report, Some(marks), &mut out)
+        }
+        (Format::Json, Some(marks)) => alint_output::write_json_with_baseline(
+            &report,
+            Some(marks),
+            cli.show_baselined,
+            &mut out,
+        ),
+        _ => format.write_with_options(&report, &mut out, opts),
+    }
+    .context("writing output")?;
     out.flush().ok();
 
     // Informational notes (non-violation findings) — surfaced on
@@ -828,6 +842,44 @@ impl<'a> FileReader<'a> {
             None => None,
         };
         alint_core::baseline::fingerprint(rule_id, v, bytes)
+    }
+}
+
+/// Build the per-result baseline marks the SARIF/JSON formatters consume:
+/// each live violation's fingerprint (parallel to the result's `violations`)
+/// and the suppressed findings grouped onto their producing rule.
+fn build_baseline_marks(
+    applied: &alint_core::baseline::AppliedBaseline,
+) -> alint_output::BaselineMarks {
+    use std::collections::HashMap;
+
+    let mut by_rule: HashMap<&str, Vec<alint_output::SuppressedFinding>> = HashMap::new();
+    for s in &applied.suppressed {
+        by_rule
+            .entry(s.rule_id.as_ref())
+            .or_default()
+            .push(alint_output::SuppressedFinding {
+                violation: s.violation.clone(),
+                fingerprint: s.fingerprint.clone(),
+            });
+    }
+    let per_result = applied
+        .live
+        .results
+        .iter()
+        .enumerate()
+        .map(|(i, rr)| alint_output::ResultMarks {
+            live_fingerprints: applied
+                .live_fingerprints
+                .get(i)
+                .cloned()
+                .unwrap_or_default(),
+            suppressed: by_rule.remove(rr.rule_id.as_ref()).unwrap_or_default(),
+        })
+        .collect();
+    alint_output::BaselineMarks {
+        per_result,
+        suppressed_total: applied.suppressed_total,
     }
 }
 

--- a/crates/alint/tests/baseline_cli.rs
+++ b/crates/alint/tests/baseline_cli.rs
@@ -285,3 +285,49 @@ fn baseline_flag_overrides_the_config_key() {
         "config key points at a missing file → hard error, proving it's consulted",
     );
 }
+
+/// `check --baseline --format sarif` MARKS baselined findings (suppressions +
+/// baselineState:unchanged) instead of dropping them, so GitHub Code Scanning
+/// dismisses rather than closes-then-reopens the alert. A fully-baselined repo
+/// still exits 0 — the exit code is gated on live findings only.
+#[test]
+fn sarif_marks_baselined_findings_not_removed() {
+    let d = fixture();
+    let root = d.path();
+    assert_eq!(
+        code(&run(root, &["baseline"])),
+        0,
+        "snapshot the 2 findings"
+    );
+
+    let out = run(
+        root,
+        &[
+            "check",
+            "--baseline",
+            ".alint-baseline.json",
+            "--format",
+            "sarif",
+        ],
+    );
+    assert_eq!(
+        code(&out),
+        0,
+        "fully-baselined → exit 0 (gated on live only)"
+    );
+    let sarif = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        sarif.matches("\"baselineState\": \"unchanged\"").count(),
+        2,
+        "both baselined findings are emitted + marked, not removed:\n{sarif}",
+    );
+    assert_eq!(
+        sarif.matches("\"kind\": \"external\"").count(),
+        2,
+        "each baselined finding carries an external suppression",
+    );
+    assert!(
+        sarif.contains("\"partialFingerprints\""),
+        "fingerprints present for Code Scanning correlation",
+    );
+}

--- a/docs/design/baseline.md
+++ b/docs/design/baseline.md
@@ -1,6 +1,9 @@
 # Design doc: baseline mode (grandfathering existing violations)
 
-Status: Draft (v3, after an implementation-time audit). (Draft | Implemented in <commit> | Superseded by <doc>.)
+Status: Implemented. Shipped across the slice series (engine, fingerprint, CLI),
+the per-rule `baseline_key` audit (v3), the `baseline:` config key, and the
+per-format SARIF suppression marking + JSON `baselined_suppressed` (§3.8 — the
+final piece). (Draft | Implemented | Superseded by <doc>.)
 Decisions: [ADR-0006](../adr/0006-baseline-suppression.md) — **Accepted (2026-06-21)** (new persistent suppression mechanism; affects pass/fail semantics).
 Demand evidence: External adoption evaluation, §4.1 — *"the single feature that makes ESLint/RuboCop/etc. adoptable on legacy code, and its absence is the #1 thing that stops a team from flipping alint on as a merge gate."* Reproduced firsthand against alint 0.13.0.
 Target version: Phase 4, unscheduled (post-v0.14). Draft for review; resolve §7 before implementation and move it under the assigned `docs/design/vX.Y/` directory then.


### PR DESCRIPTION
## What

Under a baseline, SARIF/JSON output previously **dropped** the suppressed findings. GitHub Code Scanning reads a vanished result as *fixed*, so the next un-baselined run **reopens every alert** — the dismissal never sticks and the Security tab flaps on each push.

This re-emits baselined findings **marked, not removed**:

- **SARIF** — each baselined result carries `suppressions: [{ "kind": "external" }]` + `baselineState: "unchanged"`; each live result carries `baselineState: "new"`. Every result gets a stable `partialFingerprints` (`"alint/v1"` = the baseline fingerprint) so Code Scanning correlates the alert to the baseline and **dismisses** rather than closes-then-reopens.
- **JSON** — `summary.baselined_suppressed` count (always), plus a `baselined` list with fingerprints under `--show-baselined`.

## How

Plumbed through dedicated `write_{sarif,json}_with_baseline` writers + a `BaselineMarks` side-channel, rather than adding a `fingerprint` field to the core `Violation` (constructed by 47 struct literals). `apply()` now returns the live findings' fingerprints alongside the suppressed ones.

The **exit code is unchanged** — still gated on live findings only, so a fully-baselined repo stays exit 0 while emitting the marked alerts.

## Tests

- `alint-output`: 4 new unit tests (2 SARIF: marks suppressed + tags live / no-baseline leaves results unannotated; 2 JSON: adds suppressed count+list / omits the fields without a baseline).
- `alint` e2e: `sarif_marks_baselined_findings_not_removed` — baselines 2 findings, asserts `--format sarif` emits both with `baselineState: "unchanged"` + `kind: "external"` + `partialFingerprints`, exit 0.
- Full preflight green: fmt, pedantic clippy (`-D warnings`), rustdoc (`-D warnings`), all three gen-* drift checks, whole workspace test suite.

## Context

Last deferred baseline follow-up. Baseline mode is now **feature-complete**: engine + fingerprint + CLI + `baseline_key` audit (v3) + `baseline:` config key + per-format suppression marking.
