### PR TITLE
harden(baseline): audit follow-ups — correctness, robustness, perf, docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   closes-then-reopens) the alert; live findings carry `baselineState: "new"` + a
   fingerprint for run-to-run correlation. The `json` envelope gains a
   `baselined_suppressed` count (and the suppressed list under `--show-baselined`).
+  Robustness: loading a baseline **sums** duplicate fingerprints (so a git-merged
+  file suppresses the total, not the last writer's count); regeneration is
+  byte-identical across runs and its guard counts new *occurrences* (a higher
+  count on an existing finding is fresh debt too, not just new fingerprints).
   See `docs/design/baseline.md` / ADR-0006.
 - `--only <RULE_ID>` on `check` and `fix` (repeatable): restrict the run to the
   named rule id(s) from the effective config. An id that matches no loaded rule

--- a/crates/alint-core/src/baseline.rs
+++ b/crates/alint-core/src/baseline.rs
@@ -185,26 +185,41 @@ pub struct Baseline {
 impl Baseline {
     /// Build a baseline by aggregating fingerprinted violations: entries
     /// with the same fingerprint collapse into one with a `count`. The
-    /// advisory `rule_id`/`path`/`message` come from the first
-    /// occurrence of each fingerprint. Output entries are sorted for a
-    /// deterministic, merge-friendly file.
+    /// advisory `rule_id`/`path` are invariant within a fingerprint; the
+    /// advisory `message` is the lexicographically smallest of the group, so
+    /// the file is byte-identical across regenerations regardless of the
+    /// order the engine collected violations in. Output entries are sorted
+    /// for a deterministic, merge-friendly file.
     pub fn from_fingerprints<I>(alint_version: Option<String>, items: I) -> Self
     where
         I: IntoIterator<Item = FingerprintedViolation>,
     {
-        // Group by fingerprint, preserving first-seen advisory fields.
+        // Group by fingerprint. `rule_id` and `path` are invariant within a
+        // fingerprint (both are hashed into it), but the advisory `message`
+        // is NOT — a path-identity or shared-key group can collapse
+        // violations whose messages differ, and `items` arrives in the
+        // engine's collection order. Pin the lexicographically smallest
+        // message so the committed file is byte-identical across
+        // regenerations even if that order ever shifts.
         let mut by_fp: BTreeMap<String, BaselineEntry> = BTreeMap::new();
         for item in items {
-            by_fp
-                .entry(item.fingerprint.clone())
-                .and_modify(|e| e.count += 1)
-                .or_insert(BaselineEntry {
-                    rule_id: item.rule_id,
-                    path: item.path,
-                    fingerprint: item.fingerprint,
-                    count: 1,
-                    message: item.message,
-                });
+            if let Some(e) = by_fp.get_mut(&item.fingerprint) {
+                e.count += 1;
+                if item.message < e.message {
+                    e.message = item.message;
+                }
+            } else {
+                by_fp.insert(
+                    item.fingerprint.clone(),
+                    BaselineEntry {
+                        rule_id: item.rule_id,
+                        path: item.path,
+                        fingerprint: item.fingerprint,
+                        count: 1,
+                        message: item.message,
+                    },
+                );
+            }
         }
         let mut entries: Vec<BaselineEntry> = by_fp.into_values().collect();
         entries.sort_by(|a, b| {
@@ -255,14 +270,29 @@ impl Baseline {
             });
         }
 
-        let mut entries = Vec::new();
+        // Collapse duplicate fingerprints by SUMMING counts. A freshly
+        // written baseline has none (`from_fingerprints` dedups), but the
+        // file is line-oriented to be merge-friendly: a git merge of two
+        // baselines that each recorded the same finding — or a hand-edit —
+        // can leave two entries with one fingerprint. Summing keeps the
+        // suppression budget the total (not the last writer's) and gives
+        // `apply`/`stale` the one-entry-per-fingerprint invariant they
+        // assume. First-appearance order and the first entry's advisory
+        // fields win.
+        let mut entries: Vec<BaselineEntry> = Vec::new();
+        let mut pos: BTreeMap<String, usize> = BTreeMap::new();
         for line in lines {
             let entry: BaselineEntry =
                 serde_json::from_str(line).map_err(|source| BaselineError::Parse {
                     what: "entry",
                     source,
                 })?;
-            entries.push(entry);
+            if let Some(&i) = pos.get(&entry.fingerprint) {
+                entries[i].count = entries[i].count.saturating_add(entry.count);
+            } else {
+                pos.insert(entry.fingerprint.clone(), entries.len());
+                entries.push(entry);
+            }
         }
         Ok(Self {
             alint_version: header.alint_version,
@@ -353,9 +383,11 @@ where
 
     for result in &report.results {
         // Stable match order so suppression is deterministic regardless
-        // of the engine's parallel collection order.
+        // of the engine's parallel collection order. `sort_by_cached_key`
+        // computes each key once (one path allocation per violation) rather
+        // than on every comparison.
         let mut ordered: Vec<&Violation> = result.violations.iter().collect();
-        ordered.sort_by(|a, b| order_key(a).cmp(&order_key(b)));
+        ordered.sort_by_cached_key(|v| order_key(v));
 
         let mut live = Vec::new();
         let mut live_fps = Vec::new();
@@ -708,6 +740,44 @@ mod tests {
         assert_eq!(b.total(), 0);
     }
 
+    #[test]
+    fn load_sums_duplicate_fingerprints() {
+        // Two entries with the SAME fingerprint (e.g. a git merge of two
+        // baselines that each recorded the finding) must SUM, not
+        // last-writer-wins, so the suppression budget is the total.
+        let text = format!(
+            "{{\"schema_version\":{SCHEMA_VERSION}}}\n\
+             {{\"rule_id\":\"r\",\"fingerprint\":\"ff\",\"count\":2}}\n\
+             {{\"rule_id\":\"r\",\"fingerprint\":\"ff\",\"count\":3}}\n"
+        );
+        let b = Baseline::load(&text).unwrap();
+        assert_eq!(b.entries.len(), 1, "duplicates collapse to one entry");
+        assert_eq!(b.entries[0].count, 5, "counts sum (2 + 3)");
+        assert_eq!(b.total(), 5);
+    }
+
+    #[test]
+    fn from_fingerprints_advisory_message_is_order_independent() {
+        // A path-identity group collapses violations whose messages differ;
+        // the committed advisory message must not depend on input order.
+        let mk = |msg: &str| FingerprintedViolation {
+            rule_id: "r".into(),
+            path: Some("a.rs".into()),
+            fingerprint: "shared".into(),
+            message: Some(msg.into()),
+        };
+        let one = Baseline::from_fingerprints(None, vec![mk("zeta"), mk("alpha")]);
+        let two = Baseline::from_fingerprints(None, vec![mk("alpha"), mk("zeta")]);
+        assert_eq!(one, two, "advisory message must not depend on input order");
+        assert_eq!(one.entries.len(), 1);
+        assert_eq!(one.entries[0].count, 2);
+        assert_eq!(
+            one.entries[0].message.as_deref(),
+            Some("alpha"),
+            "the lexicographically smallest message is pinned"
+        );
+    }
+
     // ─── apply (the suppression transform) ──────────────────────────
 
     use crate::Level;
@@ -847,5 +917,79 @@ mod tests {
             !out.live.has_errors(),
             "a fully-baselined error report must exit clean"
         );
+    }
+
+    #[test]
+    fn apply_honors_summed_budget_from_merged_duplicates() {
+        // A merged baseline with the same fingerprint twice (2 + 3) must
+        // suppress all five occurrences, not just the last writer's three.
+        let text = format!(
+            "{{\"schema_version\":{SCHEMA_VERSION}}}\n\
+             {{\"rule_id\":\"r\",\"fingerprint\":\"X\",\"count\":2}}\n\
+             {{\"rule_id\":\"r\",\"fingerprint\":\"X\",\"count\":3}}\n"
+        );
+        let base = Baseline::load(&text).unwrap();
+        let rep = report(
+            "r",
+            Level::Error,
+            &[
+                ("X", Some(1)),
+                ("X", Some(2)),
+                ("X", Some(3)),
+                ("X", Some(4)),
+                ("X", Some(5)),
+            ],
+        );
+        let out = apply(&rep, &base, by_message);
+        assert_eq!(out.suppressed_total, 5, "summed budget suppresses all five");
+        assert_eq!(out.live.total_violations(), 0);
+        assert!(out.stale.is_empty());
+    }
+
+    #[test]
+    fn apply_live_fingerprints_align_with_live_violations() {
+        // Two rules, each with one suppressed + one live finding. Every
+        // stored live fingerprint must equal recomputing it on the SAME
+        // live violation it sits beside — the invariant the SARIF/JSON
+        // formatters rely on via positional indexing.
+        let lined = |m: &str, l: usize| {
+            Violation::new(m.to_string())
+                .with_path(Path::new("f.rs"))
+                .with_location(l, 1)
+        };
+        let r1 = RuleResult::new(
+            std::sync::Arc::from("r1"),
+            Level::Error,
+            None,
+            vec![lined("A", 1), lined("B", 2)],
+            false,
+        );
+        let r2 = RuleResult::new(
+            std::sync::Arc::from("r2"),
+            Level::Error,
+            None,
+            vec![lined("C", 1), lined("D", 2)],
+            false,
+        );
+        let rep = Report {
+            results: vec![r1, r2],
+        };
+        // Baseline A and C (by_message fingerprints) → B and D stay live.
+        let base = Baseline {
+            alint_version: None,
+            entries: vec![entry("A", 1), entry("C", 1)],
+        };
+        let out = apply(&rep, &base, by_message);
+        for (ri, rr) in out.live.results.iter().enumerate() {
+            for (vi, v) in rr.violations.iter().enumerate() {
+                assert_eq!(
+                    out.live_fingerprints[ri][vi],
+                    by_message(&rr.rule_id, v),
+                    "live_fingerprints[{ri}][{vi}] must match its own violation"
+                );
+            }
+        }
+        assert_eq!(out.live.results[0].violations[0].message.as_ref(), "B");
+        assert_eq!(out.live.results[1].violations[0].message.as_ref(), "D");
     }
 }

--- a/crates/alint-output/src/sarif.rs
+++ b/crates/alint-output/src/sarif.rs
@@ -455,4 +455,60 @@ mod tests {
         assert!(r.get("suppressions").is_none());
         assert!(r.get("partialFingerprints").is_none());
     }
+
+    #[test]
+    fn live_fingerprints_attach_to_their_own_result() {
+        use crate::{BaselineMarks, ResultMarks};
+        // Two rules, each with one live finding carrying a DISTINCT
+        // fingerprint. The marks are positionally indexed, so a desync would
+        // stamp fp-a1 onto rule-b's finding — this pins each to its own.
+        let report = Report {
+            results: vec![
+                RuleResult {
+                    rule_id: "rule-a".into(),
+                    level: Level::Error,
+                    policy_url: None,
+                    violations: vec![Violation::new("a1").with_path(Path::new("a.txt"))],
+                    notes: Vec::new(),
+                    is_fixable: false,
+                },
+                RuleResult {
+                    rule_id: "rule-b".into(),
+                    level: Level::Error,
+                    policy_url: None,
+                    violations: vec![Violation::new("b1").with_path(Path::new("b.txt"))],
+                    notes: Vec::new(),
+                    is_fixable: false,
+                },
+            ],
+        };
+        let marks = BaselineMarks {
+            per_result: vec![
+                ResultMarks {
+                    live_fingerprints: vec!["fp-a1".into()],
+                    suppressed: Vec::new(),
+                },
+                ResultMarks {
+                    live_fingerprints: vec!["fp-b1".into()],
+                    suppressed: Vec::new(),
+                },
+            ],
+            suppressed_total: 0,
+        };
+        let mut buf = Vec::new();
+        write_sarif_with_baseline(&report, Some(&marks), &mut buf).unwrap();
+        let v: Value = serde_json::from_slice(&buf).unwrap();
+        let results = v["runs"][0]["results"].as_array().unwrap();
+        assert_eq!(results.len(), 2);
+        let by_msg = |m: &str| {
+            results
+                .iter()
+                .find(|r| r["message"]["text"] == m)
+                .unwrap_or_else(|| panic!("no result for {m}"))
+        };
+        assert_eq!(by_msg("a1")["ruleId"], "rule-a");
+        assert_eq!(by_msg("a1")["partialFingerprints"]["alint/v1"], "fp-a1");
+        assert_eq!(by_msg("b1")["ruleId"], "rule-b");
+        assert_eq!(by_msg("b1")["partialFingerprints"]["alint/v1"], "fp-b1");
+    }
 }

--- a/crates/alint/src/main.rs
+++ b/crates/alint/src/main.rs
@@ -755,6 +755,8 @@ fn cmd_check(path: &Path, changed: &ChangedMode, only: &[String], cli: &Cli) -> 
 
     let report = engine.run(path, &index).context("running rules")?;
 
+    let format: Format = cli.format.parse().map_err(|e: String| anyhow::anyhow!(e))?;
+
     // Baseline suppression (when --baseline is in effect): grandfather
     // recorded violations, leaving only new ones to format + gate on.
     let mut strict_stale_fail = false;
@@ -768,13 +770,16 @@ fn cmd_check(path: &Path, changed: &ChangedMode, only: &[String], cli: &Cli) -> 
         if cli.strict_baseline && !applied.stale.is_empty() {
             strict_stale_fail = true;
         }
-        let marks = build_baseline_marks(&applied);
-        (applied.live, Some(marks))
+        // Only SARIF and JSON consume the marks; building them clones every
+        // suppressed finding, so skip that work for the formats that ignore
+        // the baseline and emit only the live (new) findings.
+        let marks =
+            matches!(format, Format::Sarif | Format::Json).then(|| build_baseline_marks(&applied));
+        (applied.live, marks)
     } else {
         (report, None)
     };
 
-    let format: Format = cli.format.parse().map_err(|e: String| anyhow::anyhow!(e))?;
     let (mut out, opts) = render_env(cli)?;
     // SARIF and JSON render baselined findings (marked / counted) so Code
     // Scanning dismisses rather than re-opens them; every other format ignores
@@ -992,19 +997,30 @@ fn cmd_baseline(
     // Regeneration guard: refuse to grandfather NEW debt without
     // --accept-new. Pruning stale entries is always allowed.
     if out_path.exists() && !accept_new {
+        use std::collections::HashMap;
         let existing = load_baseline(&out_path)?;
-        let old: std::collections::HashSet<&str> = existing
+        // Compare by OCCURRENCE, not just fingerprint identity: a higher count
+        // on an already-baselined finding is fresh debt too, and must not slip
+        // in silently. Both baselines are dup-free (load + from_fingerprints
+        // dedup), so each fingerprint maps to exactly one count.
+        let old_counts: HashMap<&str, u32> = existing
             .entries
             .iter()
-            .map(|e| e.fingerprint.as_str())
+            .map(|e| (e.fingerprint.as_str(), e.count))
             .collect();
-        let new: std::collections::HashSet<&str> = new_baseline
+        let new_counts: HashMap<&str, u32> = new_baseline
             .entries
             .iter()
-            .map(|e| e.fingerprint.as_str())
+            .map(|e| (e.fingerprint.as_str(), e.count))
             .collect();
-        let added = new.difference(&old).count();
-        let removed = old.difference(&new).count();
+        let added: u64 = new_counts
+            .iter()
+            .map(|(fp, &c)| u64::from(c.saturating_sub(old_counts.get(fp).copied().unwrap_or(0))))
+            .sum();
+        let removed: u64 = old_counts
+            .iter()
+            .map(|(fp, &c)| u64::from(c.saturating_sub(new_counts.get(fp).copied().unwrap_or(0))))
+            .sum();
         if added > 0 {
             bail!(
                 "regenerating {} would grandfather {added} new violation(s) (+{added} / -{removed}); \

--- a/crates/alint/tests/baseline_cli.rs
+++ b/crates/alint/tests/baseline_cli.rs
@@ -331,3 +331,112 @@ fn sarif_marks_baselined_findings_not_removed() {
         "fingerprints present for Code Scanning correlation",
     );
 }
+
+/// `check --baseline --format json` carries the suppressed count in the
+/// envelope and the live findings in `results` — exercising the JSON
+/// dispatch arm (`write_json_with_baseline`) that the SARIF test doesn't.
+#[test]
+fn json_baseline_reports_suppressed_count() {
+    let d = fixture();
+    let root = d.path();
+    assert_eq!(code(&run(root, &["baseline"])), 0);
+
+    // Fully baselined → exit 0, the envelope still reports the 2 suppressed.
+    let out = run(
+        root,
+        &[
+            "check",
+            "--baseline",
+            ".alint-baseline.json",
+            "--format",
+            "json",
+        ],
+    );
+    assert_eq!(code(&out), 0, "fully baselined → exit 0");
+    let json = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        json.contains("\"baselined_suppressed\": 2"),
+        "suppressed count in the envelope:\n{json}",
+    );
+
+    // A new finding surfaces in `results`; the suppressed count is unchanged.
+    std::fs::write(root.join("c.txt"), "another TODO\n").unwrap();
+    let out2 = run(
+        root,
+        &[
+            "check",
+            "--baseline",
+            ".alint-baseline.json",
+            "--format",
+            "json",
+        ],
+    );
+    assert_eq!(code(&out2), 1, "a new finding fails the gate");
+    let json2 = String::from_utf8_lossy(&out2.stdout);
+    assert!(json2.contains("\"baselined_suppressed\": 2"), "{json2}");
+    assert!(
+        json2.contains("c.txt"),
+        "the new finding is in results:\n{json2}"
+    );
+}
+
+/// `alint baseline` is byte-identical across regenerations of an unchanged
+/// tree — the committed file must never churn (e.g. on advisory fields), or
+/// CI diffs would flap. Guards the determinism `from_fingerprints` enforces.
+#[test]
+fn baseline_regeneration_is_byte_identical() {
+    let d = fixture();
+    let root = d.path();
+    assert_eq!(code(&run(root, &["baseline", "--output", "one.json"])), 0);
+    assert_eq!(code(&run(root, &["baseline", "--output", "two.json"])), 0);
+    let one = std::fs::read(root.join("one.json")).unwrap();
+    let two = std::fs::read(root.join("two.json")).unwrap();
+    assert_eq!(
+        one, two,
+        "two regenerations of the same tree must be byte-identical",
+    );
+}
+
+/// Regenerating must refuse a higher OCCURRENCE count on an
+/// already-baselined fingerprint — that's fresh debt, not just new
+/// fingerprints — unless `--accept-new` is given.
+#[test]
+fn regeneration_refuses_count_increase_on_existing_fingerprint() {
+    let d = tempfile::tempdir().unwrap();
+    let root = d.path();
+    // `for_each_match` flags every selected line (no per-finding key), so two
+    // IDENTICAL offending lines share a fingerprint and collapse to a count.
+    std::fs::write(
+        root.join(".alint.yml"),
+        "version: 1\n\
+         rules:\n\
+         \x20 - id: fem\n\
+         \x20   kind: for_each_match\n\
+         \x20   paths: [\"**/*.txt\"]\n\
+         \x20   select: \"BAD\"\n\
+         \x20   require:\n\
+         \x20     forbid: [\"BAD\"]\n\
+         \x20   level: error\n",
+    )
+    .unwrap();
+    // One offending line → its fingerprint is recorded with count 1.
+    std::fs::write(root.join("a.txt"), "BAD\n").unwrap();
+    assert_eq!(code(&run(root, &["baseline"])), 0);
+
+    // A second IDENTICAL offending line → same fingerprint, count now 2.
+    std::fs::write(root.join("a.txt"), "BAD\nBAD\n").unwrap();
+    let refused = run(root, &["baseline"]);
+    assert_eq!(
+        code(&refused),
+        2,
+        "a higher count on an existing finding is fresh debt",
+    );
+    assert!(
+        String::from_utf8_lossy(&refused.stderr).contains("grandfather 1 new violation"),
+        "{}",
+        String::from_utf8_lossy(&refused.stderr),
+    );
+
+    // --accept-new takes it.
+    assert_eq!(code(&run(root, &["baseline", "--accept-new"])), 0);
+}

--- a/docs/design/baseline.md
+++ b/docs/design/baseline.md
@@ -129,13 +129,15 @@ split-brain onto different files; resolves review M5).
   violations and silently omit the rest of the legacy tree, producing a baseline
   that suppresses an arbitrary subset (review H3/H4). Whole-tree only.
 - **Regeneration guard.** If a baseline file already exists, `alint baseline`
-  computes the delta and **refuses to add fingerprints not already present unless
-  `--accept-new` is passed**; it always prints `+N would be grandfathered /
-  -M stale removed`. *Pruning stale entries is always safe and happens without
-  the flag; accepting NEW debt is explicit.* This closes the happy-path footgun
-  where re-running `baseline` (which §3.4 may prompt) silently grandfathers
-  everything introduced since the last run (review H5). First-time creation (no
-  existing file) writes freely.
+  computes the delta and **refuses to grandfather new violation _occurrences_
+  unless `--accept-new` is passed** — a brand-new fingerprint *or* a higher
+  `count` on an existing one (both are fresh debt). It always prints
+  `+N would be grandfathered / -M stale removed` (N/M counted in occurrences).
+  *Pruning stale entries is always safe and happens without the flag; accepting
+  NEW debt is explicit.* This closes the happy-path footgun where re-running
+  `baseline` (which §3.4 may prompt) silently grandfathers everything introduced
+  since the last run (review H5). First-time creation (no existing file) writes
+  freely.
 - Exits 0 on success; 2 on a write/IO failure (§3.9).
 
 ### 2.3 `alint check --baseline <file>` — enforce only the delta
@@ -260,6 +262,12 @@ occurrence is reported. Distinct content/keys are never confused — this is the
 narrowest possible masking window and is the price of line-content (vs
 line-number) keying.
 
+`Baseline::load` **sums** the counts of any duplicate fingerprints it reads, so a
+file with two entries for one fingerprint (e.g. a git merge of two branches that
+each ran `alint baseline` for the same finding, or a hand-edit) suppresses the
+*total*, not the last writer's count. A freshly written file never has duplicates
+(`from_fingerprints` collapses them), so loading and re-writing is idempotent.
+
 ### 3.3 Enforcement pass (`check --baseline`)
 
 A deterministic **post-evaluation report transform**, between `Engine::run` and
@@ -285,19 +293,29 @@ Determinism: suppression is a pure function of `(sorted Report, baseline)`.
 Suppression *marks* violations rather than deleting them, so each formatter can
 do the right thing for its consumer (review C2):
 
-- **human / json / agent / markdown / junit / gitlab** — omit suppressed
-  violations from the primary output (with `--show-baselined`, human/json list
-  them separately). This matches "report only new."
 - **sarif** — emit suppressed results **with `result.suppressions: [{ "kind":
-  "external" }]`** (and `baselineState: "unchanged"`). Removing them instead would
-  make GitHub Code Scanning mark the alert *fixed* and then *reopen* it when the
-  finding resurfaces — alert flapping in the exact blocking-gate scenario this
-  feature targets. Marking keeps the alert open-but-dismissed. The SARIF emitter
-  also gains `partialFingerprints` (the baseline fingerprint) so Code Scanning's
-  own correlation aligns with alint's.
+  "external" }]`** (and `baselineState: "unchanged"`; live results get
+  `baselineState: "new"`). Removing them instead would make GitHub Code Scanning
+  mark the alert *fixed* and then *reopen* it when the finding resurfaces — alert
+  flapping in the exact blocking-gate scenario this feature targets. Marking keeps
+  the alert open-but-dismissed. Every result also carries `partialFingerprints`
+  (the baseline fingerprint) so Code Scanning's own correlation aligns with
+  alint's.
+- **json** — omit suppressed findings from `results` (so the gate sees only new),
+  but the envelope carries a `summary.baselined_suppressed` count, and a
+  fingerprinted `baselined` list under `--show-baselined`.
+- **human** — omit from the primary output; print the suppressed **count** on
+  stderr (the full list under `--show-baselined`).
+- **github / gitlab / junit / markdown / agent** — emit the live (new) findings
+  only, with **no suppressed-count signal in the artifact**. This is deliberate:
+  these formats gate or annotate on new findings, and a synthetic "N suppressed"
+  record has no natural representation in their schemas. A consumer that needs the
+  suppressed count should select `json` or `sarif`.
 
-The `json` envelope gains a `baselined_suppressed` count (and the suppressed list
-under `--show-baselined`) so machine consumers see the suppression happened.
+Only **sarif** and **json** are baseline-aware (they consume the per-result marks
+the CLI threads in via `BaselineMarks`); the rest receive the already-filtered
+live report and are oblivious to the baseline. The exit code is gated on the live
+findings only, in every format.
 
 ### 3.4 `fix` and the baseline
 


### PR DESCRIPTION
A self-audit of baseline mode surfaced edge-case gaps. None break a fresh `alint baseline` (the write path dedups; the engine collects deterministically), but each is reachable via merges, hand-edits, or a future engine change — closed now while the feature is unreleased.

## Correctness / robustness

- **`Baseline::load` sums duplicate fingerprints** (was last-writer-wins). The file is line-oriented to be merge-friendly, so a git merge of two branches that each baselined the same finding can leave two entries for one fingerprint; summing keeps the suppression budget the *total* and restores `apply`/`stale`'s one-entry-per-fingerprint assumption. Previously it under-suppressed — a baselined finding could resurface as "new".
- **`from_fingerprints` pins the smallest advisory message** per fingerprint group → regeneration is byte-identical regardless of the engine's collection order (a path-identity group can collapse violations whose messages differ).
- **Regeneration guard counts new _occurrences_**, not just new fingerprints: a higher `count` on an already-baselined finding is fresh debt too and now requires `--accept-new`.

## Perf / cleanup

- **`apply` uses `sort_by_cached_key`** — the per-violation order key (allocates a path `String`) is computed once per element, not on every comparison.
- **`cmd_check` builds `BaselineMarks` only for SARIF/JSON** (the formats that consume them), skipping the per-suppressed-finding clones on human/github/gitlab/junit/markdown/agent runs.

## Tests

- Core: load-sums-duplicates, apply-honors-summed-budget, advisory-message-order-independence, **live-fingerprint↔live-violation alignment**.
- Output: **SARIF per-result fingerprint discrimination** (2 rules, distinct fingerprints) — together these guard the positional coupling the formatters rely on against future index drift.
- e2e: `check --baseline --format json` suppressed-count (the JSON dispatch arm the SARIF e2e didn't cover), byte-identical regeneration, count-increase-refused-without-`--accept-new`.

## Docs

`baseline.md` §3.8 now spells out which formats are baseline-aware (only SARIF + JSON surface the suppression; the rest emit live-only with no count, by design), plus the load-dedup and occurrence-guard guarantees.

## Deferred (intentionally)

`offending_line` is O(lines) per call and fingerprinting is sequential — both fine at current scale, not worth the API churn / thread-safety cost until a profile says otherwise.

## Verification

Full preflight green: fmt, pedantic clippy (`-D warnings`), rustdoc (`-D warnings`), all three gen-* drift checks, whole workspace (**1849 passed, 0 failed**) including the `coverage_audit_baseline_safety` collision-invariant.
