### PR TITLE
docs(changelog): correct the root_only fix note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,10 +56,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **`root_only:` now works on `file_absent` / `dir_exists` / `dir_absent`.** The
   option was documented as the existence-family counterpart of `file_exists`'s
   `root_only` and used in a bundled ruleset, but the three sibling rules silently
-  ignored it (so a "forbid `notes.md` at the repo root only" rule actually
-  forbade it at every depth). They now honor it — only paths directly at the
-  repository root are considered — with the option validated and published in the
-  config schema, like `file_exists`.
+  ignored it. They now honor it — `root_only: true` restricts a glob that would
+  otherwise match at any depth (e.g. `**/NOTES.md`) to paths directly at the
+  repository root — with the option validated and published in the config schema,
+  like `file_exists`. (The bundled usages pin bare filenames, which already match
+  only the root, so their behavior is unchanged.)
 - **LSP server robustness.** The `alint lsp` server held its shared state behind
   a `std::sync::Mutex` accessed via `.lock().unwrap()` at every site, so a panic
   in any one async handler poisoned the lock and wedged the whole session


### PR DESCRIPTION
## What

Corrects the `[Unreleased]` CHANGELOG entry for the `root_only` work (#98). Docs-only; no code change.

## Why (found during a thorough review of #98)

The entry implied the bundled ruleset's existence-family rules **"actually forbade it at every depth"** before `root_only` was honored. That's inaccurate. The two configs that set `root_only` on these rules — `agent-hygiene.yml`'s `agent-no-scratch-docs-at-root` and the `s4_agent_hygiene` bench scenario — pin **bare filenames** (`PLAN.md`, `NOTES.md`, …), and the glob matcher already anchors a bare filename to the repository root:

```
file_absent paths: ["PLAN.md"]            (root PLAN.md + docs/PLAN.md)  -> 1 match (root only)
file_absent paths: ["PLAN.md"] root_only  -> 1 match  (root_only redundant)
file_absent paths: ["**/PLAN.md"]         -> 2 matches (glob matches nested)
```

So `root_only` was a **no-op** for the shipped configs — their behavior is unchanged — not an over-broad bug. `root_only` only changes behavior when it scopes a glob that *would* match at any depth (e.g. `**/NOTES.md`) down to the repo root.

## Review verdict on #98

The **implementation is correct.** Verified empirically via the CLI across all three rules (the exists/absent inversion holds: `dir_exists` requires a root-level match; `file_absent`/`dir_absent` forbid only the root-level match) and re-confirmed by the unit tests (which use `**/` globs, so they genuinely exercise the filter). `is_nested` (`components().count() != 1`) is correct for the walker's relative `Arc<Path>` entries at any depth. Schema, option validation, and docs are all accurate. The only issue was this CHANGELOG wording.