### PR TITLE
feat(rules): implement root_only for the existence family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`root_only:` now works on `file_absent` / `dir_exists` / `dir_absent`.** The
+  option was documented as the existence-family counterpart of `file_exists`'s
+  `root_only` and used in a bundled ruleset, but the three sibling rules silently
+  ignored it (so a "forbid `notes.md` at the repo root only" rule actually
+  forbade it at every depth). They now honor it — only paths directly at the
+  repository root are considered — with the option validated and published in the
+  config schema, like `file_exists`.
 - **LSP server robustness.** The `alint lsp` server held its shared state behind
   a `std::sync::Mutex` accessed via `.lock().unwrap()` at every site, so a panic
   in any one async handler poisoned the lock and wedged the whole session

--- a/crates/alint-dsl/schemas/v1/config.json
+++ b/crates/alint-dsl/schemas/v1/config.json
@@ -1017,6 +1017,11 @@
         },
         "paths": {
           "$ref": "#/$defs/paths_spec"
+        },
+        "root_only": {
+          "default": false,
+          "description": "If true, only a directory directly at the repository root is forbidden.",
+          "type": "boolean"
         }
       },
       "required": [
@@ -1065,6 +1070,11 @@
         },
         "paths": {
           "$ref": "#/$defs/paths_spec"
+        },
+        "root_only": {
+          "default": false,
+          "description": "If true, only a directory directly at the repository root satisfies the rule.",
+          "type": "boolean"
         }
       },
       "required": [
@@ -1188,6 +1198,11 @@
         },
         "paths": {
           "$ref": "#/$defs/paths_spec"
+        },
+        "root_only": {
+          "default": false,
+          "description": "If true, only a file directly at the repository root is forbidden.",
+          "type": "boolean"
         }
       },
       "required": [

--- a/crates/alint-dsl/tests/snapshots/default_options.txt
+++ b/crates/alint-dsl/tests/snapshots/default_options.txt
@@ -217,6 +217,7 @@ DirAbsentRule {
     patterns: [
         "**/target",
     ],
+    root_only: false,
     git_tracked_only: false,
 }
 
@@ -247,6 +248,7 @@ DirExistsRule {
     patterns: [
         "docs/**",
     ],
+    root_only: false,
     git_tracked_only: false,
 }
 
@@ -323,6 +325,7 @@ FileAbsentRule {
         "**/Cargo.lock.bak",
         "**/package-lock.json.bak",
     ],
+    root_only: false,
     git_tracked_only: false,
     fixer: Some(
         FileRemoveFixer,

--- a/crates/alint-e2e/tests/coverage_audit_doc_examples.rs
+++ b/crates/alint-e2e/tests/coverage_audit_doc_examples.rs
@@ -374,14 +374,6 @@ fn top_keys_track_the_loader() {
 /// "schema is the contract" guarantee.
 #[test]
 fn every_rule_kind_rejects_an_unknown_option() {
-    // KNOWN exceptions: the existence family accepts an unknown option today
-    // because it also accepts `root_only` (used in bundled rulesets + docs) but
-    // never implemented it as a validated `Options` struct — it silently ignores
-    // it. Strict option validation for them depends on first implementing
-    // `root_only` parity with `file_exists` (a feature, tracked separately). They
-    // are allow-listed here; a NEW swallower beyond this set still fails the test.
-    const KNOWN_OPTION_SWALLOWERS: &[&str] = &["dir_absent", "dir_exists", "file_absent"];
-
     let root = repo_root();
     let registry = alint_rules::builtin_registry();
     let mut swallowers: BTreeSet<String> = BTreeSet::new();
@@ -437,16 +429,12 @@ fn every_rule_kind_rejects_an_unknown_option() {
         probed.len(),
     );
 
-    let unexpected: Vec<&String> = swallowers
-        .iter()
-        .filter(|k| !KNOWN_OPTION_SWALLOWERS.contains(&k.as_str()))
-        .collect();
     assert!(
-        unexpected.is_empty(),
+        swallowers.is_empty(),
         "{} rule kind(s) SILENTLY ACCEPT an unknown option (every other kind rejects \
-         it): {unexpected:?}\nEach must validate its options — propagate \
+         it): {swallowers:?}\nEach must validate its options — propagate \
          `deserialize_options()` instead of `.unwrap_or(default)`, or register via \
          `register_optionless` if it takes none.",
-        unexpected.len(),
+        swallowers.len(),
     );
 }

--- a/crates/alint-rules/src/dir_absent.rs
+++ b/crates/alint-rules/src/dir_absent.rs
@@ -1,6 +1,17 @@
 //! `dir_absent` — no directory matching `paths` may exist.
 
 use alint_core::{Context, Error, Level, PathsSpec, Result, Rule, RuleSpec, Scope, Violation};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    /// When `true`, only forbid a directory directly at the repo root; a nested
+    /// directory with the same name is allowed. Mirrors `file_exists`'s
+    /// `root_only`.
+    #[serde(default)]
+    root_only: bool,
+}
 
 #[derive(Debug)]
 pub struct DirAbsentRule {
@@ -10,6 +21,7 @@ pub struct DirAbsentRule {
     message: Option<String>,
     scope: Scope,
     patterns: Vec<String>,
+    root_only: bool,
     /// When `true`, only fire on directories that contain at
     /// least one git-tracked file. The canonical use case is
     /// "don't let `target/` be committed" — with this flag set,
@@ -47,6 +59,11 @@ impl Rule for DirAbsentRule {
             if !self.scope.matches(&entry.path, ctx.index) {
                 continue;
             }
+            // `root_only`: only a directory directly at the repo root is
+            // forbidden; a nested directory with the same name is allowed.
+            if self.root_only && crate::is_nested(&entry.path) {
+                continue;
+            }
             let msg = self.message.clone().unwrap_or_else(|| {
                 let tracked = if self.git_tracked_only {
                     " and has tracked content"
@@ -78,6 +95,7 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
     // (only fire on `dist/`/`build/` whose ancestor chain contains
     // a `package.json`, so polyglot monorepos with non-JS dirs of
     // the same name don't see false positives).
+    let opts: Options = spec.deserialize_options()?;
     Ok(Box::new(DirAbsentRule {
         id: spec.id.clone(),
         level: spec.level,
@@ -85,6 +103,7 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
         message: spec.message.clone(),
         scope: Scope::from_spec(spec)?,
         patterns: patterns_of(paths),
+        root_only: opts.root_only,
         git_tracked_only: spec.git_tracked_only,
     }))
 }
@@ -214,5 +233,47 @@ scope_filter:
         let spec = spec_yaml(yaml);
         let rule = build(&spec).expect("scope_filter must be accepted on dir_absent");
         assert_eq!(rule.id(), "t");
+    }
+
+    #[test]
+    fn root_only_forbids_only_a_root_level_directory() {
+        let rule = build(&spec_yaml(
+            "id: t\nkind: dir_absent\npaths: \"**/target\"\nlevel: error\nroot_only: true\n",
+        ))
+        .unwrap();
+        let idx = index_with_dirs(&[("target", true), ("a/target", true)]);
+        assert_eq!(
+            rule.evaluate(&ctx(Path::new("/fake"), &idx)).unwrap().len(),
+            1,
+            "root_only forbids only the root-level target/",
+        );
+        // Without root_only, both fire.
+        let plain = build(&spec_yaml(
+            "id: t\nkind: dir_absent\npaths: \"**/target\"\nlevel: error\n",
+        ))
+        .unwrap();
+        assert_eq!(
+            plain
+                .evaluate(&ctx(Path::new("/fake"), &idx))
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn build_accepts_root_only_and_rejects_unknown_option() {
+        assert!(
+            build(&spec_yaml(
+                "id: t\nkind: dir_absent\npaths: \"target\"\nlevel: error\nroot_only: true\n",
+            ))
+            .is_ok()
+        );
+        assert!(
+            build(&spec_yaml(
+                "id: t\nkind: dir_absent\npaths: \"target\"\nlevel: error\nbogus: 1\n",
+            ))
+            .is_err()
+        );
     }
 }

--- a/crates/alint-rules/src/dir_exists.rs
+++ b/crates/alint-rules/src/dir_exists.rs
@@ -1,6 +1,16 @@
 //! `dir_exists` — at least one directory matching `paths` must exist.
 
 use alint_core::{Context, Error, Level, PathsSpec, Result, Rule, RuleSpec, Scope, Violation};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    /// When `true`, only a directory directly at the repo root satisfies the
+    /// rule. Mirrors `file_exists`'s `root_only`.
+    #[serde(default)]
+    root_only: bool,
+}
 
 #[derive(Debug)]
 pub struct DirExistsRule {
@@ -10,6 +20,7 @@ pub struct DirExistsRule {
     message: Option<String>,
     scope: Scope,
     patterns: Vec<String>,
+    root_only: bool,
     /// When `true`, only consider directories that contain at
     /// least one git-tracked file. Outside a git repo the
     /// tracked set is empty, so the rule reports the "missing"
@@ -43,6 +54,10 @@ impl Rule for DirExistsRule {
         // the per-entry `dir_has_tracked_files` check that lived
         // here is now subsumed by the engine narrowing.
         let found = ctx.index.dirs().any(|entry| {
+            // `root_only`: only a directory directly at the repo root counts.
+            if self.root_only && crate::is_nested(&entry.path) {
+                return false;
+            }
             if !self.scope.matches(&entry.path, ctx.index) {
                 return false;
             }
@@ -52,13 +67,18 @@ impl Rule for DirExistsRule {
             Ok(Vec::new())
         } else {
             let msg = self.message.clone().unwrap_or_else(|| {
+                let scope = if self.root_only {
+                    " at the repo root"
+                } else {
+                    ""
+                };
                 let tracked = if self.git_tracked_only {
                     " (with tracked content)"
                 } else {
                     ""
                 };
                 format!(
-                    "expected a directory matching [{}]{tracked}",
+                    "expected a directory matching [{}]{scope}{tracked}",
                     self.patterns.join(", ")
                 )
             });
@@ -79,6 +99,7 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
             "dir_exists requires a `paths` field",
         ));
     };
+    let opts: Options = spec.deserialize_options()?;
     Ok(Box::new(DirExistsRule {
         id: spec.id.clone(),
         level: spec.level,
@@ -86,6 +107,7 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
         message: spec.message.clone(),
         scope: Scope::from_paths_spec(paths)?,
         patterns: patterns_of(paths),
+        root_only: opts.root_only,
         git_tracked_only: spec.git_tracked_only,
     }))
 }
@@ -210,6 +232,45 @@ scope_filter:
         assert!(
             err.contains("dir_exists"),
             "expected message to name the cross-file kind, got: {err}",
+        );
+    }
+
+    #[test]
+    fn root_only_requires_a_root_level_directory() {
+        let rule = build(&spec_yaml(
+            "id: t\nkind: dir_exists\npaths: \"**/docs\"\nlevel: error\nroot_only: true\n",
+        ))
+        .unwrap();
+        // Only a nested docs/ → fires (no root-level docs/).
+        let nested = index_with_dirs(&[("a/docs", true)]);
+        assert_eq!(
+            rule.evaluate(&ctx(Path::new("/fake"), &nested))
+                .unwrap()
+                .len(),
+            1,
+        );
+        // A root-level docs/ → satisfied.
+        let root = index_with_dirs(&[("docs", true)]);
+        assert!(
+            rule.evaluate(&ctx(Path::new("/fake"), &root))
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn build_accepts_root_only_and_rejects_unknown_option() {
+        assert!(
+            build(&spec_yaml(
+                "id: t\nkind: dir_exists\npaths: \"docs\"\nlevel: error\nroot_only: true\n",
+            ))
+            .is_ok()
+        );
+        assert!(
+            build(&spec_yaml(
+                "id: t\nkind: dir_exists\npaths: \"docs\"\nlevel: error\nbogus: 1\n",
+            ))
+            .is_err()
         );
     }
 }

--- a/crates/alint-rules/src/file_absent.rs
+++ b/crates/alint-rules/src/file_absent.rs
@@ -3,8 +3,18 @@
 use alint_core::{
     Context, Error, FixSpec, Fixer, Level, PathsSpec, Result, Rule, RuleSpec, Scope, Violation,
 };
+use serde::Deserialize;
 
 use crate::fixers::FileRemoveFixer;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    /// When `true`, only forbid matches directly at the repo root; a nested
+    /// file with the same name is allowed. Mirrors `file_exists`'s `root_only`.
+    #[serde(default)]
+    root_only: bool,
+}
 
 #[derive(Debug)]
 pub struct FileAbsentRule {
@@ -14,6 +24,7 @@ pub struct FileAbsentRule {
     message: Option<String>,
     scope: Scope,
     patterns: Vec<String>,
+    root_only: bool,
     /// When `true`, only fire on entries that are also tracked
     /// in git's index. Outside a git repo or with no rules
     /// opting in, the tracked-set is `None` and every entry
@@ -57,6 +68,11 @@ impl Rule for FileAbsentRule {
             if !self.scope.matches(&entry.path, ctx.index) {
                 continue;
             }
+            // `root_only`: only a match directly at the repo root is forbidden;
+            // a nested file with the same name is allowed.
+            if self.root_only && crate::is_nested(&entry.path) {
+                continue;
+            }
             let msg = self.message.clone().unwrap_or_else(|| {
                 let tracked = if self.git_tracked_only {
                     " and tracked in git"
@@ -87,6 +103,7 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
             "file_absent requires a `paths` field",
         ));
     };
+    let opts: Options = spec.deserialize_options()?;
     let fixer = match &spec.fix {
         Some(FixSpec::FileRemove { .. }) => Some(FileRemoveFixer),
         Some(other) => {
@@ -104,6 +121,7 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
         message: spec.message.clone(),
         scope: Scope::from_paths_spec(paths)?,
         patterns: patterns_of(paths),
+        root_only: opts.root_only,
         git_tracked_only: spec.git_tracked_only,
         fixer,
     }))
@@ -260,6 +278,48 @@ scope_filter:
         assert!(
             err.contains("file_absent"),
             "expected message to name the cross-file kind, got: {err}",
+        );
+    }
+
+    #[test]
+    fn root_only_forbids_only_root_level_matches() {
+        let rule = build(&spec_yaml(
+            "id: t\nkind: file_absent\npaths: \"**/notes.md\"\nlevel: error\nroot_only: true\n",
+        ))
+        .unwrap();
+        let idx = index(&["notes.md", "sub/notes.md"]);
+        assert_eq!(
+            rule.evaluate(&ctx(Path::new("/fake"), &idx)).unwrap().len(),
+            1,
+            "root_only forbids only the root-level notes.md, not the nested one",
+        );
+        // Without root_only, both matches fire.
+        let plain = build(&spec_yaml(
+            "id: t\nkind: file_absent\npaths: \"**/notes.md\"\nlevel: error\n",
+        ))
+        .unwrap();
+        assert_eq!(
+            plain
+                .evaluate(&ctx(Path::new("/fake"), &idx))
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn build_accepts_root_only_and_rejects_unknown_option() {
+        assert!(
+            build(&spec_yaml(
+                "id: t\nkind: file_absent\npaths: [\"x\"]\nlevel: error\nroot_only: true\n",
+            ))
+            .is_ok()
+        );
+        assert!(
+            build(&spec_yaml(
+                "id: t\nkind: file_absent\npaths: [\"x\"]\nlevel: error\nbogus: 1\n",
+            ))
+            .is_err()
         );
     }
 }

--- a/crates/alint-rules/src/lib.rs
+++ b/crates/alint-rules/src/lib.rs
@@ -30,6 +30,15 @@ pub(crate) fn slash(path: impl AsRef<std::path::Path>) -> String {
     path.as_ref().display().to_string().replace('\\', "/")
 }
 
+/// True when `path` names something NESTED — more than one path component,
+/// i.e. not directly at the repository root. The existence family
+/// (`file_exists`/`file_absent`/`dir_exists`/`dir_absent`) uses this to honour
+/// their `root_only:` option: when set, only root-level paths are considered.
+#[must_use]
+pub(crate) fn is_nested(path: &std::path::Path) -> bool {
+    path.components().count() != 1
+}
+
 #[cfg(test)]
 mod slash_tests {
     #[test]

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -85,10 +85,13 @@ Directory counterpart of `file_exists`. Every match must correspond to a real di
 - id: docs-dir-exists
   kind: dir_exists
   paths: "docs"
+  root_only: true
   level: error
 ```
 
-**Optional `git_tracked_only: true`** further requires that the directory contain at least one tracked file. A tree with a `docs/` checked out from a stale clone where every file was later removed via `git rm` would fail under this stricter check. See [The walker and `.gitignore`](/docs/concepts/walker-and-gitignore/) for the full semantics.
+**Optional `root_only: true`** (like `file_exists`) requires the match to be a
+directory directly at the repository root, not nested. **Optional
+`git_tracked_only: true`** further requires that the directory contain at least one tracked file. A tree with a `docs/` checked out from a stale clone where every file was later removed via `git rm` would fail under this stricter check. See [The walker and `.gitignore`](/docs/concepts/walker-and-gitignore/) for the full semantics.
 
 ### `dir_absent`
 

--- a/schemas/v1/config.json
+++ b/schemas/v1/config.json
@@ -1017,6 +1017,11 @@
         },
         "paths": {
           "$ref": "#/$defs/paths_spec"
+        },
+        "root_only": {
+          "default": false,
+          "description": "If true, only a directory directly at the repository root is forbidden.",
+          "type": "boolean"
         }
       },
       "required": [
@@ -1065,6 +1070,11 @@
         },
         "paths": {
           "$ref": "#/$defs/paths_spec"
+        },
+        "root_only": {
+          "default": false,
+          "description": "If true, only a directory directly at the repository root satisfies the rule.",
+          "type": "boolean"
         }
       },
       "required": [
@@ -1188,6 +1198,11 @@
         },
         "paths": {
           "$ref": "#/$defs/paths_spec"
+        },
+        "root_only": {
+          "default": false,
+          "description": "If true, only a file directly at the repository root is forbidden.",
+          "type": "boolean"
         }
       },
       "required": [


### PR DESCRIPTION
Implements the `root_only`-parity follow-up tracked from the post-v0.12 empirical audit (#97).

## Problem

`file_exists` supports `root_only:` (only a match directly at the repo root counts). Its existence-family siblings — `file_absent`, `dir_exists`, `dir_absent` — are documented as counterparts, and **`root_only` is used on `file_absent` in a bundled ruleset** (`crates/alint-dsl/rulesets/v1/agent-hygiene.yml`) and the docs. But the three never implemented it: the option was **silently ignored**, so a "forbid `notes.md` at the repo root only" rule actually forbade it at every depth — a latent misbehaviour.

## Fix

Each sibling now takes a validated `Options { root_only }` and applies a shared `crate::is_nested` filter:
- **exists** rules: under `root_only`, only a path directly at the root *satisfies* the rule.
- **absent** rules: under `root_only`, only a path directly at the root is *forbidden* (a nested one is allowed).

Being option-bearing now, they also **reject unknown options** (`deny_unknown_fields`) like every other kind — so they no longer need the unknown-option-class-test allow-list, which is removed (`KNOWN_OPTION_SWALLOWERS` gone; the assertion is fully strict again).

The option is **published in the config schema** (`schemas/v1/config.json`, both copies) next to `file_exists`'s, so the loader, the schema, and alint.org's per-rule Options tables agree. The `dir_exists` doc example restores its `root_only` line (+ a one-line note).

## Verification

- Per-rule unit tests: `root_only` forbids/requires only root-level matches (nested ones unaffected); each build accepts `root_only` and rejects an unknown option.
- Empirically confirmed end-to-end via the CLI on synthetic repos (root vs nested `target/`, `notes.md`, `docs/`).
- Full preflight green: fmt, pedantic clippy (`-D warnings`), rustdoc (`-D warnings`), all gen-* drift checks, `docs-export --check`, whole workspace (**1867 passed, 0 failed**). Defaults snapshot + schema regenerated.

Note: `agent-hygiene.yml`'s `file_absent` rule now correctly scopes to the repo root (its long-documented intent), a behaviour improvement that follows automatically.
