### PR TITLE
ci: isolate untrusted fork-PR runs to ephemeral runners (H6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,22 @@ jobs:
       # Routing runs FIRST and writes to its OWN step output, which the
       # (untrusted) detect step below cannot touch — so a fork's
       # detect-changes.sh can never force the downstream jobs onto the box.
+      # Trust is decided by full_name equality and fails CLOSED: a non-PR
+      # event (push/tag), or a PR whose head repo IS this repo (a collaborator
+      # branch), is trusted → self-hosted. A fork — OR a null/absent head.repo
+      # (a deleted/detached fork) — is untrusted → ephemeral ubuntu-latest.
+      # (`== github.repository`, not the `fork` bit, so it also stays correct
+      # were this repo itself a fork.)
       - id: route
         env:
-          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+          IS_TRUSTED: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
-          if [ "$IS_FORK" = "true" ]; then
-            echo 'runner=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
-            echo 'untrusted=true' >> "$GITHUB_OUTPUT"
-          else
+          if [ "$IS_TRUSTED" = "true" ]; then
             echo 'runner=["self-hosted","linux","alint"]' >> "$GITHUB_OUTPUT"
             echo 'untrusted=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'runner=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
+            echo 'untrusted=true' >> "$GITHUB_OUTPUT"
           fi
       - id: detect
         env:
@@ -349,7 +355,10 @@ jobs:
       - examples
       - shell-tests
       - editors
-    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
+    # Defensive default: `summary` is `if: always()`, so it evaluates runs-on
+    # even when `changes` is cancelled before the route step (empty `runner`);
+    # fall back to ubuntu-latest so a clean cancel can't fail on fromJSON('').
+    runs-on: ${{ needs.changes.outputs.runner && fromJSON(needs.changes.outputs.runner) || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
       - env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,20 +24,43 @@ env:
 # ─────────────────────────────────────────────────────────────────────
 jobs:
 
-  # ── Change detection ──────────────────────────────────────────────
+  # ── Change detection + runner routing ─────────────────────────────
+  # SECURITY (audit H6): this entry job runs on ubuntu-latest, never the
+  # self-hosted box — it's the first job a fork PR reaches and it checks out
+  # (untrusted) PR code. It routes every downstream job's runner from the
+  # IMMUTABLE `head.repo.fork` context: a fork PR → ephemeral ubuntu-latest;
+  # anything trusted (push / tag / same-repo PR) → the warm self-hosted box.
+  # The decision is taken from context, NOT from a checked-out script — see
+  # docs/design/v0.14/ci-fork-pr-isolation.md.
   changes:
     name: Detect Changes
-    runs-on: [self-hosted, linux, alint]
+    runs-on: ubuntu-latest
     outputs:
       rust: ${{ steps.detect.outputs.rust }}
       docs: ${{ steps.detect.outputs.docs }}
       bench: ${{ steps.detect.outputs.bench }}
       examples: ${{ steps.detect.outputs.examples }}
       editors: ${{ steps.detect.outputs.editors }}
+      runner: ${{ steps.route.outputs.runner }}
+      untrusted: ${{ steps.route.outputs.untrusted }}
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+      # Routing runs FIRST and writes to its OWN step output, which the
+      # (untrusted) detect step below cannot touch — so a fork's
+      # detect-changes.sh can never force the downstream jobs onto the box.
+      - id: route
+        env:
+          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+        run: |
+          if [ "$IS_FORK" = "true" ]; then
+            echo 'runner=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
+            echo 'untrusted=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'runner=["self-hosted","linux","alint"]' >> "$GITHUB_OUTPUT"
+            echo 'untrusted=false' >> "$GITHUB_OUTPUT"
+          fi
       - id: detect
         env:
           GH_EVENT: ${{ github.event_name }}
@@ -50,7 +73,7 @@ jobs:
     name: Format
     needs: changes
     if: needs.changes.outputs.rust == 'true'
-    runs-on: [self-hosted, linux, alint]
+    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -65,7 +88,7 @@ jobs:
     if: >-
       !cancelled() && !failure()
       && needs.changes.outputs.rust == 'true'
-    runs-on: [self-hosted, linux, alint]
+    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -80,7 +103,7 @@ jobs:
     if: >-
       !cancelled() && !failure()
       && needs.changes.outputs.rust == 'true'
-    runs-on: [self-hosted, linux, alint]
+    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -95,7 +118,7 @@ jobs:
     if: >-
       !cancelled() && !failure()
       && needs.changes.outputs.rust == 'true'
-    runs-on: [self-hosted, linux, alint]
+    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -110,7 +133,7 @@ jobs:
     if: >-
       !cancelled() && !failure()
       && needs.changes.outputs.rust == 'true'
-    runs-on: [self-hosted, linux, alint]
+    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -125,7 +148,7 @@ jobs:
     if: >-
       !cancelled() && !failure()
       && needs.changes.outputs.rust == 'true'
-    runs-on: [self-hosted, linux, alint]
+    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -147,13 +170,21 @@ jobs:
     if: >-
       !cancelled() && !failure()
       && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.docs == 'true')
-    runs-on: [self-hosted, linux, alint]
+    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           key: ci-docs
+      # Ephemeral fork-PR path only: the box's runner image already ships
+      # Node 22, but a fresh ubuntu-latest needs it so docs.sh's
+      # `likec4 validate` + `gen-mermaid --check` gates run (they fetch
+      # likec4 via `npx -y likec4@<pin>`). Skipped on the box.
+      - if: needs.changes.outputs.untrusted == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
       # Load-bearing for schema/parser/contract correctness; must catch drift
       # on a PR, not only post-merge.
       - run: ci/scripts/docs.sh
@@ -164,7 +195,7 @@ jobs:
     if: >-
       !cancelled() && !failure()
       && needs.changes.outputs.rust == 'true'
-    runs-on: [self-hosted, linux, alint]
+    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -177,10 +208,13 @@ jobs:
   bench-smoke:
     name: Bench Smoke
     needs: [changes, build]
+    # `untrusted != 'true'` keeps this box-only job off fork PRs (they route
+    # to ubuntu-latest, where a bench job is meaningless).
     if: >-
       !cancelled() && !failure()
       && needs.changes.outputs.bench == 'true'
-    runs-on: [self-hosted, linux, alint]
+      && needs.changes.outputs.untrusted != 'true'
+    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -199,11 +233,13 @@ jobs:
   perf-gate:
     name: Perf Gate (deterministic)
     needs: [changes, build]
+    # `untrusted != 'true'` keeps this box-only (Valgrind) job off fork PRs.
     if: >-
       !cancelled() && !failure()
       && github.event_name == 'pull_request'
       && needs.changes.outputs.rust == 'true'
-    runs-on: [self-hosted, linux, alint]
+      && needs.changes.outputs.untrusted != 'true'
+    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     env:
       # Advisory: a perf regression annotates but does not fail the job. When
       # flipping this to "0" (enforcing), also add `perf-gate` to the `summary`
@@ -232,7 +268,7 @@ jobs:
     if: >-
       !cancelled() && !failure()
       && needs.changes.outputs.examples == 'true'
-    runs-on: [self-hosted, linux, alint]
+    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -251,7 +287,7 @@ jobs:
     if: >-
       !cancelled() && !failure()
       && needs.changes.outputs.rust == 'true'
-    runs-on: [self-hosted, linux, alint]
+    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
       - uses: actions/checkout@v7
       - run: ci/scripts/shell-tests.sh
@@ -313,7 +349,7 @@ jobs:
       - examples
       - shell-tests
       - editors
-    runs-on: [self-hosted, linux, alint]
+    runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
       - uses: actions/checkout@v7
       - env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
     # forks anyway. The ALINT_COVERAGE_FLOOR gate still runs on push-to-main
     # and on every same-repo (collaborator) PR. See
     # docs/design/v0.14/ci-fork-pr-isolation.md.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux, alint]
     # Self-fail fast if the runner ever hangs again, instead of sitting at the
     # 360-min GitHub default and holding the single self-hosted runner. 90 min

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,13 @@ env:
 jobs:
   coverage:
     name: cargo-llvm-cov
+    # SECURITY (audit H6): never run on the self-hosted box for a fork PR.
+    # Coverage needs the box's pids-limit / CARGO_BUILD_JOBS tuning (a hosted
+    # instrumented build OOMs/hangs) and its Codecov secret is withheld from
+    # forks anyway. The ALINT_COVERAGE_FLOOR gate still runs on push-to-main
+    # and on every same-repo (collaborator) PR. See
+    # docs/design/v0.14/ci-fork-pr-isolation.md.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     runs-on: [self-hosted, linux, alint]
     # Self-fail fast if the runner ever hangs again, instead of sitting at the
     # 360-min GitHub default and holding the single self-hosted runner. 90 min

--- a/ci/scripts/audit.sh
+++ b/ci/scripts/audit.sh
@@ -4,6 +4,20 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$REPO_ROOT"
 
+# cargo-audit may not be on the runner. It is on the self-hosted CI runner
+# but NOT on a fresh GitHub-hosted ubuntu-latest (the fork-PR lane — see
+# docs/design/v0.14/ci-fork-pr-isolation.md). Install on demand, pinned with
+# --locked, so the gate is portable across both. Swatinem/rust-cache persists
+# ~/.cargo/bin so the install only pays once per cache window. (Mirrors
+# deny.sh.)
+if ! command -v cargo-audit >/dev/null 2>&1; then
+    echo "==> cargo-audit not found; installing (cargo install --locked)"
+    # Clear RUSTFLAGS for the tool build only: CI sets `-D warnings` for
+    # *alint's* code, but applying it while compiling a third-party tool
+    # would fail the install on any upstream warning.
+    RUSTFLAGS= cargo install cargo-audit --locked
+fi
+
 echo "==> Running cargo audit"
 # Advisory-only for v0.1: known vulnerabilities in upstream deps should be
 # visible but must not block the pipeline until we have a policy.


### PR DESCRIPTION
Implements the H6 follow-up specced in `docs/design/v0.14/ci-fork-pr-isolation.md` (in #103), with its three recommended defaults: **skip coverage on fork PRs**, **dynamic routing** (keep the fast box for trusted CI), and **fold tool-installs into the scripts**.

## Why
`asamarts/alint` is public. `ci.yml` + `coverage.yml` were the only two workflows running on the **self-hosted** box for `pull_request` (verified — every other PR workflow is `ubuntu-latest`). A fork PR there runs untrusted PR code on the maintainer's persistent machine (SSH/deploy keys, both `gh` tokens, cargo creds). That's audit finding **H6**. The GitHub "require approval for all outside collaborators" setting (already enabled) gates *auto-run*; this keeps fork code off the box entirely — defence in depth.

## What
- The `changes` entry job now runs on **`ubuntu-latest`** (never the box — it's the first job a fork PR reaches and it checks out PR code). It routes every downstream job's runner from the **immutable `head.repo.fork` context**:
  - **fork PR → ephemeral `ubuntu-latest`** (no box secrets; GitHub also withholds secrets + isolates the cache),
  - **trusted** (push / tag / same-repo collaborator PR) → the warm **self-hosted** box.
- **Security invariant:** the route is computed in its *own* step from context, before — and unreadable by — the (untrusted) `detect-changes.sh` step, so a fork's script can't force itself onto the box. (For `pull_request`, GitHub runs the base repo's workflow YAML but the fork's scripts; the routing must come from context, not a script.)
- **Box-only jobs skip on fork PRs:** `bench-smoke`, `perf-gate` (Valgrind), and `coverage` (needs the box's pids/jobs tuning; its Codecov secret is withheld from forks anyway). Their gates still run on push + collaborator PRs.
- **Ephemeral-path gaps closed:** `audit.sh` now self-installs `cargo-audit` (mirrors `deny.sh`); the `docs` job gets Node 22 on the hosted path so its `likec4 validate` / `gen-mermaid --check` gates run. `editors` stays `ubuntu-latest` (unchanged).

Net for a fork PR: full fmt/clippy/test/build/audit/deny/docs/dogfood/examples/shell-tests on `ubuntu-latest`; bench/perf/coverage skipped. A contributor still sees a real green/red.

## Validation
- `actionlint` clean (it caught one real bug pre-push: inline `#` comments on `if: >-` expression lines — moved to proper comment lines).
- YAML parses; `bash -n` on the changed script.
- **Needs a real fork PR to exercise end-to-end** (the trusted path is unchanged and runs on this PR). Rollout/test steps are in the spec §7: open a throwaway-fork PR and confirm (a) all jobs land on `ubuntu-latest`, (b) bench/perf/coverage skip, (c) the box shows no jobs for it; and that a same-repo PR + push still use the box.

Companion to the security PR #103 (the spec lives there).
