### PR TITLE
fix(audit): close three "fail loudly" gaps from the post-v0.12 audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,28 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The `is_text` rule kind no longer silently accepts unknown options.** The
+  `is_text` alias of `file_is_text` was registered without the
+  `deny_unknown_options` wrapper its canonical name carries, so a typo'd option
+  on an `is_text` rule was swallowed instead of failing the build (every other
+  kind, the canonical `file_is_text` included, already rejected it). A
+  registry-driven coverage test now probes **every** registered kind — aliases
+  included — so an alias can't diverge from its canonical kind again.
+- **`validate-config` (and `check`) now structurally validate nested `require:`
+  rules.** `for_each_dir` / `for_each_file` / `every_matching_has` build their
+  nested rules lazily per matched entry, so a nested rule with an unknown kind,
+  an unknown option, or a missing required field passed `validate-config` clean
+  and was caught by `check` only when the selector matched at least one entry
+  (with a selector matching nothing, never). Each rule now dry-builds its nested
+  specs at load, so these errors surface immediately — honoring
+  `validate-config`'s "is the config loadable?" contract.
+- **A nested config declaring `allow_out_of_root:` is now rejected, not silently
+  dropped.** Every other trusted root-only key (`extends`, `facts`, `vars`,
+  `ignore`/`nested_configs`, `baseline`) already errored when set in a nested
+  `.alint.yml`; `allow_out_of_root` parsed and was ignored without feedback. The
+  out-of-root grant was never honored from a nested config (confinement always
+  held), but it now fails loudly for parity, so a subtree can't appear to grant
+  itself reads outside the repo root.
 - **`root_only:` now works on `file_absent` / `dir_exists` / `dir_absent`.** The
   option was documented as the existence-family counterpart of `file_exists`'s
   `root_only` and used in a bundled ruleset, but the three sibling rules silently

--- a/crates/alint-core/src/rule.rs
+++ b/crates/alint-core/src/rule.rs
@@ -331,6 +331,22 @@ pub trait Rule: Send + Sync + std::fmt::Debug {
     /// `docs/design/v0.12/allow_out_of_root.md`.
     fn set_allow_out_of_root(&mut self, _allow: bool) {}
 
+    /// Validate this rule's nested sub-rules (the `require:` block of
+    /// `for_each_dir` / `for_each_file` / `every_matching_has`) against the
+    /// registry at config-load time. Default no-op — most rules have none.
+    ///
+    /// The cross-file iteration rules store their nested specs and build
+    /// them lazily, once per matched iteration, so a nested rule with an
+    /// unknown kind, an unknown option, or a missing required field would
+    /// otherwise slip past `validate-config` entirely — and past `check`
+    /// too whenever the selector matches no entries. Overriders dry-build
+    /// each nested spec here (with placeholder path tokens) so those
+    /// structural errors surface at load. The loader calls this post-build
+    /// at both the `validate-config` and `check` build sites.
+    fn validate_nested(&self, _registry: &RuleRegistry) -> Result<()> {
+        Ok(())
+    }
+
     /// In `--changed` mode, return `true` to evaluate this rule
     /// against the **full** [`FileIndex`] rather than the
     /// changed-only filtered subset. Default `false` (per-file

--- a/crates/alint-dsl/src/lib.rs
+++ b/crates/alint-dsl/src/lib.rs
@@ -1784,6 +1784,28 @@ rules:
     }
 
     #[test]
+    fn nested_allow_out_of_root_is_rejected() {
+        // A nested config may not declare `allow_out_of_root:` — the
+        // out-of-root escape hatch is a trusted, root-only grant (a subtree
+        // must not grant itself reads outside the repo root). Parallels
+        // `nested_baseline_is_rejected`; both close the silent-drop gap where
+        // the key parsed into the config but was ignored without feedback,
+        // unlike every other root-only key.
+        let tmp = tempfile::tempdir().unwrap();
+        let root_cfg = tmp.path().join(".alint.yml");
+        std::fs::write(&root_cfg, "version: 1\nnested_configs: true\nrules: []\n").unwrap();
+        let pkg_dir = tmp.path().join("packages/foo");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(
+            pkg_dir.join(".alint.yml"),
+            "version: 1\nallow_out_of_root: true\nrules: []\n",
+        )
+        .unwrap();
+        let err = load(&root_cfg).unwrap_err();
+        assert!(err.to_string().contains("allow_out_of_root"), "{err}");
+    }
+
+    #[test]
     fn nested_discovery_ignored_when_flag_is_false() {
         let tmp = tempfile::tempdir().unwrap();
         let root_cfg = tmp.path().join(".alint.yml");

--- a/crates/alint-dsl/src/nested.rs
+++ b/crates/alint-dsl/src/nested.rs
@@ -177,6 +177,13 @@ fn load_nested_config(abs_path: &Path, rel_dir: &Path) -> Result<Vec<Mapping>> {
              trusted, root-only input; declare it in the top-level config"
         )));
     }
+    if !config.allow_out_of_root.is_confined() {
+        return Err(Error::Other(format!(
+            "nested config {source} declares `allow_out_of_root:` — the out-of-root \
+             escape hatch is a trusted, root-only grant; declare it in the top-level \
+             config. (It is ignored here, never silently honored.)"
+        )));
+    }
 
     // Glob patterns are platform-agnostic (always `/`); on
     // Windows `rel_dir.to_string_lossy()` would emit `\` and we'd

--- a/crates/alint-dsl/tests/schema.rs
+++ b/crates/alint-dsl/tests/schema.rs
@@ -130,6 +130,62 @@ fn fixture_covers_every_registered_rule_kind() {
     }
 }
 
+/// Every registered rule kind — **including aliases** — must reject an
+/// unknown option at load. Drives the loader (not just the schema) off
+/// `all_kinds.yaml`, which `fixture_covers_every_registered_rule_kind`
+/// guarantees holds one building entry per registered kind. Guards against
+/// an alias registered via `register` instead of `register_optionless` (the
+/// v0.13 `is_text` regression): the doc-example probe in alint-e2e's
+/// `coverage_audit_doc_examples` misses such aliases because no documentation
+/// example uses them, so only a registry-driven probe catches the divergence.
+#[test]
+fn every_registered_kind_rejects_an_unknown_option() {
+    let path =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/all_kinds.yaml");
+    let config = alint_dsl::load(&path).expect("all_kinds.yaml loads");
+    let registry = alint_rules::builtin_registry();
+
+    let mut swallowers: Vec<String> = Vec::new();
+    let mut probed: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for spec in &config.rules {
+        // Only probe specs that build cleanly, so a build failure under the
+        // probe is attributable to the injected option, not a terse entry.
+        if registry.build(spec).is_err() {
+            continue;
+        }
+        let mut bogus = spec.clone();
+        bogus.extra.insert(
+            serde_yaml_ng::Value::String("__alint_unknown_option_probe__".into()),
+            serde_yaml_ng::Value::Bool(true),
+        );
+        probed.insert(spec.kind.clone());
+        if registry.build(&bogus).is_ok() {
+            swallowers.push(spec.kind.clone());
+        }
+    }
+    swallowers.sort();
+    swallowers.dedup();
+    assert!(
+        swallowers.is_empty(),
+        "rule kind(s) SILENTLY ACCEPT an unknown option (register via \
+         `register_optionless` if the kind takes none, else propagate \
+         `deserialize_options()`): {swallowers:?}",
+    );
+
+    // Completeness: every registered kind must have been probed, so a newly
+    // added kind or alias can't slip the check by lacking a building fixture
+    // entry. `fixture_covers_every_registered_rule_kind` guarantees presence;
+    // this asserts the entry builds and was actually probed.
+    let registered: std::collections::BTreeSet<String> =
+        registry.known_kinds().map(str::to_string).collect();
+    let unprobed: Vec<&String> = registered.difference(&probed).collect();
+    assert!(
+        unprobed.is_empty(),
+        "registered kind(s) not probed for unknown-option rejection — their \
+         `all_kinds.yaml` entry must build cleanly: {unprobed:?}",
+    );
+}
+
 #[test]
 fn accepts_dogfood_config() {
     // The repo's own `.alint.yml` lives outside this crate; load it at

--- a/crates/alint-rules/src/every_matching_has.rs
+++ b/crates/alint-rules/src/every_matching_has.rs
@@ -23,7 +23,7 @@ use serde::Deserialize;
 
 use crate::for_each_dir::{
     IterateMode, SelectSpec, compile_nested_require, evaluate_for_each, parse_when_iter,
-    resolve_select,
+    resolve_select, validate_nested_require,
 };
 
 #[derive(Debug, Deserialize)]
@@ -47,6 +47,10 @@ pub struct EveryMatchingHasRule {
 
 impl Rule for EveryMatchingHasRule {
     alint_core::rule_common_impl!();
+
+    fn validate_nested(&self, registry: &alint_core::RuleRegistry) -> Result<()> {
+        validate_nested_require(&self.id, self.level, &self.require, registry)
+    }
 
     fn requires_full_index(&self) -> bool {
         // Cross-file: every entry matching `select` must satisfy

--- a/crates/alint-rules/src/for_each_dir.rs
+++ b/crates/alint-rules/src/for_each_dir.rs
@@ -105,6 +105,10 @@ impl Rule for ForEachDirRule {
         true
     }
 
+    fn validate_nested(&self, registry: &alint_core::RuleRegistry) -> Result<()> {
+        validate_nested_require(&self.id, self.level, &self.require, registry)
+    }
+
     fn evaluate(&self, ctx: &Context<'_>) -> Result<Vec<Violation>> {
         evaluate_for_each(
             &self.id,
@@ -159,6 +163,35 @@ pub(crate) fn compile_nested_require(
         .enumerate()
         .map(|(idx, spec)| CompiledNestedSpec::compile(spec, parent_id, idx))
         .collect()
+}
+
+/// Dry-build each nested `require:` spec against the registry so a
+/// nested rule with an unknown kind, an unknown option, or a missing
+/// required field fails at config-load time — not lazily on the first
+/// matching iteration, and not silently when the selector matches
+/// nothing. Shared by `for_each_dir`, `for_each_file`, and
+/// `every_matching_has` via their `Rule::validate_nested` impls.
+///
+/// A placeholder path token set is used: only structural errors
+/// (kind / option / required-field) surface here — the per-iteration
+/// path *values* are irrelevant to whether a nested spec builds.
+pub(crate) fn validate_nested_require(
+    parent_id: &str,
+    level: Level,
+    require: &[CompiledNestedSpec],
+    registry: &alint_core::RuleRegistry,
+) -> Result<()> {
+    let tokens = alint_core::template::PathTokens::from_path(std::path::Path::new("_"));
+    for (idx, compiled) in require.iter().enumerate() {
+        let synthesized = compiled.spec.instantiate(parent_id, idx, level, &tokens);
+        registry.build(&synthesized).map_err(|e| {
+            Error::rule_config(
+                parent_id,
+                format!("nested rule #{idx} (`{}`): {e}", compiled.spec.kind),
+            )
+        })?;
+    }
+    Ok(())
 }
 
 /// Compile a `when_iter:` source string into a `WhenExpr` at
@@ -537,6 +570,36 @@ mod tests {
         let r = rule("components/*", vec![require_file_exists("{dir}/index.tsx")]);
         let v = eval_with(&r, &[("src", true), ("src/foo", true)]);
         assert!(v.is_empty());
+    }
+
+    #[test]
+    fn validate_nested_rejects_unknown_kind_and_option() {
+        let reg = registry();
+
+        // A valid nested rule validates clean.
+        let good = rule("src/*", vec![require_file_exists("{path}/mod.rs")]);
+        assert!(good.validate_nested(&reg).is_ok());
+
+        // Unknown nested KIND → Err naming the kind. The selector deliberately
+        // matches nothing: `validate_nested` runs at load, before any walk, so
+        // a nested typo is caught even when no directory would be iterated
+        // (the gap where `check` previously reported "passed").
+        let bad_kind: NestedRuleSpec =
+            serde_yaml_ng::from_str("kind: totally_fake_kind\npaths: \"{path}/x\"\n").unwrap();
+        let r = rule("matches-nothing/*", vec![bad_kind]);
+        let err = r.validate_nested(&reg).unwrap_err().to_string();
+        assert!(err.contains("totally_fake_kind"), "{err}");
+
+        // Unknown nested OPTION → Err.
+        let bad_opt: NestedRuleSpec =
+            serde_yaml_ng::from_str("kind: file_exists\npaths: \"{path}/x\"\nbogusopt: true\n")
+                .unwrap();
+        let r = rule("src/*", vec![bad_opt]);
+        let err = r.validate_nested(&reg).unwrap_err().to_string();
+        assert!(
+            err.contains("bogusopt") || err.contains("unknown field"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/crates/alint-rules/src/for_each_file.rs
+++ b/crates/alint-rules/src/for_each_file.rs
@@ -25,7 +25,7 @@ use serde::Deserialize;
 
 use crate::for_each_dir::{
     IterateMode, SelectSpec, compile_nested_require, evaluate_for_each, parse_when_iter,
-    resolve_select,
+    resolve_select, validate_nested_require,
 };
 
 #[derive(Debug, Deserialize)]
@@ -53,6 +53,10 @@ pub struct ForEachFileRule {
 
 impl Rule for ForEachFileRule {
     alint_core::rule_common_impl!();
+
+    fn validate_nested(&self, registry: &alint_core::RuleRegistry) -> Result<()> {
+        validate_nested_require(&self.id, self.level, &self.require, registry)
+    }
 
     fn evaluate(&self, ctx: &Context<'_>) -> Result<Vec<Violation>> {
         evaluate_for_each(

--- a/crates/alint-rules/src/lib.rs
+++ b/crates/alint-rules/src/lib.rs
@@ -351,7 +351,7 @@ pub fn register_builtin(registry: &mut RuleRegistry) {
     registry.register("git_blame_age", git_blame_age::build);
     registry.register("changeset_requires_path", changeset_requires_path::build);
     registry.register_optionless("file_is_text", file_is_text::build);
-    registry.register("is_text", file_is_text::build);
+    registry.register_optionless("is_text", file_is_text::build);
 
     registry.register("filename_case", filename_case::build);
     registry.register("filename_regex", filename_regex::build);

--- a/crates/alint/src/main.rs
+++ b/crates/alint/src/main.rs
@@ -1592,8 +1592,13 @@ fn validate_config_inner(config_path: &Path) -> Result<usize> {
         if matches!(spec.level, alint_core::Level::Off) {
             continue;
         }
-        registry
+        let rule = registry
             .build(spec)
+            .with_context(|| format!("building rule {:?}", spec.id))?;
+        // Structurally validate any nested `require:` sub-rules (unknown
+        // kind / option / missing field) — the cross-file iteration rules
+        // build these lazily, so without this they slip past validate-config.
+        rule.validate_nested(&registry)
             .with_context(|| format!("building rule {:?}", spec.id))?;
         if let Some(when_src) = &spec.when {
             alint_core::when::parse(when_src)
@@ -1673,6 +1678,11 @@ fn load_rules(cwd: &Path, cli: &Cli) -> Result<LoadedConfig> {
         }
         let mut rule = registry
             .build(spec)
+            .with_context(|| format!("building rule {:?}", spec.id))?;
+        // Structurally validate nested `require:` sub-rules at load, so a
+        // typo'd nested kind/option fails here rather than lazily mid-walk
+        // (or never, when the selector matches no entries).
+        rule.validate_nested(&registry)
             .with_context(|| format!("building rule {:?}", spec.id))?;
         // Apply the top-level `allow_out_of_root:` policy (parsed from
         // the user's own config only — never from `extends:`). A rule

--- a/examples/clap-rs-clap/.alint.yml
+++ b/examples/clap-rs-clap/.alint.yml
@@ -253,7 +253,7 @@ rules:
     require:
       - kind: toml_path_matches
         paths: "{path}/Cargo.toml"
-        path: "$.package.metadata.docs.rs.rustdoc-args[*]"
+        path: "$.package.metadata.docs.rs['rustdoc-args'][*]"
         matches: '^--generate-link-to-definition$'
         if_present: true
     level: info


### PR DESCRIPTION
## What

A thorough audit of every feature added since v0.12 surfaced three cases where a **config error that should fail loudly passed silently**. This PR makes all three error, each with a regression test. (Docs/schema/polish findings from the same audit follow in a second PR.)

## The three fixes

### 1. 🔴 `is_text` swallowed unknown options
The `is_text` alias of `file_is_text` was registered with plain `register()` instead of `register_optionless()`, so a typo'd option built clean — while the canonical `file_is_text` (and every other kind) rejected it.

```
kind: is_text + notarealoption:true   → was: ✓ Config valid (exit 0)   now: unknown field (exit 1)
```

One-line registration fix. The prior unknown-option class-test enumerated kinds from **doc examples** (and only asserted `>= 30` probed), so an alias with no doc example slipped through. Replaced with a **registry-driven** test that probes *every* registered kind — aliases included — off `all_kinds.yaml` (guaranteed by `fixture_covers_every_registered_rule_kind` to cover all kinds), with a completeness assertion. Verified it fails (`["is_text"]`) without the fix.

### 2. 🟠 `validate-config` skipped nested `require:` validation
`for_each_dir` / `for_each_file` / `every_matching_has` build their nested rules lazily per matched entry, so a nested unknown kind / option / missing-field passed `validate-config` clean, and `check` caught it **only when the selector matched ≥1 entry** (matched-nothing → never).

```
for_each_dir → require:[{kind: totally_fake_kind}], select: "nonexistent/*"
   → was: validate-config ✓ AND check ✓ (exit 0)   now: both error naming the kind
```

New `Rule::validate_nested` hook (default no-op; the three iteration rules override it) dry-builds each nested spec at load against the registry — so structural errors surface immediately at both the validate-config and check build sites, honoring validate-config's "is the config loadable?" contract.

### 3. 🟠 nested `allow_out_of_root:` silently dropped (security-adjacent)
Every other root-only trust key (`extends`/`facts`/`vars`/`ignore`/`nested_configs`/`baseline`) already errored when set in a nested `.alint.yml`; `allow_out_of_root` parsed and was ignored without feedback. Confinement always held (the grant was **never** honored from a nested config), but it now fails loudly for parity, so a subtree can't appear to grant itself out-of-root reads.

## Tests
- `every_registered_kind_rejects_an_unknown_option` (alint-dsl) — registry-driven, all kinds + aliases; **fails without fix 1**.
- `validate_nested_rejects_unknown_kind_and_option` (alint-rules) — incl. the empty-selector case.
- `nested_allow_out_of_root_is_rejected` (alint-dsl) — mirrors `nested_baseline_is_rejected`.

Full preflight green (fmt/clippy/test/doc + all gen-* drift gates/dogfood).