### PR TITLE
perf(docs-bundle): skip the redundant release build in the rule-page bridge

### DIFF
--- a/.github/workflows/docs-bundle.yml
+++ b/.github/workflows/docs-bundle.yml
@@ -159,7 +159,11 @@ jobs:
           # ephemeral ubuntu-latest runner (the VM is discarded), but correct
           # hygiene and safe if the job ever moves to a persistent host.
           trap 'git worktree remove --force "$main_tree" >/dev/null 2>&1 || true; rm -rf "$main_tree"' EXIT
-          ( cd "$main_tree" && cargo run -q -p xtask -- docs-export --out "$main_tree/_bundle" )
+          # --rules-only: the bridge reads only rules/ below, so skip the rest of
+          # the export — most importantly the CLI-reference step's `cargo build
+          # --release -p alint`, which this second (cold) build would otherwise
+          # redo from scratch on top of the tag build above.
+          ( cd "$main_tree" && cargo run -q -p xtask -- docs-export --rules-only --out "$main_tree/_bundle" )
           refreshed=0
           while IFS= read -r page; do
             src="${main_tree}/_bundle/${page#target/docs-bundle/}"

--- a/xtask/src/docs_export.rs
+++ b/xtask/src/docs_export.rs
@@ -85,7 +85,7 @@ fn copy_c4_model(workspace: &Path, target_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn docs_export(out: Option<PathBuf>, check: bool) -> Result<()> {
+pub(crate) fn docs_export(out: Option<PathBuf>, check: bool, rules_only: bool) -> Result<()> {
     let workspace = workspace_root()?;
     let target_dir = out.unwrap_or_else(|| workspace.join("target/docs-bundle"));
 
@@ -109,6 +109,20 @@ pub(crate) fn docs_export(out: Option<PathBuf>, check: bool) -> Result<()> {
     };
 
     eprintln!("[xtask] docs-export → {}", target_dir.display());
+
+    if rules_only {
+        // The docs-bundle rule-page bridge overlays ONLY the per-rule
+        // reference pages from main, so generate just those and skip the rest
+        // of the export — most importantly step 5 (`generate_cli_reference`),
+        // which builds the alint release binary. That redundant build is the
+        // bulk of the bridge's cost, and the bridge never reads its output.
+        generate_rules_pages(&workspace, &target_dir)?;
+        eprintln!(
+            "[xtask] docs-export --rules-only wrote {}/rules",
+            target_dir.display()
+        );
+        return Ok(());
+    }
 
     // 1. Hand-written long-form prose, copied verbatim.
     copy_site_tree(&workspace, &target_dir)?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -234,6 +234,13 @@ enum Commands {
         /// bundle.
         #[arg(long)]
         check: bool,
+        /// Generate ONLY the per-rule reference pages (`rules/`), skipping the
+        /// rest of the bundle — most importantly the CLI-reference step, which
+        /// builds the alint release binary. Used by the docs-bundle rule-page
+        /// bridge, which overlays only those pages from main; the redundant
+        /// release build was the bulk of that bridge's cost.
+        #[arg(long)]
+        rules_only: bool,
     },
     /// Render the public roadmap from canonical `docs/design/ROADMAP.md`,
     /// stripping `<!-- alint:internal-start -->` /
@@ -334,7 +341,11 @@ fn main() -> Result<()> {
         Commands::BenchGate { results, baseline } => {
             bench::gate::run(&results, baseline.as_deref())
         }
-        Commands::DocsExport { out, check } => docs_export::docs_export(out, check),
+        Commands::DocsExport {
+            out,
+            check,
+            rules_only,
+        } => docs_export::docs_export(out, check, rules_only),
         Commands::GenPublicRoadmap {
             input,
             output,


### PR DESCRIPTION
## Problem

The `docs-bundle` workflow builds the alint **release binary twice**: once for the tag bundle (`docs-export` at the checked-out tag), and again inside the `origin/main` worktree where the rule-page bridge re-runs the **full** `docs-export` just to overlay the per-rule reference pages. That second run lives in a separate, cold worktree `target/` dir, so it redoes `cargo build --release -p alint` (which step 5, `generate_cli_reference`, triggers for the `--help` capture) entirely from scratch — work the bridge never reads. It only copies `rules/**`.

## Fix

Add a `docs-export --rules-only` mode that generates **only** the per-rule pages via `generate_rules_pages` (self-contained — registry + `docs/rules.md`, no binary) and skips the rest of the export, most importantly the CLI-reference step that builds the release binary. The bridge step now passes `--rules-only`.

```
( cd "$main_tree" && cargo run -q -p xtask -- docs-export --rules-only --out "$main_tree/_bundle" )
```

## Verification

- **Byte-identical output:** `diff -rq` of `--rules-only`'s `rules/` against a full export's `rules/` → identical. The bridge gets exactly the same pages.
- **Zero release builds:** `--rules-only` runs with **0** `cargo build --release` invocations (vs. the full export's 1).
- Full `docs-export` and `docs-export --check` (the CI gate) are unchanged; fmt + pedantic clippy + xtask tests green.

## Why not share the target dir?

The other option — point the worktree build at the tag build's `target/` via `CARGO_TARGET_DIR` — is fragile here: `build_release_binary` locates the binary at `workspace_root()/target/release/alint`, ignoring `CARGO_TARGET_DIR`, and `workspace_root()` derives from the **compile-time** `CARGO_MANIFEST_DIR`. Doing *less work* is the simpler, correct-by-construction fix.
