### PR TITLE
fix: post-v0.13 audit tail — contained security/correctness fixes (M2/M8/M10/M14 + L1–L14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   it into a regular file). `final_newline`'s
   on-disk path is reconciled with its editor path (it no longer double-appends
   to an already-terminated or empty file). (H3)
+- **GitLab Code Quality no longer drops duplicate findings.** The
+  `fingerprint` was `SHA256(rule_id|path|message)`, so two genuinely-distinct
+  findings sharing all three (a generic-message per-line rule firing on
+  several lines of one file) produced the same fingerprint — and the Code
+  Climate spec GitLab consumes requires per-report uniqueness, so GitLab
+  silently kept only one. The fingerprint now folds in a per-report
+  `occurrence` discriminator. The line number is still deliberately excluded,
+  so a finding that drifts up/down stays the same issue across runs; only true
+  duplicates are disambiguated. (M10)
 - **`--config` is honest about being single-valued.** The flag help promised
   "repeatable; later overrides earlier", but every consumer read only the
   first `-c`, so a second was silently dropped — and worse, was position-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   for a secrets control. Bare patterns are now auto-anchored to `**/<pattern>`
   (matching any depth, root included); explicit-path patterns
   (`secrets/*.key`, `**/*.pem`) are taken as written. (M5)
+- **Human output neutralizes terminal escapes in untrusted text.** A repo
+  file named with an `\x1b[…]` sequence — or a `kind: command` rule whose
+  subprocess output carries ANSI codes — could clear the screen, hide
+  findings below the fold, or forge an "all rules passed." banner when a
+  human lints an untrusted repo (alint's `anstream` stream passes raw bytes
+  through on a TTY, exactly where the escapes fire). The grouped, compact,
+  and fix renderers now replace every control char (except the intentional
+  newline) in attacker-controlled paths/messages with a visible `\xNN`
+  escape. alint's own styling is unaffected, machine formats (JSON/SARIF/…)
+  are unchanged, and clean output is byte-identical (no TTY-conditional
+  divergence). (M8)
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   for a secrets control. Bare patterns are now auto-anchored to `**/<pattern>`
   (matching any depth, root included); explicit-path patterns
   (`secrets/*.key`, `**/*.pem`) are taken as written. (M5)
+- **Completed the Unicode control-character sets for the obfuscation rules.**
+  `no_bidi_controls` now also flags the implicit directional marks U+061C
+  (ALM), U+200E (LRM), and U+200F (RLM) — completing the Trojan-Source
+  (CVE-2021-42574) set that rustc's own lint covers; `no_zero_width_chars`
+  now also flags U+2060 (WORD JOINER) and U+180E. The strip fixers extend in
+  lockstep. Note: U+200D (ZWJ) stays flagged even though it joins emoji
+  sequences, so its strip fixer will break a literal emoji ZWJ sequence —
+  scope the rule away from files that legitimately carry such emoji. (L1)
 - **Human output neutralizes terminal escapes in untrusted text.** A repo
   file named with an `\x1b[…]` sequence — or a `kind: command` rule whose
   subprocess output carries ANSI codes — could clear the screen, hide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   carrying a 19-digit author-time (parses as `u64`, overflows `SystemTime` on
   `+`) aborted the run; the addition is now checked and a malformed timestamp
   is dropped. (M7)
+- **`git_no_denied_paths` denylist patterns are anchored to any depth.** A
+  bare denied pattern (no `/`) like `*.pem` or `id_rsa` was root-anchored by
+  globset, so `secrets/server.pem` evaded the denylist — a dangerous default
+  for a secrets control. Bare patterns are now auto-anchored to `**/<pattern>`
+  (matching any depth, root included); explicit-path patterns
+  (`secrets/*.key`, `**/*.pem`) are taken as written. (M5)
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   literals.** A dash in a comparison literal (`@.x == 'a.dashed-value'`) used
   to trigger the "use bracket notation" hint; quoted spans are now masked
   before the check. (L11)
+- **`custom` facts now honor a 30s timeout.** The doc promised that a timing-out
+  custom-fact command resolves to the empty string, but the implementation used
+  a blocking `Command::output()` with no timeout — a hanging command froze the
+  run. It now drains output on a thread and kills the child at the deadline
+  (matching the `command` rule's 30s default). (L6)
+- **`when:` `matches` on a missing fact is falsy, not an error.** `null == "x"`
+  was already falsy, but `<missing fact> matches "x"` hard-errored — an
+  inconsistency. A missing (null) left-hand side now evaluates to `false`; a
+  non-string *value* is still a config-type error. (L10)
 - **SARIF file paths are now valid URI references.** `artifactLocation.uri`
   emitted the raw OS path, so a `\`-separated path on Windows broke GitHub
   Code Scanning's repo-file mapping, and a path containing a space / `#` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   fetcher now refuses redirects outright; an `extends:` URL is SRI-pinned to
   specific content, so it must point at the final resource and a redirect
   surfaces as a clear error. (M1)
+- **Local `extends:` targets are confined to the config's directory.** A local
+  `extends: ../../../../etc/shadow` (or an absolute path) in a shared ruleset
+  committed to the repo was read off the host, and a YAML-parse error could
+  echo file content back — a read/exfil oracle. The loader now rejects any
+  local `extends:` target that resolves outside the top-level config's
+  directory; both sides are canonicalized so `..` and symlinks (an in-tree
+  symlink pointing out) are caught. A top-level `allow_out_of_root: true`
+  lifts it for the whole chain (the same blanket escape that lifts per-rule
+  read confinement); `extends:`'d and nested configs still cannot grant it. (M2)
 - **A non-UTF-8 commit can no longer bypass commit linting.** `parse_commit_log`
   silently dropped any commit whose author name, email, or message was not
   valid UTF-8, so a contributor could dodge `git_commit_subject_matches` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,23 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   was already falsy, but `<missing fact> matches "x"` hard-errored — an
   inconsistency. A missing (null) left-hand side now evaluates to `false`; a
   non-string *value* is still a config-type error. (L10)
+- **`when:` string literals are decoded as UTF-8.** The lexer cast each byte to
+  `char` (Latin-1), so a non-ASCII literal like `vars.x == "café"` was lexed as
+  mojibake and could never match. Multi-byte scalars now lex correctly. (L3)
+- **`no_case_conflicts` folds case the Unicode way.** It lowercased ASCII-only,
+  so `É.txt`/`é.txt` (and other non-ASCII case pairs) slipped past — yet a
+  case-insensitive filesystem folds them. It now uses Unicode `to_lowercase`,
+  the strict portable default. (L2)
+- **`command` argv is guarded against option-injection via filenames.** A repo
+  file named like a flag (e.g. `--write`) rendered from `{path}` could turn a
+  trusted `command: ["prettier", "--check", "{path}"]` into a destructive
+  `--write`. A path token that would render to a leading dash is now prefixed
+  with `./`; flags you wrote yourself are untouched. (L13)
+- **Unreadable files are reported, not silently skipped.** A non-`NotFound`
+  read error (permission denied, I/O) during the per-file walk was
+  indistinguishable from "file absent." Such errors are now logged at `warn`
+  (visible with `-v` / `RUST_LOG`); a genuinely-absent file still skips
+  silently and the run stays resilient. (L7)
 - **SARIF file paths are now valid URI references.** `artifactLocation.uri`
   emitted the raw OS path, so a `\`-separated path on Windows broke GitHub
   Code Scanning's repo-file mapping, and a path containing a space / `#` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   sensitive across the subcommand boundary, so `-c base.yml -c override.yml`
   could use `base`. A second `--config` is now a hard error pointing at
   `extends:` for composition, and the help text is corrected. (H4)
+- **`file_header` / `file_footer` fixers no longer stack duplicates.** When a
+  configured header/footer's content didn't satisfy the rule's own pattern,
+  the violation never cleared, so each `--fix` re-prepended/appended it. The
+  prepend/append fixers now skip when the file already begins/ends with that
+  content (idempotent across runs). (L4)
+- **`{token}` path templates no longer re-substitute.** `render_path` ran a
+  sequence of `String::replace` passes, so a token that appeared in an earlier
+  substitution's value (e.g. a file literally named `a{ext}.c`, stem `a{ext}`)
+  was wrongly re-expanded by a later pass. It now does a single left-to-right
+  scan, emitting each value once. (L8)
+- **The JSONPath dashed-key hint no longer false-fires inside string
+  literals.** A dash in a comparison literal (`@.x == 'a.dashed-value'`) used
+  to trigger the "use bracket notation" hint; quoted spans are now masked
+  before the check. (L11)
 - **SARIF file paths are now valid URI references.** `artifactLocation.uri`
   emitted the raw OS path, so a `\`-separated path on Windows broke GitHub
   Code Scanning's repo-file mapping, and a path containing a space / `#` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   lockstep. Note: U+200D (ZWJ) stays flagged even though it joins emoji
   sequences, so its strip fixer will break a literal emoji ZWJ sequence —
   scope the rule away from files that legitimately carry such emoji. (L1)
+- **Resource-exhaustion hardening (several spots).** A few unbounded
+  operations on attacker-influenced input are now capped: the `extends:`
+  chain has a depth cap (`MAX_EXTENDS_DEPTH = 64`) so a deeply-nested acyclic
+  chain errors instead of overflowing the recursion stack (L5); the remote-
+  `extends:` disk cache writes a PID-unique temp file instead of a fixed
+  `<sri>.yml.tmp` (no concurrent-run race) (L5); the "did you mean" suggester
+  skips length-mismatched candidates before building its edit-distance matrix,
+  bounding work on a multi-kilobyte unknown field name (L9); and a spawned
+  rule's captured stdout/stderr is capped at 64 MiB with the excess drained,
+  so a runaway generator can't OOM the run (L12). (L5, L9, L12)
 - **Human output neutralizes terminal escapes in untrusted text.** A repo
   file named with an `\x1b[…]` sequence — or a `kind: command` rule whose
   subprocess output carries ANSI codes — could clear the screen, hide

--- a/crates/alint-core/src/did_you_mean.rs
+++ b/crates/alint-core/src/did_you_mean.rs
@@ -134,12 +134,22 @@ fn levenshtein(a: &str, b: &str) -> usize {
 /// Find the closest expected field to `wrong` by Levenshtein
 /// distance, but only suggest if distance is ≤ 2 (otherwise the
 /// "suggestion" is more confusing than nothing).
+/// Largest edit distance we ever surface as a "did you mean" suggestion.
+const MAX_SUGGEST_DISTANCE: usize = 2;
+
 fn levenshtein_suggestion<'a>(wrong: &str, expected: &[&'a str]) -> Option<&'a str> {
+    // Edit distance is >= the difference in length, and we only suggest within
+    // `MAX_SUGGEST_DISTANCE`. So skip any candidate whose length differs by more
+    // than that *before* building the O(n*m) matrix (L9): this bounds the work
+    // on a hostile multi-kilobyte unknown-field name — every real field name is
+    // short, so a huge `wrong` matches nothing and no matrix is ever built.
+    let wrong_len = wrong.chars().count();
     expected
         .iter()
+        .filter(|e| wrong_len.abs_diff(e.chars().count()) <= MAX_SUGGEST_DISTANCE)
         .map(|&e| (e, levenshtein(wrong, e)))
         .min_by_key(|&(_, d)| d)
-        .filter(|&(_, d)| d <= 2)
+        .filter(|&(_, d)| d <= MAX_SUGGEST_DISTANCE)
         .map(|(e, _)| e)
 }
 
@@ -259,6 +269,17 @@ mod tests {
         let msg = "unknown field `completely_random`, expected one of `paths`, `level`";
         let out = enrich("file_exists", msg);
         assert!(!out.contains("did you mean"), "out: {out}");
+    }
+
+    #[test]
+    fn huge_unknown_field_is_bounded_and_suggests_nothing() {
+        // L9: a hostile multi-kilobyte unknown field must not build a giant
+        // edit-distance matrix; it is length-mismatched from every real field
+        // by far more than the threshold, so it suggests nothing (and fast).
+        let huge = "x".repeat(50_000);
+        let msg = format!("unknown field `{huge}`, expected one of `paths`, `level`");
+        let out = enrich("file_exists", &msg);
+        assert!(!out.contains("did you mean"), "no suggestion for a huge field");
     }
 
     #[test]

--- a/crates/alint-core/src/did_you_mean.rs
+++ b/crates/alint-core/src/did_you_mean.rs
@@ -131,12 +131,12 @@ fn levenshtein(a: &str, b: &str) -> usize {
     dp[n][m]
 }
 
-/// Find the closest expected field to `wrong` by Levenshtein
-/// distance, but only suggest if distance is ≤ 2 (otherwise the
-/// "suggestion" is more confusing than nothing).
 /// Largest edit distance we ever surface as a "did you mean" suggestion.
 const MAX_SUGGEST_DISTANCE: usize = 2;
 
+/// Find the closest expected field to `wrong` by Levenshtein distance, but only
+/// suggest if distance is ≤ [`MAX_SUGGEST_DISTANCE`] (otherwise the
+/// "suggestion" is more confusing than nothing).
 fn levenshtein_suggestion<'a>(wrong: &str, expected: &[&'a str]) -> Option<&'a str> {
     // Edit distance is >= the difference in length, and we only suggest within
     // `MAX_SUGGEST_DISTANCE`. So skip any candidate whose length differs by more

--- a/crates/alint-core/src/did_you_mean.rs
+++ b/crates/alint-core/src/did_you_mean.rs
@@ -279,7 +279,10 @@ mod tests {
         let huge = "x".repeat(50_000);
         let msg = format!("unknown field `{huge}`, expected one of `paths`, `level`");
         let out = enrich("file_exists", &msg);
-        assert!(!out.contains("did you mean"), "no suggestion for a huge field");
+        assert!(
+            !out.contains("did you mean"),
+            "no suggestion for a huge field"
+        );
     }
 
     #[test]

--- a/crates/alint-core/src/engine.rs
+++ b/crates/alint-core/src/engine.rs
@@ -490,13 +490,13 @@ impl Engine {
                 if applicable.is_empty() {
                     return Vec::new();
                 }
-                // 2. Read once. Read failures (file deleted
-                // mid-walk, permission flake) skip the file
-                // silently — same shape as today's per-rule
-                // `let Ok(bytes) = std::fs::read(...) else
-                // continue;`.
+                // 2. Read once. A genuinely-absent file (deleted
+                // mid-walk) skips silently; a real read error
+                // (permission denied, I/O) is logged at `warn` so
+                // it isn't silently mistaken for "file absent"
+                // (L7). Either way the run stays resilient.
                 let abs = root.join(&file_entry.path);
-                let Ok(bytes) = std::fs::read(&abs) else {
+                let Some(bytes) = crate::walker::read_or_skip(&abs) else {
                     return Vec::new();
                 };
                 // 3. Dispatch. Every applicable rule sees the

--- a/crates/alint-core/src/facts.rs
+++ b/crates/alint-core/src/facts.rs
@@ -20,6 +20,9 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use std::io::Read as _;
+use std::time::{Duration, Instant};
+
 use regex::Regex;
 use serde::Deserialize;
 
@@ -134,8 +137,9 @@ impl FactKind {
 /// Fact-kind body for `custom`. Spawns `argv` as a child process
 /// rooted at the repo; the process's stdout (trimmed of trailing
 /// whitespace) becomes the fact's `String` value. A non-zero
-/// exit code resolves to the empty string; timeouts and spawn
-/// failures do the same. No shell is invoked — `argv` is passed
+/// exit code resolves to the empty string; a run past the 30s
+/// timeout (the child is killed) and spawn failures do the same.
+/// No shell is invoked — `argv` is passed
 /// to `execve` (or the platform equivalent) verbatim.
 ///
 /// Security: `custom` facts are only allowed in the user's own
@@ -266,27 +270,74 @@ fn evaluate_one(spec: &FactSpec, root: &Path, index: &FileIndex) -> Result<FactV
     }
 }
 
-/// Best-effort: spawn `argv` at `root`, capture stdout. Non-zero
-/// exit / spawn failures / unusable output → empty string.
+/// How long a `custom` fact's process may run before it is killed and the
+/// fact resolves to the empty string. Matches the `command` rule's default
+/// (30s) so the two trust-gated spawn paths behave consistently (L6).
+const CUSTOM_FACT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Best-effort: spawn `argv` at `root`, capture stdout. Non-zero exit / spawn
+/// failures / a run past [`CUSTOM_FACT_TIMEOUT`] / unusable output → empty
+/// string. stdout is drained on a thread so a chatty child can't deadlock on a
+/// full pipe while we wait on the deadline.
 fn run_custom(spec: &CustomFact, root: &Path) -> String {
+    run_custom_with_timeout(spec, root, CUSTOM_FACT_TIMEOUT)
+}
+
+/// [`run_custom`] with an injectable timeout so tests can exercise the
+/// deadline path without sleeping the full 30s.
+fn run_custom_with_timeout(spec: &CustomFact, root: &Path, timeout: Duration) -> String {
     let Some((program, args)) = spec.argv.split_first() else {
         return String::new();
     };
-    let output = std::process::Command::new(program)
+    let Ok(mut child) = std::process::Command::new(program)
         .args(args)
         .current_dir(root)
         .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
-        .output();
-    let Ok(output) = output else {
+        .spawn()
+    else {
         return String::new();
     };
-    if !output.status.success() {
-        return String::new();
-    }
-    match std::str::from_utf8(&output.stdout) {
-        Ok(text) => text.trim_end().to_string(),
-        Err(_) => String::new(),
+
+    let mut out_pipe = child.stdout.take();
+    let reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(p) = out_pipe.as_mut() {
+            // Custom facts are tiny by nature (a branch, a count); cap defensively.
+            let _ = p.take(1024 * 1024).read_to_end(&mut buf);
+        }
+        buf
+    });
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let buf = reader.join().unwrap_or_default();
+                if !status.success() {
+                    return String::new();
+                }
+                return std::str::from_utf8(&buf)
+                    .map(|t| t.trim_end().to_string())
+                    .unwrap_or_default();
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let _ = reader.join();
+                    return String::new();
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = reader.join();
+                return String::new();
+            }
+        }
     }
 }
 
@@ -605,6 +656,34 @@ mod tests {
         let facts = parse("- id: bad\n  custom:\n    argv: [\"/bin/false\"]\n");
         let v = evaluate_facts(&facts, tmp.path(), &idx(&[])).unwrap();
         assert_eq!(v.get("bad"), Some(&FactValue::String(String::new())));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn custom_fact_times_out_to_empty_string() {
+        // L6: a hanging custom fact is killed at the deadline and resolves to
+        // the empty string (the doc's promise), rather than hanging the run.
+        let spec = CustomFact {
+            argv: vec!["sleep".to_string(), "30".to_string()],
+        };
+        let start = Instant::now();
+        let got = run_custom_with_timeout(&spec, Path::new("."), Duration::from_millis(150));
+        assert_eq!(got, "", "timed-out fact is empty");
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "must return promptly at the deadline, not run the full sleep"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn custom_fact_captures_before_timeout() {
+        // A fast command still returns its output under the injectable timeout.
+        let spec = CustomFact {
+            argv: vec!["echo".to_string(), "hi".to_string()],
+        };
+        let got = run_custom_with_timeout(&spec, Path::new("."), Duration::from_secs(5));
+        assert_eq!(got, "hi");
     }
 
     #[test]

--- a/crates/alint-core/src/facts.rs
+++ b/crates/alint-core/src/facts.rs
@@ -255,7 +255,7 @@ fn evaluate_one(spec: &FactSpec, root: &Path, index: &FileIndex) -> Result<FactV
                 if !scope.matches(&entry.path, index) {
                     return false;
                 }
-                let Ok(bytes) = std::fs::read(root.join(&entry.path)) else {
+                let Some(bytes) = crate::walker::read_or_skip(&root.join(&entry.path)) else {
                     return false;
                 };
                 let Ok(text) = std::str::from_utf8(&bytes) else {

--- a/crates/alint-core/src/jsonpath_diagnostics.rs
+++ b/crates/alint-core/src/jsonpath_diagnostics.rs
@@ -44,10 +44,16 @@ pub fn diagnose_path(path: &str) -> Option<String> {
     // Pitfall #10: dashed key after `.` segment (in any position —
     // top-level or inside a filter). RFC 9535 dot-notation requires
     // identifier-shape keys; dashed keys must use bracket notation.
-    if let Some(cap) = dashed_after_dot_re().captures(path)
+    //
+    // Match against a copy with quoted string literals masked to spaces, so a
+    // dashed key *inside* a literal (`@.x == 'a.dashed-value'`) doesn't trigger
+    // a false hint (L11). Masking preserves byte length, so the match range
+    // still indexes the original `path` for the real key text.
+    let masked = mask_quoted_spans(path);
+    if let Some(cap) = dashed_after_dot_re().captures(&masked)
         && let Some(key_match) = cap.get(1)
     {
-        let key = key_match.as_str();
+        let key = &path[key_match.range()];
         return Some(format!(
             "JSONPath dot-notation requires identifier-shape keys (RFC 9535). For dashed keys, use \
              bracket notation: `$['{key}']` instead of `$.{key}` (or `@['{key}']` instead of \
@@ -56,6 +62,46 @@ pub fn diagnose_path(path: &str) -> Option<String> {
     }
 
     None
+}
+
+/// Replace the contents of single- or double-quoted spans in `s` with spaces,
+/// preserving the quote delimiters and the total byte length (each masked char
+/// becomes `len_utf8()` spaces). Backslash escapes inside a span are honored so
+/// an escaped quote doesn't end it early. Used to keep the dashed-key hint from
+/// firing on a dash that lives inside a string literal (L11).
+fn mask_quoted_spans(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+    for c in s.chars() {
+        if let Some(q) = quote {
+            if escaped {
+                escaped = false;
+                push_blank(&mut out, c);
+            } else if c == '\\' {
+                escaped = true;
+                push_blank(&mut out, c);
+            } else if c == q {
+                quote = None;
+                out.push(c);
+            } else {
+                push_blank(&mut out, c);
+            }
+        } else {
+            if c == '\'' || c == '"' {
+                quote = Some(c);
+            }
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Push `c.len_utf8()` spaces, so masking preserves byte offsets.
+fn push_blank(out: &mut String, c: char) {
+    for _ in 0..c.len_utf8() {
+        out.push(' ');
+    }
 }
 
 /// Build a complete error-message string for a `JSONPath` parse
@@ -108,6 +154,23 @@ mod tests {
     fn already_correct_bracket_notation_no_hint() {
         let path = "$['package-name']";
         assert!(diagnose_path(path).is_none());
+    }
+
+    #[test]
+    fn dashed_key_inside_string_literal_no_hint() {
+        // L11: the dash here is inside a comparison string literal, which is
+        // valid; the hint must not fire on it.
+        assert!(diagnose_path("$.foo[?@.bar == 'a.dashed-value']").is_none());
+        assert!(diagnose_path("$.items[?@.kind == \"x.y-z\"]").is_none());
+    }
+
+    #[test]
+    fn real_dashed_key_outside_literal_still_hints() {
+        // A genuine dashed key in the path is still diagnosed even when a
+        // string literal (with its own dash) is also present.
+        let hint = diagnose_path("$.foo[?@.real-key == 'a.dashed-value']")
+            .expect("should diagnose the real dashed key");
+        assert!(hint.contains("$['real-key']"), "hint: {hint}");
     }
 
     #[test]

--- a/crates/alint-core/src/rule.rs
+++ b/crates/alint-core/src/rule.rs
@@ -487,7 +487,7 @@ pub fn eval_per_file<R: PerFileRule + ?Sized>(
             continue;
         }
         let full = ctx.root.join(&entry.path);
-        let Ok(bytes) = std::fs::read(&full) else {
+        let Some(bytes) = crate::walker::read_or_skip(&full) else {
             continue;
         };
         violations.extend(rule.evaluate_file(ctx, &entry.path, &bytes)?);

--- a/crates/alint-core/src/scope.rs
+++ b/crates/alint-core/src/scope.rs
@@ -19,6 +19,18 @@ use crate::walker::FileIndex;
 /// `has_ancestor: Cargo.toml`). v0.9.10 moved it into `Scope` so
 /// `matches(&Path, &FileIndex)` honours it on every call automatically —
 /// the v0.9.6/v0.9.7/v0.9.9 silent-no-op bug class can no longer recur.
+///
+/// **Empty / exclude-only patterns are match-all (fail-open).** With no
+/// *include* pattern, the include check is skipped, so every non-excluded
+/// path matches. This is by design for the exclude-only idiom
+/// (`paths: ["!vendor/**"]` = "everything except vendor"), but it also means
+/// an explicit `paths: []` (no includes *and* no excludes) applies the rule to
+/// the **whole tree**, not to nothing — a foot-gun if `[]` was meant as "off."
+/// Prefer omitting `paths` for match-all, `level: off` to disable a rule, and
+/// real patterns otherwise. (L14: a load-time warning for the truly-empty case
+/// is a tracked follow-up — it needs an absent-vs-`[]` signal at the spec layer
+/// and a load-warning channel the loader doesn't yet expose, and must not
+/// false-warn the intentional exclude-only idiom.)
 #[derive(Debug, Clone)]
 pub struct Scope {
     include: GlobSet,
@@ -121,7 +133,8 @@ impl Scope {
 
     /// Returns `true` iff `path` is in scope:
     /// 1. Excluded patterns reject (dominant).
-    /// 2. Include patterns must match (skipped if no includes).
+    /// 2. Include patterns must match — **skipped if there are no includes**,
+    ///    so empty / exclude-only `paths` is match-all (see the type-level note).
     /// 3. `scope_filter` (if any) must match.
     ///
     /// The `index` argument is the engine's [`FileIndex`] —

--- a/crates/alint-core/src/template.rs
+++ b/crates/alint-core/src/template.rs
@@ -66,17 +66,40 @@ impl PathTokens {
 /// Substitute `{token}` placeholders in a path-shaped template. Unknown
 /// tokens are preserved literally (so `"{unknown}"` renders as `"{unknown}"`).
 ///
-/// Multi-character tokens are replaced longest-first so future additions like
-/// `{stem_kebab}` do not accidentally match `{stem}` first.
+/// Substitution is a single left-to-right scan into a fresh buffer: each known
+/// `{token}` is replaced by its value, and that value is emitted as-is and
+/// never re-scanned. A repeated `String::replace` pass (the prior approach)
+/// re-substituted a token that appeared in an *earlier* substitution's value —
+/// so a repo file literally named `a{ext}.c` (stem `a{ext}`) had its embedded
+/// `{ext}` wrongly expanded by the later `{ext}` pass, yielding a bogus path
+/// for the forbidding rules (L8). Unknown `{tokens}` are preserved verbatim.
 pub fn render_path(template: &str, t: &PathTokens) -> String {
-    let mut out = template.to_string();
-    // Order matters: longest keys first.
-    out = out.replace("{parent_name}", &t.parent_name);
-    out = out.replace("{basename}", &t.basename);
-    out = out.replace("{path}", &t.path);
-    out = out.replace("{stem}", &t.stem);
-    out = out.replace("{dir}", &t.dir);
-    out = out.replace("{ext}", &t.ext);
+    // Longest-first only matters if one token is a prefix of another; none is,
+    // but the order is kept stable for clarity / future additions.
+    let tokens: [(&str, &str); 6] = [
+        ("{parent_name}", &t.parent_name),
+        ("{basename}", &t.basename),
+        ("{path}", &t.path),
+        ("{stem}", &t.stem),
+        ("{dir}", &t.dir),
+        ("{ext}", &t.ext),
+    ];
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(open) = rest.find('{') {
+        out.push_str(&rest[..open]);
+        let at_brace = &rest[open..];
+        if let Some((tok, val)) = tokens.iter().find(|(tok, _)| at_brace.starts_with(tok)) {
+            out.push_str(val);
+            rest = &at_brace[tok.len()..];
+        } else {
+            // A `{` that doesn't begin a known token: emit it literally and
+            // resume after it (preserves `{unknown}` verbatim).
+            out.push('{');
+            rest = &at_brace['{'.len_utf8()..];
+        }
+    }
+    out.push_str(rest);
     out
 }
 
@@ -192,6 +215,16 @@ mod tests {
     fn render_path_unknown_token_preserved() {
         let t = PathTokens::from_path(Path::new("a.c"));
         assert_eq!(render_path("{bogus}/{stem}.x", &t), "{bogus}/a.x");
+    }
+
+    #[test]
+    fn render_path_does_not_resubstitute_token_in_value() {
+        // L8: a file literally named `a{ext}.c` has stem `a{ext}`. The `{ext}`
+        // that comes FROM the path value must NOT be expanded by the `{ext}`
+        // substitution (the old repeated-replace pass produced `ac.h`).
+        let t = PathTokens::from_path(Path::new("a{ext}.c"));
+        assert_eq!(t.stem, "a{ext}");
+        assert_eq!(render_path("{stem}.h", &t), "a{ext}.h");
     }
 
     #[test]

--- a/crates/alint-core/src/template.rs
+++ b/crates/alint-core/src/template.rs
@@ -103,6 +103,25 @@ pub fn render_path(template: &str, t: &PathTokens) -> String {
     out
 }
 
+/// [`render_path`] for a **command argv** element. If substituting a path token
+/// turns a non-flag template into a leading-dash string, the matched repo file
+/// name is masquerading as an option to the spawned tool — e.g. a file named
+/// `--write` rendered from `{path}` would flip `prettier --check {path}` into a
+/// destructive `--write`. Prefix `./` so it is unambiguously a path (L13).
+///
+/// A template element the user *wrote* as a flag (`--check`, `--file={path}`)
+/// already starts with `-`, so it is left untouched — only a leading dash
+/// *introduced by substitution* is guarded.
+#[must_use]
+pub fn render_path_argv(template: &str, t: &PathTokens) -> String {
+    let rendered = render_path(template, t);
+    if rendered.starts_with('-') && !template.starts_with('-') {
+        format!("./{rendered}")
+    } else {
+        rendered
+    }
+}
+
 /// Substitute `{{namespace.key}}` placeholders in a message template. The
 /// caller-supplied `resolve` closure returns the substituted value, or
 /// `None` to leave the placeholder literal.
@@ -225,6 +244,20 @@ mod tests {
         let t = PathTokens::from_path(Path::new("a{ext}.c"));
         assert_eq!(t.stem, "a{ext}");
         assert_eq!(render_path("{stem}.h", &t), "a{ext}.h");
+    }
+
+    #[test]
+    fn render_path_argv_guards_leading_dash_from_substitution() {
+        // L13: a repo file named like an option must not flip a trusted command.
+        let evil = PathTokens::from_path(Path::new("--write"));
+        assert_eq!(render_path_argv("{path}", &evil), "./--write");
+        // A flag the *user* wrote is left alone (it already starts with `-`).
+        let normal = PathTokens::from_path(Path::new("src/main.rs"));
+        assert_eq!(render_path_argv("--check", &normal), "--check");
+        // A path embedded after `=` keeps the dash inside the value (no option).
+        assert_eq!(render_path_argv("--file={path}", &evil), "--file=--write");
+        // The ordinary case is unchanged.
+        assert_eq!(render_path_argv("{path}", &normal), "src/main.rs");
     }
 
     #[test]

--- a/crates/alint-core/src/walker.rs
+++ b/crates/alint-core/src/walker.rs
@@ -8,6 +8,26 @@ use ignore::{
 
 use crate::error::{Error, Result};
 
+/// Read a walked file's bytes, returning `None` to skip it on any read error
+/// — but only *silently* when the file is genuinely gone (`NotFound`, the
+/// benign deleted-between-walk-and-read race). Any other error (permission
+/// denied, I/O failure) is logged at `warn` so it is observable with `-v` /
+/// `RUST_LOG`, instead of being indistinguishable from "file absent" (L7).
+///
+/// The run stays resilient (one unreadable file never aborts the whole lint),
+/// which is the long-standing per-file-read contract; this only makes the
+/// real-error case *loud* rather than silent.
+pub(crate) fn read_or_skip(path: &Path) -> Option<Vec<u8>> {
+    match std::fs::read(path) {
+        Ok(bytes) => Some(bytes),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e, "skipping unreadable file");
+            None
+        }
+    }
+}
+
 /// Debug-only tracing for `FileIndex` lazy index builds. Emits a
 /// `phase=index_build kind=<name> elapsed_us=N entries=M` event so
 /// `xtask bench-scale` profile runs and contributor debugging can

--- a/crates/alint-core/src/when/eval.rs
+++ b/crates/alint-core/src/when/eval.rs
@@ -82,6 +82,10 @@ fn eval_at(e: &WhenExpr, env: &WhenEnv<'_>, depth: usize) -> Result<Value, WhenE
             let lv = eval_at(left, env, depth)?;
             match lv {
                 Value::String(s) => Ok(Value::Bool(pattern.is_match(&s))),
+                // A missing fact (Null) matches nothing → falsy, mirroring how
+                // `null == "x"` is falsy (not an error). A non-string *value*
+                // (bool/int/list) is still a config-type error (L10).
+                Value::Null => Ok(Value::Bool(false)),
                 other => Err(WhenError::Eval(format!(
                     "`matches` left-hand side must be a string; got {}",
                     other.type_name()

--- a/crates/alint-core/src/when/lexer.rs
+++ b/crates/alint-core/src/when/lexer.rs
@@ -133,8 +133,18 @@ pub(super) fn lex(src: &str) -> Result<Vec<(Tok, usize)>, WhenError> {
                         s.push(ch);
                         i += 2;
                     } else {
-                        s.push(bytes[i] as char);
-                        i += 1;
+                        // Decode the full UTF-8 scalar rather than casting one
+                        // byte to `char` (which interprets a multi-byte char as
+                        // Latin-1 mojibake, so a non-ASCII `when:` literal like
+                        // `== "café"` could never match) (L3). `src` is valid
+                        // UTF-8 and `i` sits on a char boundary here (every
+                        // branch advances by whole chars / ASCII bytes).
+                        let ch = src[i..]
+                            .chars()
+                            .next()
+                            .expect("i < len and on a UTF-8 boundary");
+                        s.push(ch);
+                        i += ch.len_utf8();
                     }
                 }
                 if i >= bytes.len() {
@@ -205,4 +215,38 @@ fn is_ident_cont(c: u8) -> bool {
 /// "unknown iter method" rather than silently coercing to false.
 pub(super) fn is_known_iter_method(name: &str) -> bool {
     matches!(name, "has_file")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn first_str(src: &str) -> String {
+        lex(src)
+            .unwrap()
+            .into_iter()
+            .find_map(|(t, _)| match t {
+                Tok::Str(s) => Some(s),
+                _ => None,
+            })
+            .expect("a string token")
+    }
+
+    #[test]
+    fn non_ascii_string_literal_lexes_as_utf8() {
+        // L3: a multi-byte char must lex as one scalar, not Latin-1 mojibake
+        // (the old `byte as char` produced "cafÃ©", so `== "café"` never matched).
+        assert_eq!(first_str("\"café\""), "café");
+        assert_eq!(first_str("\"naïve Москва\""), "naïve Москва");
+    }
+
+    #[test]
+    fn emoji_string_literal_lexes_as_utf8() {
+        assert_eq!(first_str("\"a🎉b\""), "a🎉b");
+    }
+
+    #[test]
+    fn escapes_still_work_alongside_unicode() {
+        assert_eq!(first_str("\"café\\n\""), "café\n");
+    }
 }

--- a/crates/alint-core/src/when/mod.rs
+++ b/crates/alint-core/src/when/mod.rs
@@ -420,6 +420,14 @@ mod tests {
     }
 
     #[test]
+    fn matches_on_missing_fact_is_false_not_error() {
+        // L10: a missing fact (Null) on the LHS of `matches` is falsy, mirroring
+        // how `null == "x"` is falsy — not a hard error. (`check` unwraps, so a
+        // regression here would panic.)
+        assert!(!check("facts.nonexistent_fact matches \"anything\""));
+    }
+
+    #[test]
     fn parentheses_override_precedence() {
         assert!(check(
             "(facts.is_node or facts.is_rust) and facts.n_files > 0"

--- a/crates/alint-dsl/src/extends/cache.rs
+++ b/crates/alint-dsl/src/extends/cache.rs
@@ -12,6 +12,10 @@ use directories::ProjectDirs;
 
 use super::sri::Sri;
 
+/// Distinguishes concurrent temp files within this process (the PID
+/// distinguishes across processes). See [`Cache::put`] (L5).
+static TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// On-disk cache rooted at `<cache-dir>/alint/rulesets/`.
 #[derive(Debug, Clone)]
 pub struct Cache {
@@ -80,15 +84,31 @@ impl Cache {
             source,
         })?;
         let final_path = self.entry_path(sri);
-        let tmp_path = final_path.with_extension("yml.tmp");
-        std::fs::write(&tmp_path, bytes).map_err(|source| CacheError::Io {
-            path: tmp_path.clone(),
-            source,
-        })?;
-        std::fs::rename(&tmp_path, &final_path).map_err(|source| CacheError::Io {
-            path: final_path,
-            source,
-        })?;
+        // Unique temp name (PID + atomic counter): two concurrent `alint` runs
+        // caching the same SRI must not write — and rename — the same fixed
+        // `<sri>.yml.tmp` underneath each other (L5). The content is identical
+        // (SRI-verified above), so the race was never corrupting, but a unique
+        // temp keeps each writer's rename atomic and independent.
+        let n = TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let tmp_path = self.root.join(format!(
+            "{}.{}.{n}.yml.tmp",
+            sri.encoded(),
+            std::process::id()
+        ));
+        if let Err(source) = std::fs::write(&tmp_path, bytes) {
+            return Err(CacheError::Io {
+                path: tmp_path,
+                source,
+            });
+        }
+        if let Err(source) = std::fs::rename(&tmp_path, &final_path) {
+            // Don't leave our uniquely-named temp behind on a failed rename.
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(CacheError::Io {
+                path: final_path,
+                source,
+            });
+        }
         Ok(())
     }
 }

--- a/crates/alint-dsl/src/lib.rs
+++ b/crates/alint-dsl/src/lib.rs
@@ -78,7 +78,18 @@ pub fn load(path: &Path) -> Result<Config> {
 /// fetcher.
 pub fn load_with(path: &Path, opts: &LoadOptions) -> Result<Config> {
     let mut visiting = std::collections::HashSet::new();
-    let mut raw = loader::load_recursive(path, &mut visiting, opts)?;
+    // Confinement boundary for local `extends:` targets — the top-level
+    // config's directory. A local extends chain (e.g. a shared ruleset
+    // committed to the repo) may not escape this tree to read arbitrary
+    // local files; `allow_out_of_root: true` on the top-level config lifts
+    // it. The top-level config itself is trusted and unchecked (it may sit
+    // anywhere, e.g. a `-c` outside the linted tree); only the *targets* it
+    // pulls in are confined.
+    let confine_root = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+    let mut raw = loader::load_recursive(path, &mut visiting, opts, Some(&confine_root))?;
 
     // `.alint.d/*.yml` drop-ins — auto-discovered next to the
     // top-level config and merged in alphabetical order. The
@@ -100,7 +111,8 @@ pub fn load_with(path: &Path, opts: &LoadOptions) -> Result<Config> {
         .unwrap_or_else(|| Path::new("."))
         .join(".alint.d");
     for drop_in_path in collect_drop_ins(&drop_in_dir)? {
-        let drop_in = loader::load_recursive(&drop_in_path, &mut visiting, opts)?;
+        let drop_in =
+            loader::load_recursive(&drop_in_path, &mut visiting, opts, Some(&confine_root))?;
         raw = merge(raw, drop_in);
     }
 
@@ -1073,6 +1085,51 @@ rules:
         let cfg = load(&tmp.path().join(".alint.yml")).unwrap();
         assert!(cfg.allow_out_of_root.allows("any", "pair_hash"));
         assert!(!cfg.allow_out_of_root.allows("any", "json_schema_passes"));
+    }
+
+    #[test]
+    fn local_extends_outside_lint_root_is_rejected() {
+        // M2 (security): a local `extends:` target may not escape the
+        // top-level config's directory to read arbitrary files off the host.
+        // Layout: tmp/secret.yml (out of the config's tree) + tmp/repo/.alint.yml
+        // that climbs to it with `../secret.yml`.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("secret.yml"), "version: 1\nrules: []\n").unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        std::fs::write(
+            repo.join(".alint.yml"),
+            "version: 1\nextends: [../secret.yml]\nrules: []\n",
+        )
+        .unwrap();
+        let err = load(&repo.join(".alint.yml")).unwrap_err().to_string();
+        assert!(err.contains("outside the lint root"), "{err}");
+        assert!(err.contains("secret.yml"), "{err}");
+    }
+
+    #[test]
+    fn local_extends_out_of_root_allowed_with_top_level_flag() {
+        // M2: the same blanket `allow_out_of_root: true` that lifts per-rule
+        // read confinement also lifts the local-extends boundary — for users
+        // who deliberately keep a shared ruleset beside (not inside) the tree.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("shared.yml"),
+            "version: 1\nrules:\n  - id: inherited\n    kind: file_exists\n    paths: INHERITED.md\n    level: warning\n",
+        )
+        .unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        std::fs::write(
+            repo.join(".alint.yml"),
+            "version: 1\nallow_out_of_root: true\nextends: [../shared.yml]\nrules: []\n",
+        )
+        .unwrap();
+        let cfg = load(&repo.join(".alint.yml")).unwrap();
+        assert!(
+            cfg.rules.iter().any(|r| r.id == "inherited"),
+            "extends resolved"
+        );
     }
 
     #[test]

--- a/crates/alint-dsl/src/loader.rs
+++ b/crates/alint-dsl/src/loader.rs
@@ -14,6 +14,11 @@ use crate::{
     reject_baseline_in, reject_command_rules_in, reject_spawning_templates_in,
 };
 
+/// Maximum depth of an `extends:` chain — a recursion-stack guard against a
+/// hostile deeply-nested (acyclic) chain. Generous: real compositions are a
+/// handful deep. See [`load_recursive`] (L5).
+const MAX_EXTENDS_DEPTH: usize = 64;
+
 /// Parse a local config file's `contents` into a [`RawConfig`],
 /// resolving `{{env.X}}` interpolation first. Shared by
 /// `load_recursive` and nested-config loading so every local config
@@ -59,6 +64,19 @@ pub(crate) fn load_recursive(
         return Err(Error::Other(format!(
             "cycle in `extends` chain at {}",
             canonical.display()
+        )));
+    }
+    // Bound the depth of an *acyclic* chain (the cycle guard above only catches
+    // repeats): a hostile repo could otherwise nest thousands of local configs
+    // each extending the next and overflow the recursion stack (L5). `visiting`
+    // holds exactly the ancestors on the current DFS path (balanced insert /
+    // remove), so its length is the current depth. The cap is far above any
+    // real composition (root → team → org → bundled is ~4).
+    if visiting.len() > MAX_EXTENDS_DEPTH {
+        return Err(Error::Other(format!(
+            "`extends:` chain exceeds the maximum depth of {MAX_EXTENDS_DEPTH} (at {}); \
+             flatten the chain or split the ruleset",
+            canonical.display(),
         )));
     }
 
@@ -288,5 +306,38 @@ mod tests {
         let inside = tmp.path().join("base.yml");
         std::fs::write(&inside, "x").unwrap();
         assert!(confine_extends_target(&inside, "./base.yml", Some(tmp.path())).is_ok());
+    }
+
+    #[test]
+    fn extends_chain_depth_is_capped() {
+        // L5: an acyclic chain deeper than the cap is rejected (not a stack
+        // overflow). c0 -> c1 -> ... all within one dir (so confinement passes).
+        let tmp = tempfile::tempdir().unwrap();
+        let n = MAX_EXTENDS_DEPTH + 5;
+        for i in 0..n {
+            let body = if i + 1 < n {
+                format!("version: 1\nextends: [./c{}.yml]\nrules: []\n", i + 1)
+            } else {
+                "version: 1\nrules: []\n".to_string()
+            };
+            std::fs::write(tmp.path().join(format!("c{i}.yml")), body).unwrap();
+        }
+        let err = crate::load(&tmp.path().join("c0.yml"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("maximum depth"), "{err}");
+    }
+
+    #[test]
+    fn extends_chain_within_depth_cap_loads() {
+        // A short chain (well under the cap) still composes fine.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("base.yml"), "version: 1\nrules: []\n").unwrap();
+        std::fs::write(
+            tmp.path().join(".alint.yml"),
+            "version: 1\nextends: [./base.yml]\nrules: []\n",
+        )
+        .unwrap();
+        assert!(crate::load(&tmp.path().join(".alint.yml")).is_ok());
     }
 }

--- a/crates/alint-dsl/src/loader.rs
+++ b/crates/alint-dsl/src/loader.rs
@@ -6,7 +6,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use alint_core::{Error, Result};
+use alint_core::{AllowOutOfRoot, Error, Result};
 
 use crate::extends;
 use crate::{
@@ -49,6 +49,7 @@ pub(crate) fn load_recursive(
     path: &Path,
     visiting: &mut std::collections::HashSet<PathBuf>,
     opts: &LoadOptions,
+    confine: Option<&Path>,
 ) -> Result<RawConfig> {
     let canonical = path.canonicalize().map_err(|source| Error::Io {
         path: path.to_path_buf(),
@@ -77,6 +78,20 @@ pub(crate) fn load_recursive(
         .parent()
         .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
 
+    // Local `extends:` targets stay within the lint tree (the confinement
+    // boundary the loader was handed — the top-level config's directory),
+    // so a shared ruleset committed to the repo cannot smuggle in a local
+    // `extends: ../../../../etc/shadow` to read arbitrary files off the
+    // host. The top-level `allow_out_of_root: true` lifts it for the whole
+    // chain — the same blanket escape that lifts per-rule read confinement.
+    // A `Selective` allowlist names rule kinds/ids and has no meaning for an
+    // extends *path*, so only the `All` form opens this gate. (Sub-configs
+    // can't set the flag: `reject_allow_out_of_root_in` fires below.)
+    let confine = match &config.allow_out_of_root {
+        AllowOutOfRoot::All => None,
+        _ => confine,
+    };
+
     let mut merged = RawConfig {
         version: config.version,
         ..RawConfig::default()
@@ -94,7 +109,8 @@ pub(crate) fn load_recursive(
             load_bundled(spec)?
         } else {
             let target = resolve_relative(&source_dir, url);
-            load_recursive(&target, visiting, opts)?
+            confine_extends_target(&target, url, confine)?;
+            load_recursive(&target, visiting, opts, confine)?
         };
         // Extended configs cannot introduce `custom:` facts or
         // `kind: command` rules — both spawn arbitrary processes
@@ -190,11 +206,87 @@ fn load_bundled(spec: &str) -> Result<RawConfig> {
     Ok(config)
 }
 
+/// Reject a local `extends:` target that resolves outside the confinement
+/// root. `confine == None` means confinement is disabled — either a
+/// programmatic caller that handed the loader no root, or a top-level config
+/// that opted out via `allow_out_of_root: true`.
+///
+/// Both sides are canonicalized, so `..`, `.`, and symlinks are resolved: a
+/// symlink that lives inside the tree but points out is caught too. A
+/// canonicalize failure (most often a missing target) is deliberately *not*
+/// treated as an escape — there is nothing to read, so it is left for
+/// [`load_recursive`] to surface with its existing not-found error.
+fn confine_extends_target(target: &Path, entry: &str, confine: Option<&Path>) -> Result<()> {
+    let Some(root) = confine else { return Ok(()) };
+    let (Ok(canon_root), Ok(canon_target)) = (root.canonicalize(), target.canonicalize()) else {
+        return Ok(());
+    };
+    if !canon_target.starts_with(&canon_root) {
+        return Err(Error::Other(format!(
+            "`extends:` target {entry:?} resolves to {} which is outside the lint root {}; \
+             a local `extends:` chain must stay within the linted tree. Set \
+             `allow_out_of_root: true` on the top-level config to override.",
+            canon_target.display(),
+            canon_root.display(),
+        )));
+    }
+    Ok(())
+}
+
 fn resolve_relative(source_dir: &Path, entry: &str) -> PathBuf {
     let candidate = Path::new(entry);
     if candidate.is_absolute() {
         candidate.to_path_buf()
     } else {
         source_dir.join(candidate)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn confine_none_disables_the_check() {
+        // A programmatic caller (or `allow_out_of_root: true`) hands `None`:
+        // even a blatant escape target is permitted.
+        assert!(confine_extends_target(Path::new("/etc/shadow"), "/etc/shadow", None).is_ok());
+    }
+
+    #[test]
+    fn confine_missing_target_is_not_an_escape() {
+        // A non-existent target can't be canonicalized; it is left for the
+        // caller's not-found path, NOT reported as out-of-root (nothing to read).
+        let tmp = tempfile::tempdir().unwrap();
+        let res = confine_extends_target(
+            &tmp.path().join("nope.yml"),
+            "../nope.yml",
+            Some(tmp.path()),
+        );
+        assert!(
+            res.is_ok(),
+            "missing target must defer to the not-found path"
+        );
+    }
+
+    #[test]
+    fn confine_rejects_target_outside_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("repo");
+        std::fs::create_dir(&root).unwrap();
+        let outside = tmp.path().join("outside.yml");
+        std::fs::write(&outside, "x").unwrap();
+        let err = confine_extends_target(&outside, "../outside.yml", Some(&root))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("outside the lint root"), "{err}");
+    }
+
+    #[test]
+    fn confine_allows_target_inside_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let inside = tmp.path().join("base.yml");
+        std::fs::write(&inside, "x").unwrap();
+        assert!(confine_extends_target(&inside, "./base.yml", Some(tmp.path())).is_ok());
     }
 }

--- a/crates/alint-output/src/gitlab.rs
+++ b/crates/alint-output/src/gitlab.rs
@@ -9,8 +9,8 @@
 //! objects, one per violation.
 //!
 //! Each issue carries: `description`, `check_name`,
-//! `fingerprint` (SHA-256 hex of `rule_id|path|message` for
-//! cross-run de-duplication), `severity` (one of
+//! `fingerprint` (SHA-256 hex of `rule_id|path|message|occurrence` for
+//! cross-run de-duplication; see [`fingerprint`]), `severity` (one of
 //! `info` / `minor` / `major` / `critical` / `blocker`), and
 //! `location.path` + `location.lines.begin`.
 //!
@@ -35,12 +35,18 @@ use sha2::{Digest, Sha256};
 
 pub fn write_gitlab(report: &Report, w: &mut dyn Write) -> std::io::Result<()> {
     let mut issues: Vec<Issue> = Vec::new();
+    // Per-report occurrence counter keyed by the base `rule|path|message`
+    // tuple, so genuinely-distinct findings that share all three get distinct
+    // fingerprints (the Code Climate spec requires per-report uniqueness, else
+    // GitLab silently drops the duplicates). Deterministic: report iteration
+    // order is stable. (M10)
+    let mut seen: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
     for result in &report.results {
         if result.level == Level::Off {
             continue;
         }
         for violation in &result.violations {
-            issues.push(build_issue(result, violation));
+            issues.push(build_issue(result, violation, &mut seen));
         }
     }
     let json = serde_json::to_string_pretty(&issues)?;
@@ -69,16 +75,29 @@ struct Lines {
     begin: usize,
 }
 
-fn build_issue(result: &RuleResult, violation: &Violation) -> Issue {
+fn build_issue(
+    result: &RuleResult,
+    violation: &Violation,
+    seen: &mut std::collections::HashMap<String, u32>,
+) -> Issue {
     let path = violation
         .path
         .as_ref()
         .map_or_else(|| ".".to_string(), |p| p.display().to_string());
 
+    // Nth identical (rule, path, message) in this report — 0 for the first.
+    let key = format!("{}|{path}|{}", result.rule_id, violation.message);
+    let occurrence = {
+        let counter = seen.entry(key).or_insert(0);
+        let n = *counter;
+        *counter += 1;
+        n
+    };
+
     Issue {
         description: violation.message.to_string(),
         check_name: result.rule_id.to_string(),
-        fingerprint: fingerprint(&result.rule_id, &path, &violation.message),
+        fingerprint: fingerprint(&result.rule_id, &path, &violation.message, occurrence),
         severity: severity(result.level),
         location: Location {
             path,
@@ -106,19 +125,29 @@ fn severity(level: Level) -> &'static str {
 }
 
 /// Stable per-issue fingerprint for cross-run de-duplication.
-/// SHA-256 hex of `rule_id|path|message` — the line number is
-/// intentionally omitted so a violation that drifts up or down
-/// by a few lines stays the same issue from GitLab's
-/// perspective. Two violations of the same rule with the same
-/// message in the same file collide, which is the right shape:
-/// GitLab will treat them as one ongoing issue.
-fn fingerprint(rule_id: &str, path: &str, message: &str) -> String {
+/// SHA-256 hex of `rule_id|path|message|occurrence`. The line number is
+/// intentionally omitted so a violation that drifts up or down by a few
+/// lines stays the same issue from GitLab's perspective. `occurrence` is the
+/// 0-based index of this finding among others in the *same report* sharing
+/// the same `rule_id|path|message`, so two genuinely-distinct findings don't
+/// collapse to one fingerprint — the Code Climate spec requires per-report
+/// uniqueness, and a collision makes GitLab silently drop the duplicate
+/// (e.g. a generic-message per-line rule firing on several lines of one
+/// file). The single-occurrence common case keeps a line-independent
+/// fingerprint, so drift tolerance is preserved.
+///
+/// Note: this is *not* yet the `violation_fingerprint` used by baseline mode
+/// (ADR-0006); unifying the two needs report-fingerprint plumbing and is
+/// deferred — see `docs/design/baseline.md` §5/§7.
+fn fingerprint(rule_id: &str, path: &str, message: &str, occurrence: u32) -> String {
     let mut hasher = Sha256::new();
     hasher.update(rule_id.as_bytes());
     hasher.update(b"|");
     hasher.update(path.as_bytes());
     hasher.update(b"|");
     hasher.update(message.as_bytes());
+    hasher.update(b"|");
+    hasher.update(occurrence.to_le_bytes());
     let digest = hasher.finalize();
     let mut hex = String::with_capacity(64);
     for byte in digest {
@@ -323,6 +352,31 @@ mod tests {
         let fp_a = parse(&render(&mk(7)))[0]["fingerprint"].clone();
         let fp_b = parse(&render(&mk(42)))[0]["fingerprint"].clone();
         assert_eq!(fp_a, fp_b);
+    }
+
+    #[test]
+    fn distinct_findings_same_message_get_distinct_fingerprints() {
+        // M10: two genuinely-distinct violations sharing rule+path+message
+        // (e.g. a generic-message per-line rule firing on two lines) must NOT
+        // collide — the Code Climate spec requires per-report uniqueness, and
+        // a collision makes GitLab drop the duplicate.
+        let mk_v = |line: usize| Violation {
+            path: Some(Path::new("a.rs").into()),
+            message: "forbidden pattern".into(),
+            line: Some(line),
+            column: None,
+            is_note: false,
+            baseline_key: None,
+        };
+        let report = Report {
+            results: vec![rule("no-pat", Level::Error, vec![mk_v(3), mk_v(9)])],
+        };
+        let arr = parse(&render(&report));
+        assert_eq!(arr.len(), 2, "both findings emitted");
+        assert_ne!(
+            arr[0]["fingerprint"], arr[1]["fingerprint"],
+            "distinct findings must have distinct fingerprints"
+        );
     }
 
     #[test]

--- a/crates/alint-output/src/human.rs
+++ b/crates/alint-output/src/human.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use alint_core::{FixReport, FixStatus, Level, Report, RuleResult, Violation};
 
+use crate::sanitize::sanitize_terminal;
 use crate::style::{self, GlyphSet, HumanOptions, write_hyperlink};
 
 // ---------------------------------------------------------------
@@ -82,7 +83,9 @@ pub fn write_human(report: &Report, w: &mut dyn Write, opts: HumanOptions) -> st
 
         let label = bucket.as_ref().map_or_else(
             || "Repository-level".to_string(),
-            |p| p.display().to_string(),
+            // The path is attacker-controlled (a repo file name) — neutralize
+            // any terminal escapes before it lands in the header (M8).
+            |p| sanitize_terminal(&p.display().to_string()).into_owned(),
         );
         write_section_header(w, &label, width, &opts.glyphs)?;
 
@@ -159,7 +162,11 @@ fn write_violation(
     // line and let the terminal handle any overflow).
     let dim = style::DIM;
     let total_width = opts.effective_width();
-    let lines = wrap_message(&violation.message, MSG_INDENT.len(), total_width);
+    // The message can embed a matched value or a `kind: command` rule's
+    // subprocess output — neutralize terminal escapes before wrapping, while
+    // preserving the intentional `\n` paragraph breaks wrap_message honors (M8).
+    let safe_message = sanitize_terminal(&violation.message);
+    let lines = wrap_message(&safe_message, MSG_INDENT.len(), total_width);
     let (first_line, rest) = lines
         .split_first()
         .map_or(("", &[][..]), |(f, r)| (f.as_str(), r));
@@ -325,10 +332,13 @@ fn write_human_compact(
             continue;
         }
         for v in &result.violations {
-            let path = v
-                .path
-                .as_ref()
-                .map_or_else(|| "<repo>".to_string(), |p| p.display().to_string());
+            // Path + message are attacker-controlled; neutralize terminal
+            // escapes for this single-line format (M8).
+            let path = v.path.as_ref().map_or_else(
+                || "<repo>".to_string(),
+                |p| sanitize_terminal(&p.display().to_string()).into_owned(),
+            );
+            let message = sanitize_terminal(&v.message);
             let line = v.line.unwrap_or(0);
             let col = v.column.unwrap_or(0);
             let (level_style, level_name) = match result.level {
@@ -359,8 +369,8 @@ fn write_human_compact(
             };
             writeln!(
                 w,
-                "{path}:{line}:{col}: {level_style}{level_name}{level_style:#}: {rule_style}{}{rule_style:#}: {}{fix_tag}",
-                result.rule_id, v.message,
+                "{path}:{line}:{col}: {level_style}{level_name}{level_style:#}: {rule_style}{}{rule_style:#}: {message}{fix_tag}",
+                result.rule_id,
             )?;
         }
     }
@@ -471,6 +481,10 @@ pub fn write_fix_human(
                     format!("{path_prefix}{} (no fixer)", item.violation.message),
                 ),
             };
+            // `content` embeds the attacker-controlled path + message (alint's
+            // own status prose is clean ASCII); styling is applied separately
+            // below, so sanitizing the whole string is safe (M8).
+            let content = sanitize_terminal(&content);
             let lines = wrap_message(&content, FIX_INDENT.len(), total_width);
             let (first_line, rest) = lines
                 .split_first()
@@ -623,5 +637,76 @@ mod tests {
         // so tokens up to 20 chars fit on one line.
         let out = wrap_message("twenty-char-token-ok", 14, 10);
         assert_eq!(out, vec!["twenty-char-token-ok".to_string()]);
+    }
+
+    // M8: the three human render paths must neutralize terminal escapes in
+    // attacker-controlled paths/messages. alint emits its own SGR (e.g.
+    // `\x1b[2m` dim) but never the clear-screen `\x1b[2J`, so a raw `\x1b[2J`
+    // in the output would be an injection that slipped through; its
+    // neutralized form `\x1b[2J` (literal text) proves the sanitizer ran.
+    const RAW_CLEAR: &str = "\x1b[2J\x1b[H";
+
+    fn evil_report() -> Report {
+        use std::path::PathBuf;
+        let v = Violation::new(format!("{RAW_CLEAR}forged: all rules passed."))
+            .with_path(PathBuf::from(format!("src/{RAW_CLEAR}evil.rs")));
+        Report {
+            results: vec![RuleResult::new(
+                "demo".into(),
+                Level::Error,
+                None,
+                vec![v],
+                false,
+            )],
+        }
+    }
+
+    fn assert_neutralized(out: &str) {
+        assert!(
+            !out.contains("\x1b[2J"),
+            "a raw clear-screen escape survived: {out:?}"
+        );
+        assert!(
+            out.contains("\\x1b[2J"),
+            "expected the neutralized \\x1b[2J text: {out:?}"
+        );
+    }
+
+    #[test]
+    fn human_format_neutralizes_terminal_escapes() {
+        let mut buf = Vec::new();
+        write_human(&evil_report(), &mut buf, HumanOptions::default()).unwrap();
+        assert_neutralized(&String::from_utf8(buf).unwrap());
+    }
+
+    #[test]
+    fn compact_format_neutralizes_terminal_escapes() {
+        let mut buf = Vec::new();
+        let opts = HumanOptions {
+            compact: true,
+            ..HumanOptions::default()
+        };
+        write_human(&evil_report(), &mut buf, opts).unwrap();
+        assert_neutralized(&String::from_utf8(buf).unwrap());
+    }
+
+    #[test]
+    fn fix_format_neutralizes_terminal_escapes() {
+        use std::path::PathBuf;
+        let v = Violation::new(format!("{RAW_CLEAR}forged"))
+            .with_path(PathBuf::from(format!("src/{RAW_CLEAR}evil.rs")));
+        let report = FixReport {
+            results: vec![alint_core::FixRuleResult {
+                rule_id: "demo".into(),
+                level: Level::Warning,
+                items: vec![alint_core::FixItem {
+                    violation: v,
+                    status: FixStatus::Unfixable,
+                }],
+            }],
+        };
+        let mut buf = Vec::new();
+        write_fix_human(&report, &mut buf, HumanOptions::default()).unwrap();
+        assert_neutralized(&String::from_utf8(buf).unwrap());
     }
 }

--- a/crates/alint-output/src/lib.rs
+++ b/crates/alint-output/src/lib.rs
@@ -8,6 +8,7 @@ mod human;
 mod json;
 mod junit;
 mod markdown;
+mod sanitize;
 mod sarif;
 pub mod style;
 

--- a/crates/alint-output/src/sanitize.rs
+++ b/crates/alint-output/src/sanitize.rs
@@ -1,0 +1,92 @@
+//! Terminal-safety sanitizer for untrusted text in the human formatters.
+//!
+//! The human / compact / fix renderers interpolate attacker-controlled spans
+//! — repo file *paths*, violation *messages* (which can embed a matched value
+//! or a `kind: command` rule's subprocess stdout/stderr) — directly into the
+//! terminal. A repo file named `evil\x1b[2J\x1b[H` or a command whose output
+//! carries ANSI sequences could otherwise clear the screen, move the cursor,
+//! hide findings below the fold, or forge an "all rules passed." banner when a
+//! human lints an untrusted repo.
+//!
+//! alint's *own* styling is emitted as separate `{STYLE}…{STYLE:#}` tokens
+//! around the content (and gated by `anstream`), so sanitizing the content
+//! strings here never strips alint's colors. It runs unconditionally — not
+//! only on a TTY — so output is byte-identical whether written to a terminal
+//! or a pipe (`anstream` passes raw bytes straight through on a TTY, which is
+//! precisely when injected escapes would fire).
+
+use std::borrow::Cow;
+
+/// A control char alint emits on purpose and must preserve: the newline that
+/// [`crate::wrap_message`] treats as a paragraph break in a wrapped message.
+const fn is_intentional(c: char) -> bool {
+    c == '\n'
+}
+
+/// Render untrusted `s` safe to write to a terminal: every control character
+/// (C0, `DEL`, C1) except the intentional newline is replaced with a visible,
+/// inert `\xNN` escape — so an embedded `ESC` becomes the four literal
+/// characters `\x1b`, carrying no control byte for the terminal to act on.
+///
+/// Returns the input borrowed unchanged when there is nothing to strip (the
+/// overwhelming common case), so clean output pays no allocation.
+pub(crate) fn sanitize_terminal(s: &str) -> Cow<'_, str> {
+    if !s.chars().any(|c| c.is_control() && !is_intentional(c)) {
+        return Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len() + 8);
+    for c in s.chars() {
+        if c.is_control() && !is_intentional(c) {
+            use std::fmt::Write as _;
+            // Control chars are Unicode category Cc: U+0000–U+001F and
+            // U+007F–U+009F, all ≤ 0x9f, so a 2-digit hex escape suffices.
+            let _ = write!(out, "\\x{:02x}", c as u32);
+        } else {
+            out.push(c);
+        }
+    }
+    Cow::Owned(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_text_is_borrowed_unchanged() {
+        let s = "src/main.rs: tidy up";
+        assert!(matches!(sanitize_terminal(s), Cow::Borrowed(_)));
+        assert_eq!(sanitize_terminal(s), s);
+    }
+
+    #[test]
+    fn escape_sequences_are_neutralized() {
+        // A path that clears the screen + forges a banner.
+        let evil = "ok\x1b[2J\x1b[Hall rules passed.";
+        let out = sanitize_terminal(evil);
+        assert!(!out.contains('\x1b'), "no raw ESC survives: {out:?}");
+        assert!(out.contains("\\x1b"), "ESC rendered visibly: {out:?}");
+    }
+
+    #[test]
+    fn carriage_return_and_del_are_stripped() {
+        // CR can overwrite the current line; DEL / C1 are interpreted by
+        // some terminals. All neutralized.
+        let out = sanitize_terminal("a\rb\x7fc\u{85}d");
+        assert_eq!(out, "a\\x0db\\x7fc\\x85d");
+    }
+
+    #[test]
+    fn newline_is_preserved_as_paragraph_break() {
+        // `command` rule messages embed subprocess output with `\n`
+        // separators that wrap_message renders as paragraph breaks.
+        let out = sanitize_terminal("failed (1):\nline one\nline two");
+        assert_eq!(out, "failed (1):\nline one\nline two");
+    }
+
+    #[test]
+    fn tab_is_neutralized_but_newline_kept() {
+        let out = sanitize_terminal("a\tb\nc");
+        assert_eq!(out, "a\\x09b\nc");
+    }
+}

--- a/crates/alint-rules/src/command.rs
+++ b/crates/alint-rules/src/command.rs
@@ -49,7 +49,7 @@ use std::path::Path;
 use std::process::{Command as StdCommand, Stdio};
 use std::time::{Duration, Instant};
 
-use alint_core::template::{PathTokens, render_path};
+use alint_core::template::{PathTokens, render_path_argv};
 use alint_core::{Context, Error, FactValue, Level, Result, Rule, RuleSpec, Scope, Violation};
 use serde::Deserialize;
 
@@ -109,7 +109,13 @@ impl Rule for CommandRule {
                 continue;
             }
             let tokens = PathTokens::from_path(&entry.path);
-            let rendered: Vec<String> = self.argv.iter().map(|s| render_path(s, &tokens)).collect();
+            // `render_path_argv` (not `render_path`): guards against a repo
+            // filename rendered from `{path}` masquerading as an option (L13).
+            let rendered: Vec<String> = self
+                .argv
+                .iter()
+                .map(|s| render_path_argv(s, &tokens))
+                .collect();
             if let Outcome::Fail(msg) = run_one(
                 &rendered,
                 ctx.root,

--- a/crates/alint-rules/src/file_content_forbidden.rs
+++ b/crates/alint-rules/src/file_content_forbidden.rs
@@ -83,7 +83,12 @@ impl PerFileRule for FileContentForbiddenRule {
         Ok(vec![
             Violation::new(msg)
                 .with_path(std::sync::Arc::<Path>::from(path))
-                .with_location(line, 1),
+                .with_location(line, 1)
+                // First-match rule: the baseline identity is the *file*, not the
+                // matched line's content (which would churn on any edit to that
+                // line). Mirrors `no_trailing_whitespace`/`line_endings` (M14).
+                // See `docs/design/baseline.md` §4.
+                .with_baseline_key(crate::slash(path)),
         ])
     }
 }

--- a/crates/alint-rules/src/fixers/creators.rs
+++ b/crates/alint-rules/src/fixers/creators.rs
@@ -177,6 +177,19 @@ impl Fixer for FilePrependFixer {
                 path.display()
             )));
         }
+        // Idempotency guard (L4): if the file already begins with exactly this
+        // content (after any BOM), prepending again would stack a duplicate on
+        // every `--fix` — which happens when the configured content doesn't
+        // satisfy the rule's own pattern, so the violation never clears.
+        // `file_starts_with` refuses a fixer outright for this reason; here we
+        // can at least no-op safely.
+        let body = existing.strip_prefix(UTF8_BOM).unwrap_or(&existing);
+        if body.starts_with(prepend.as_slice()) {
+            return Ok(FixOutcome::Skipped(format!(
+                "{} already begins with the required content",
+                path.display()
+            )));
+        }
         let mut out = Vec::with_capacity(existing.len() + prepend.len());
         if existing.starts_with(UTF8_BOM) {
             out.extend_from_slice(UTF8_BOM);
@@ -196,6 +209,11 @@ impl Fixer for FilePrependFixer {
     fn fix_edit(&self, violation: &Violation, bytes: &[u8], root: &Path) -> Option<FixEdit> {
         let path = violation.path.as_deref()?;
         let prepend = resolve_source_bytes(&self.source, root).ok()?;
+        // Idempotency guard (L4): already-present content is not re-prepended.
+        let body = bytes.strip_prefix(UTF8_BOM).unwrap_or(bytes);
+        if body.starts_with(prepend.as_slice()) {
+            return None;
+        }
         let mut out = Vec::with_capacity(bytes.len() + prepend.len());
         if bytes.starts_with(UTF8_BOM) {
             out.extend_from_slice(UTF8_BOM);
@@ -271,6 +289,14 @@ impl Fixer for FileAppendFixer {
                 path.display()
             )));
         }
+        // Idempotency guard (L4): see FilePrependFixer — don't stack the footer
+        // on every `--fix` when the content doesn't satisfy the rule's pattern.
+        if existing.ends_with(payload.as_slice()) {
+            return Ok(FixOutcome::Skipped(format!(
+                "{} already ends with the required content",
+                path.display()
+            )));
+        }
         let mut out = existing;
         out.extend_from_slice(&payload);
         write_atomic(&abs, &out).map_err(|source| Error::Io {
@@ -286,6 +312,10 @@ impl Fixer for FileAppendFixer {
     fn fix_edit(&self, violation: &Violation, bytes: &[u8], root: &Path) -> Option<FixEdit> {
         let path = violation.path.as_deref()?;
         let payload = resolve_source_bytes(&self.source, root).ok()?;
+        // Idempotency guard (L4): already-present content is not re-appended.
+        if bytes.ends_with(payload.as_slice()) {
+            return None;
+        }
         let mut out = bytes.to_vec();
         out.extend_from_slice(&payload);
         Some(FixEdit::SetContent {
@@ -454,6 +484,28 @@ mod tests {
     }
 
     #[test]
+    fn file_prepend_is_idempotent_across_runs() {
+        // L4: a second `--fix` must NOT stack a duplicate header (the failure
+        // mode when the content doesn't satisfy the rule's pattern).
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("a.rs"), "fn main() {}\n").unwrap();
+        let fixer = FilePrependFixer::new("// Copyright 2026\n".into());
+        let v = Violation::new("missing header").with_path(std::path::Path::new("a.rs"));
+        let first = fixer.apply(&v, &make_ctx(&tmp, false)).unwrap();
+        assert!(matches!(first, FixOutcome::Applied(_)));
+        let second = fixer.apply(&v, &make_ctx(&tmp, false)).unwrap();
+        assert!(matches!(second, FixOutcome::Skipped(_)), "second run skips");
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("a.rs")).unwrap(),
+            "// Copyright 2026\nfn main() {}\n",
+            "header not stacked"
+        );
+        // The editor path is idempotent too.
+        let bytes = std::fs::read(tmp.path().join("a.rs")).unwrap();
+        assert!(fixer.fix_edit(&v, &bytes, tmp.path()).is_none());
+    }
+
+    #[test]
     fn file_prepend_preserves_utf8_bom() {
         let tmp = TempDir::new().unwrap();
         // BOM + "hello\n"
@@ -511,6 +563,31 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(tmp.path().join("notes.md")).unwrap(),
             "# Notes\n\n## Section\n"
+        );
+    }
+
+    #[test]
+    fn file_append_is_idempotent_across_runs() {
+        // L4: a second `--fix` must NOT stack a duplicate footer.
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("notes.md"), "# Notes\n").unwrap();
+        let fixer = FileAppendFixer::new("\n## Section\n".into());
+        let v = Violation::new("missing section").with_path(std::path::Path::new("notes.md"));
+        assert!(matches!(
+            fixer.apply(&v, &make_ctx(&tmp, false)).unwrap(),
+            FixOutcome::Applied(_)
+        ));
+        assert!(
+            matches!(
+                fixer.apply(&v, &make_ctx(&tmp, false)).unwrap(),
+                FixOutcome::Skipped(_)
+            ),
+            "second run skips"
+        );
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("notes.md")).unwrap(),
+            "# Notes\n\n## Section\n",
+            "footer not stacked"
         );
     }
 

--- a/crates/alint-rules/src/git_no_denied_paths.rs
+++ b/crates/alint-rules/src/git_no_denied_paths.rs
@@ -120,6 +120,20 @@ impl Rule for GitNoDeniedPathsRule {
     }
 }
 
+/// Auto-anchor a *bare* denied pattern (one with no `/`) to match at any
+/// depth: `*.pem` → `**/*.pem`, `id_rsa` → `**/id_rsa`. A pattern that
+/// already names a path (`secrets/*.key`, `**/*.pem`) is taken as written.
+/// `**/` matches zero or more segments, so the anchored form still catches
+/// the root-level file. This is the secure default for a denylist: a bare
+/// `*.pem` should ban a `.pem` anywhere in the tree, not only at the root.
+fn anchor_denied_pattern(pattern: &str) -> std::borrow::Cow<'_, str> {
+    if pattern.contains('/') {
+        std::borrow::Cow::Borrowed(pattern)
+    } else {
+        std::borrow::Cow::Owned(format!("**/{pattern}"))
+    }
+}
+
 pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
     let opts: Options = spec
         .deserialize_options()
@@ -140,7 +154,13 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
 
     let mut builder = GlobSetBuilder::new();
     for pattern in &opts.denied {
-        let glob = Glob::new(pattern).map_err(|e| {
+        // Auto-anchor a *bare* pattern (no `/`) so it matches at ANY depth.
+        // globset otherwise root-anchors it, so `*.pem` would miss
+        // `secrets/server.pem` — a dangerous default for a *security*
+        // denylist (M5). `denied_src` keeps the original spelling for the
+        // violation message.
+        let effective = anchor_denied_pattern(pattern);
+        let glob = Glob::new(&effective).map_err(|e| {
             Error::rule_config(&spec.id, format!("invalid denied pattern `{pattern}`: {e}"))
         })?;
         builder.add(glob);
@@ -163,6 +183,26 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn anchor_denied_pattern_anchors_bare_to_any_depth() {
+        assert_eq!(anchor_denied_pattern("*.pem"), "**/*.pem");
+        assert_eq!(anchor_denied_pattern("id_rsa"), "**/id_rsa");
+        // explicit-path patterns are taken as written
+        assert_eq!(anchor_denied_pattern("secrets/*.key"), "secrets/*.key");
+        assert_eq!(anchor_denied_pattern("**/*.env"), "**/*.env");
+    }
+
+    #[test]
+    fn bare_pattern_denies_nested_path() {
+        // M5: a bare `*.pem` must ban a secret at any depth, not only root.
+        let mut b = GlobSetBuilder::new();
+        b.add(Glob::new(&anchor_denied_pattern("*.pem")).unwrap());
+        let set = b.build().unwrap();
+        assert!(set.is_match("secrets/server.pem"), "nested .pem denied");
+        assert!(set.is_match("server.pem"), "root .pem still denied");
+        assert!(!set.is_match("server.txt"));
+    }
 
     fn build_set(patterns: &[&str]) -> GlobSet {
         let mut b = GlobSetBuilder::new();

--- a/crates/alint-rules/src/line_max_width.rs
+++ b/crates/alint-rules/src/line_max_width.rs
@@ -77,7 +77,12 @@ impl PerFileRule for LineMaxWidthRule {
         Ok(vec![
             Violation::new(msg)
                 .with_path(std::sync::Arc::<Path>::from(path))
-                .with_location(line_no, self.max_width + 1),
+                .with_location(line_no, self.max_width + 1)
+                // First-offender rule: the baseline identity is the *file*, not
+                // the offending line's content (which would churn on any edit
+                // to that line). Mirrors `no_trailing_whitespace`/`line_endings`
+                // (M14). See `docs/design/baseline.md` §4.
+                .with_baseline_key(crate::slash(path)),
         ])
     }
 }

--- a/crates/alint-rules/src/no_bidi_controls.rs
+++ b/crates/alint-rules/src/no_bidi_controls.rs
@@ -14,6 +14,13 @@
 //!   - U+2068 FIRST STRONG ISOLATE
 //!   - U+2069 POP DIRECTIONAL ISOLATE
 //!
+//! Plus the implicit directional marks, which reorder neighbouring
+//! runs without an explicit embedding and so can still mislead a
+//! reader (rustc's Trojan-Source lint flags these too):
+//!   - U+061C ARABIC LETTER MARK
+//!   - U+200E LEFT-TO-RIGHT MARK
+//!   - U+200F RIGHT-TO-LEFT MARK
+//!
 //! Non-UTF-8 files are skipped (can't have these codepoints
 //! anyway without being invalid UTF-8).
 
@@ -26,10 +33,15 @@ use alint_core::{
 
 use crate::fixers::FileStripBidiFixer;
 
-/// Returns true if `c` is one of the nine Unicode bidi control
-/// characters.
+/// Returns true if `c` is one of the Unicode bidi control characters
+/// (the five explicit embeddings/overrides, the four isolates, and the
+/// three implicit directional marks ALM/LRM/RLM).
 pub fn is_bidi_control(c: char) -> bool {
-    matches!(c, '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}')
+    matches!(c,
+        '\u{061C}'                  // ALM
+        | '\u{200E}' | '\u{200F}'   // LRM, RLM
+        | '\u{202A}'..='\u{202E}'   // LRE, RLE, PDF, LRO, RLO
+        | '\u{2066}'..='\u{2069}') // LRI, RLI, FSI, PDI
 }
 
 #[derive(Debug)]
@@ -156,6 +168,16 @@ mod tests {
             let s = format!("a{c}b");
             let got = first_bidi(&s).unwrap();
             assert_eq!(got.2, cp);
+        }
+    }
+
+    #[test]
+    fn flags_implicit_directional_marks() {
+        // L1: ALM, LRM, RLM complete the Trojan-Source set (rustc flags these).
+        for &cp in &[0x061Cu32, 0x200E, 0x200F] {
+            let c = char::from_u32(cp).unwrap();
+            let got = first_bidi(&format!("a{c}b")).unwrap();
+            assert_eq!(got.2, cp, "codepoint U+{cp:04X} must be flagged");
         }
     }
 

--- a/crates/alint-rules/src/no_case_conflicts.rs
+++ b/crates/alint-rules/src/no_case_conflicts.rs
@@ -34,8 +34,14 @@ impl Rule for NoCaseConflictsRule {
             let Some(as_str) = entry.path.to_str() else {
                 continue;
             };
+            // Unicode lowercasing (not ASCII-only): a case-insensitive
+            // filesystem folds `Ω.txt`/`ω.txt` and `É`/`é` too, so an
+            // ASCII-only fold would miss those real cross-platform collisions
+            // (L2). `to_lowercase` is the std Unicode fold — a strict, portable
+            // default for a "no case conflicts" convention (it may report a
+            // collision a specific OS fold table wouldn't, the safe direction).
             groups
-                .entry(as_str.to_ascii_lowercase())
+                .entry(as_str.to_lowercase())
                 .or_default()
                 .push(entry.path.clone());
         }
@@ -143,6 +149,22 @@ mod tests {
         let i = index(&["README.md", "readme.md", "Cargo.toml"]);
         let v = rule.evaluate(&ctx(Path::new("/fake"), &i)).unwrap();
         assert_eq!(v.len(), 2, "two collision members should fire");
+    }
+
+    #[test]
+    fn evaluate_fires_on_unicode_case_collision() {
+        // L2: a case-insensitive filesystem folds non-ASCII letters too, so
+        // `É.txt` and `é.txt` collide — an ASCII-only fold would miss this.
+        let spec = spec_yaml(
+            "id: t\n\
+             kind: no_case_conflicts\n\
+             paths: \"**\"\n\
+             level: warning\n",
+        );
+        let rule = build(&spec).unwrap();
+        let i = index(&["É.txt", "é.txt", "Ω.md", "ω.md"]);
+        let v = rule.evaluate(&ctx(Path::new("/fake"), &i)).unwrap();
+        assert_eq!(v.len(), 4, "both Unicode case pairs collide");
     }
 
     #[test]

--- a/crates/alint-rules/src/no_zero_width_chars.rs
+++ b/crates/alint-rules/src/no_zero_width_chars.rs
@@ -5,10 +5,19 @@
 //!   - U+200B ZERO WIDTH SPACE
 //!   - U+200C ZERO WIDTH NON-JOINER
 //!   - U+200D ZERO WIDTH JOINER
+//!   - U+2060 WORD JOINER (the no-break sibling of U+200B)
+//!   - U+180E MONGOLIAN VOWEL SEPARATOR (renders zero-width)
 //!   - U+FEFF ZERO WIDTH NO-BREAK SPACE (BOM) — *but only when
 //!     not at byte position 0*. A leading BOM is `no_bom`'s
 //!     territory; this rule stays focused on body-internal ZWs
 //!     so the two rules don't double-report.
+//!
+//! Note on U+200D (ZWJ): it is flagged even though it joins emoji
+//! sequences (e.g. the family glyph 👨‍👩‍👧), because in source it is
+//! far more often an obfuscation vector than legitimate. The strip
+//! fixer therefore *will* break a literal emoji ZWJ sequence — scope
+//! the rule away from files that legitimately carry such emoji.
+//! (Grapheme-cluster-aware ZWJ handling is a possible future refinement.)
 
 use std::path::Path;
 
@@ -24,7 +33,7 @@ use crate::fixers::FileStripZeroWidthFixer;
 /// the file (the BOM case) — that's deliberately NOT flagged.
 pub fn is_flagged_zero_width(c: char, is_leading_feff: bool) -> bool {
     match c {
-        '\u{200B}' | '\u{200C}' | '\u{200D}' => true,
+        '\u{200B}' | '\u{200C}' | '\u{200D}' | '\u{2060}' | '\u{180E}' => true,
         '\u{FEFF}' => !is_leading_feff,
         _ => false,
     }
@@ -145,6 +154,13 @@ mod tests {
     #[test]
     fn flags_zwj() {
         assert_eq!(first_zero_width("\u{200D}x").unwrap().2, 0x200D);
+    }
+
+    #[test]
+    fn flags_word_joiner_and_mongolian_vowel_separator() {
+        // L1: U+2060 (WORD JOINER) and U+180E complete the zero-width set.
+        assert_eq!(first_zero_width("a\u{2060}b").unwrap().2, 0x2060);
+        assert_eq!(first_zero_width("a\u{180E}b").unwrap().2, 0x180E);
     }
 
     #[test]

--- a/crates/alint-rules/src/no_zero_width_chars.rs
+++ b/crates/alint-rules/src/no_zero_width_chars.rs
@@ -13,11 +13,12 @@
 //!     so the two rules don't double-report.
 //!
 //! Note on U+200D (ZWJ): it is flagged even though it joins emoji
-//! sequences (e.g. the family glyph 👨‍👩‍👧), because in source it is
-//! far more often an obfuscation vector than legitimate. The strip
-//! fixer therefore *will* break a literal emoji ZWJ sequence — scope
-//! the rule away from files that legitimately carry such emoji.
-//! (Grapheme-cluster-aware ZWJ handling is a possible future refinement.)
+//! sequences (e.g. the multi-person "family" emoji, built by joining
+//! several person glyphs with ZWJ), because in source it is far more
+//! often an obfuscation vector than legitimate. The strip fixer
+//! therefore *will* break a literal emoji ZWJ sequence — scope the rule
+//! away from files that legitimately carry such emoji. (Grapheme-cluster-
+//! aware ZWJ handling is a possible future refinement.)
 
 use std::path::Path;
 

--- a/crates/alint-rules/src/spawn.rs
+++ b/crates/alint-rules/src/spawn.rs
@@ -81,22 +81,10 @@ pub(crate) fn run_capturing(
     // Concurrent drain: the child can produce more than a pipe
     // buffer's worth before exiting, so reading only after exit
     // (capped or not) would deadlock or truncate.
-    let mut out_pipe = child.stdout.take();
-    let mut err_pipe = child.stderr.take();
-    let out_h = std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        if let Some(p) = out_pipe.as_mut() {
-            let _ = p.read_to_end(&mut buf);
-        }
-        buf
-    });
-    let err_h = std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        if let Some(p) = err_pipe.as_mut() {
-            let _ = p.read_to_end(&mut buf);
-        }
-        buf
-    });
+    let out_pipe = child.stdout.take();
+    let err_pipe = child.stderr.take();
+    let out_h = std::thread::spawn(move || capture_capped(out_pipe));
+    let err_h = std::thread::spawn(move || capture_capped(err_pipe));
 
     let start = Instant::now();
     loop {
@@ -131,4 +119,26 @@ pub(crate) fn run_capturing(
             }
         }
     }
+}
+
+/// Per-stream cap on captured child output (L12). The spawning kinds are
+/// trust-gated, so this is defense-in-depth: a runaway or compromised
+/// generator cannot OOM the run. Generous — every legitimate formatter diff /
+/// generated file is orders of magnitude smaller — yet bounded.
+const CAPTURE_CAP_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Read up to [`CAPTURE_CAP_BYTES`] from `pipe`, then drain (discard) any
+/// excess so the child can finish writing and exit instead of blocking on a
+/// full pipe — preserving the concurrent-drain robustness while bounding
+/// memory. Truncation past the cap is silent but bounded (surfacing it to the
+/// caller would need `SpawnOutcome` plumbing; tracked as a follow-up). A `None`
+/// pipe yields an empty buffer.
+fn capture_capped(pipe: Option<impl std::io::Read>) -> Vec<u8> {
+    let Some(mut p) = pipe else {
+        return Vec::new();
+    };
+    let mut buf = Vec::new();
+    let _ = p.by_ref().take(CAPTURE_CAP_BYTES).read_to_end(&mut buf);
+    let _ = std::io::copy(&mut p, &mut std::io::sink());
+    buf
 }

--- a/crates/alint/tests/baseline_keys.rs
+++ b/crates/alint/tests/baseline_keys.rs
@@ -169,3 +169,36 @@ fn first_offender_keyed_on_file_survives_the_first_fix() {
         "a fully-fixed baselined finding warns as stale: {stderr}",
     );
 }
+
+/// `line_max_width` is a first-offender rule keyed on the file (M14): once
+/// baselined, editing the over-wide line's *content* (while it stays over-wide)
+/// must NOT churn — the path, not the line content, is the identity. Before M14
+/// the default line-content discriminator would re-fire on this edit.
+#[test]
+fn line_max_width_first_offender_keyed_on_file_no_content_churn() {
+    let d = tempfile::tempdir().unwrap();
+    let root = d.path();
+    write(
+        root,
+        ".alint.yml",
+        "version: 1\n\
+         rules:\n\
+         \x20 - id: max-width\n\
+         \x20   kind: line_max_width\n\
+         \x20   paths: [\"*.txt\"]\n\
+         \x20   max_width: 10\n\
+         \x20   level: error\n",
+    );
+    write(root, "code.txt", "0123456789ABCDEF\n"); // 16 chars > 10
+    assert_eq!(code(&run(root, &["check"])), 1, "dirty before baseline");
+    assert_eq!(code(&run(root, &["baseline"])), 0, "snapshot it");
+
+    // Edit the over-wide line's CONTENT (still over-wide). A content key would
+    // churn (re-fire); the path key keeps it suppressed.
+    write(root, "code.txt", "FEDCBA9876543210\n");
+    assert_eq!(
+        code(&run(root, &["check", "--baseline", ".alint-baseline.json"])),
+        0,
+        "path-keyed: editing the over-wide line's content must not re-fire",
+    );
+}

--- a/crates/alint/tests/cli/gitlab-format.stdout
+++ b/crates/alint/tests/cli/gitlab-format.stdout
@@ -2,7 +2,7 @@
   {
     "description": "expected a file matching [LICENSE]",
     "check_name": "must-have-license",
-    "fingerprint": "da6f6f588e2295ff0a00c9ae9e8af276bf7df5d8ec6359479cc24f3b2a43ec11",
+    "fingerprint": "c58a316821b90856e9c6ee478d35c9115d04994d181b47014401a7aad543b415",
     "severity": "major",
     "location": {
       "path": ".",

--- a/docs/adr/0006-baseline-suppression.md
+++ b/docs/adr/0006-baseline-suppression.md
@@ -71,9 +71,13 @@ generated fingerprint file, separate from `.alint.yml`:
   per-fingerprint counts, and is reword-proof. (v1 keyed only no-path rules; v2
   over-corrected to "key every non-line-content rule"; the v3 audit showed the
   `(rule_id, path)` default is both safe and far smaller.)
-- This is **one** fingerprint definition for the whole tool: the existing
-  `gitlab.rs` cross-run-dedup fingerprint (keyed on the message) is migrated onto
-  it, and SARIF gains it as `partialFingerprints`.
+- This is *intended* as **one** fingerprint definition for the whole tool:
+  SARIF gains it as `partialFingerprints` (shipped). Migrating the existing
+  `gitlab.rs` cross-run-dedup fingerprint onto it is **deferred** — it needs
+  report-fingerprint plumbing (see `docs/design/baseline.md` §5/§7). Until
+  then `gitlab.rs` keeps its own `rule_id|path|message|occurrence` fingerprint
+  (the `occurrence` discriminator added in the post-v0.13 audit guarantees the
+  per-report uniqueness the Code Climate spec requires).
 - A stale entry (the fixed/edited case) warns and re-tightens but does not fail
   the build by default; `--strict-baseline` opts into failing on stale.
 - Suppression **marks rather than removes**: a deterministic, order-preserving

--- a/docs/design/baseline.md
+++ b/docs/design/baseline.md
@@ -186,10 +186,13 @@ genuinely isn't `(rule_id, path)` — i.e. when it emits *more than one* finding
   `cross_file_value_equals`, `dir_absent`, `generated_file_fresh`): no single
   `path`, or several findings per path, so the default would collapse them.
   Key = the sorted set of involved repo-relative paths (or the per-finding path).
-- **First-offender line rules** (`no_trailing_whitespace`, `line_endings`):
-  report only the first offending line per file. Their identity is `(rule, file)`,
-  not a line's content (content-hashing churns when the first offender is fixed
-  and the second surfaces). Key = the path.
+- **First-offender / first-match rules** (`no_trailing_whitespace`,
+  `line_endings`, `line_max_width`, `file_content_forbidden`): report only the
+  first offending line (or first match) per file. Their identity is
+  `(rule, file)`, not a line's content (content-hashing churns when the first
+  offender is fixed and the second surfaces, or when the offending line is
+  edited but stays an offense). Key = the path. The trade-off — a *file-level*
+  acceptance window, wider than content-keying — is disclosed in §4.
 - **Line-collision** (`markdown_paths_resolve`): emits several findings on one
   line (e.g. two broken links), so line-content alone collapses them. Key = the
   per-finding target (the unresolved path/link).
@@ -200,9 +203,12 @@ makes their identity `(rule_id, path)`, stable as the magnitude grows (the "same
 accepted finding"; see the "ratchet" note in §4), with the volatile magnitude no
 longer in the hash. And the bulk of **single-finding path-only** rules
 (`file_exists`, `dir_exists`, `file_hash`, `file_content_matches`, …) and the
-**line-content** rules (`for_each_match`, `commented_out_code`, and the
-first-offender `line_max_width` — one finding per file, on the first over-wide
-line): the default discriminator (§3.1) covers them. The §6 collision-invariant enforces
+**line-content** rules (`for_each_match`, `commented_out_code` — several
+findings per file, each on its own line): the default discriminator (§3.1)
+covers them. (The first-offender `line_max_width` / `file_content_forbidden`
+were previously grouped here on a "one finding per file" rationale; v3.1 moves
+them to the path-keyed first-offender bucket above for consistency with the
+other first-offender rules — see §4.) The §6 collision-invariant enforces
 the boundary so a new kind can't silently fall into an unsafe default.
 
 ## 3. Semantics
@@ -262,9 +268,11 @@ with fingerprint *F* suppresses `min(k, baseline[F].count)`; any beyond that are
 Residual masking (documented, accepted): at or below the recorded count, a *new*
 violation whose content is byte-identical to a baselined one is indistinguishable
 from the old and stays suppressed; only the `(count+1)`th such identical
-occurrence is reported. Distinct content/keys are never confused — this is the
-narrowest possible masking window and is the price of line-content (vs
-line-number) keying.
+occurrence is reported. Distinct content/keys are never confused — for
+content-keyed rules this is the narrowest possible masking window and is the
+price of line-content (vs line-number) keying. (The path-keyed first-offender
+rules of §2.4 deliberately accept a *wider*, file-level window instead — see
+§4.)
 
 `Baseline::load` **sums** the counts of any duplicate fingerprints it reads, so a
 file with two entries for one fingerprint (e.g. a git merge of two branches that
@@ -384,6 +392,19 @@ By failure mode:
   editing the offending line's own content (or a rule's structural key) re-fires.
   A sweeping reformat that rewrites offending lines re-fires them — acceptable and
   arguably correct (re-run `alint baseline` to re-accept).
+- **First-offender rules accept a *file-level* window.** The path-keyed
+  first-offender / first-match rules (`no_trailing_whitespace`, `line_endings`,
+  `line_max_width`, `file_content_forbidden`; §2.4) emit at most one finding per
+  file and are keyed on the path, so once a file is baselined for one of them
+  the *rule is suppressed for that file* — a later offense on a **different**
+  line is masked, not just a byte-identical recurrence. This is wider than the
+  content-keyed window of §3.2, and is the deliberate price of not churning
+  every time the first offending line is edited (the alternative, content
+  keying, re-fires on any edit to that line even when it stays an offense). It
+  is bounded: the window is one rule × one file, the baseline diff names the
+  file, `--show-baselined` lists it, and re-running `alint baseline` after the
+  file is cleaned drops the entry. Choose the rule's `level`/scope accordingly
+  if a per-line guarantee matters more than churn-freedom.
 - **Threshold rules and the "ratchet" gap.** A baselined `file_max_lines` keyed on
   path stays suppressed as the file grows further (the magnitude isn't in the
   key). This is correct *baseline* semantics — you accepted "this file is over the

--- a/docs/design/v0.14/post_v0.13_audit.md
+++ b/docs/design/v0.14/post_v0.13_audit.md
@@ -403,18 +403,26 @@ slashes `\`→`/` and percent-encodes space/`#`/`%`/controls/non-ASCII per
 RFC 3986; plain-ASCII paths are unchanged (existing snapshots stable);
 unit-tested.
 
-### M10 — GitLab fingerprint omits line; ADR-0006 overclaims unification `[-]`
-**Deferred:** the code half (add `line` to the gitlab fingerprint) is
-small, but it pairs with the ADR-0006 / `baseline.md` reconciliation and
-the deferred gitlab fingerprint-unification work (baseline.md §5/§7); do
-together so the fingerprint isn't changed twice. Tracked.
-**Where:** `output/gitlab.rs:115` (`SHA256(rule_id|path|message)`,
-excludes line). Distinct findings with identical messages collapse →
-count disagrees with json/junit/sarif. `docs/adr/0006:74` claims this
-fingerprint was unified onto `violation_fingerprint`; it wasn't. **Fix:**
-include line (and/or a per-occurrence discriminator) in the gitlab
-fingerprint; reconcile ADR-0006 §Decision with `baseline.md` (the
-unification is deferred, not done — say so).
+### M10 — GitLab fingerprint omits line; ADR-0006 overclaims unification `[x]`
+**Where:** `output/gitlab.rs` (`SHA256(rule_id|path|message)`, excludes
+line). Distinct findings with identical rule+path+message collapse to one
+fingerprint — and the Code Climate spec requires *per-report uniqueness*,
+so GitLab silently drops the duplicates (a generic-message per-line rule
+firing on several lines of one file loses all but one). **Done (code):**
+added a per-report `occurrence` discriminator (0-based index among
+findings sharing `rule|path|message`) folded into the hash. This was
+chosen over including the *line* deliberately: the existing
+`fingerprint_independent_of_line_number` test encodes a real design goal
+(a finding that drifts up/down stays the same issue across runs), and the
+discriminator preserves it (single-occurrence findings keep a
+line-independent fingerprint) while still disambiguating true duplicates.
+New test `distinct_findings_same_message_get_distinct_fingerprints`; the
+two existing stability tests still pass. **Done (docs):** ADR-0006 §74
+claimed the gitlab fingerprint was migrated onto `violation_fingerprint`
+— it wasn't. Corrected to say SARIF integration shipped but the gitlab
+unification is **deferred** (report-fingerprint plumbing, `baseline.md`
+§5/§7), matching what `baseline.md` already states. The full unification
+remains the tracked follow-up.
 
 ### M11 — exit codes: documented `3` never produced; `2` overloaded `[-]`
 **Deferred (needs error-model work; maintainer chose to implement exit 3):**

--- a/docs/design/v0.14/post_v0.13_audit.md
+++ b/docs/design/v0.14/post_v0.13_audit.md
@@ -526,9 +526,14 @@ Doc drift (D):
 
 LOW correctness cleanup (L):
 
-- `[ ]` **L1** `no_bidi_controls.rs:31` add U+200E/200F/061C (complete
-  the Trojan-Source set); `no_zero_width_chars.rs:25` add U+2060/U+180E;
-  decide ZWJ-in-grapheme handling for the strip fixer.
+- `[x]` **L1** `no_bidi_controls` now also flags U+061C/200E/200F (the
+  implicit directional marks — completes the Trojan-Source set, matching
+  rustc); `no_zero_width_chars` now also flags U+2060/U+180E. Both predicates
+  back the strip fixers, so detection + fix extend together. ZWJ-in-grapheme:
+  kept flagged (suspicious in source) with an honest doc note that the strip
+  fixer breaks legit emoji ZWJ sequences (scope away from such files);
+  grapheme-aware refinement noted as a future, not done (out of contained
+  scope). Tests added for all five new codepoints.
 - `[ ]` **L2** `no_case_conflicts.rs:38`, `case.rs:69`,
   `filename_case.rs:48` — ASCII-only case-folding misses real macOS/NTFS
   Unicode collisions; `file_ops.rs:112` rename guard false-positives

--- a/docs/design/v0.14/post_v0.13_audit.md
+++ b/docs/design/v0.14/post_v0.13_audit.md
@@ -334,16 +334,15 @@ flagged. **Deferred:** needs a walker/`FileIndex` change — a per-entry
 symlinks the walker currently prunes. Core + determinism-sensitive;
 wants its own pass.
 
-### M5 — `git_no_denied_paths` denylist is root-anchored `[-]`
-**Where:** `git_no_denied_paths.rs:99`. For a *secrets* control,
-`*.pem`/`id_rsa` match only repo root, so `secrets/server.pem` evades.
-**Fix:** auto-anchor bare/`*` denied patterns to `**/` (or emit a
-loud build-time warning when a denied pattern lacks `**/`), documented as
-a security-control default distinct from the general glob footgun.
-**Deferred (semantics call):** auto-anchoring silently changes glob
-matching for everyone (a user who wrote `*.env` expecting root-only would
-suddenly match any depth). Wants a decision on auto-anchor vs
-warn-at-build vs doc-only before landing. Tracked.
+### M5 — `git_no_denied_paths` denylist is root-anchored `[x]`
+**Where:** `git_no_denied_paths.rs`. For a *secrets* control, `*.pem` /
+`id_rsa` matched only the repo root, so `secrets/server.pem` evaded.
+**Done (maintainer chose auto-anchor):** a bare denied pattern (no `/`) is
+rewritten to `**/<pattern>` so it bans a match at any depth; explicit-path
+patterns (`secrets/*.key`, `**/*.pem`) are taken as written; the violation
+message keeps the original spelling. The semantics change (a bare `*.env`
+now matches any depth) is the intended secure default for a denylist.
+Tested (`anchor_denied_pattern` + a nested-match check).
 
 ### M6 — non-UTF-8 git data silently collapses checks `[~]`
 **Where:** `core/git.rs:60,135` (one non-UTF-8 path → whole tracked/
@@ -403,10 +402,14 @@ fingerprint; reconcile ADR-0006 §Decision with `baseline.md` (the
 unification is deferred, not done — say so).
 
 ### M11 — exit codes: documented `3` never produced; `2` overloaded `[-]`
-**Deferred (doc-coordination):** the README half overlaps the parallel
-doc-drift pass; §Open decisions leans "document the real 2-code contract"
-(a 2/3 split is a public-contract change, low value). Do after the doc
-branch merges.
+**Deferred (needs error-model work; maintainer chose to implement exit 3):**
+a clean config-vs-internal split is NOT type-inferrable — `alint_core::Error::
+Other` is overloaded for *config* errors (the spawn-gate rejections, extends
+errors, cycle errors all use it), so mapping by variant would mislabel config
+as internal. Implementing exit 3 honestly needs an explicit `Error::Internal`
+variant tagged at the genuinely-internal sites (output-write failures, engine
+invariants) and `main()` classifying on it — a focused error-model change, not
+a funnel tweak. Tracked for a dedicated CLI/error pass.
 **Where:** README:212 documents `3` (internal); `main.rs:380` funnels
 every `anyhow` error to exit `2`. **Fix:** either implement distinct
 exit codes (`2` config, `3` internal) or correct the README + the
@@ -422,9 +425,15 @@ except `check` (the `baseline` subcommand writes via its own `--output`,
 not this flag), mirroring the `--only` rejection; trycmd-tested.
 
 ### M13 — global `--format` bypasses per-subcommand value gate by position `[-]`
-**Deferred:** validate `--format` against each subcommand's allowed set in
-the handler (fail loudly regardless of position) — clean but multi-site;
-next CLI pass.
+**Deferred (CLI-surface change; attempted + reverted):** the root cause is
+the *dual* `--format` — a global arg and a per-subcommand arg with the same
+long name. clap MERGES them, so `cli.format` already reflects the local value
+(`markdown` for export-agents-md, `yaml` for suggest); a naive "reject a
+non-default global format" gate fires on those subcommands' normal operation
+(it broke `export-agents-md-markdown` / `suggest-rust-yaml`, reverted). The
+real fix unifies the surface — drop the per-subcommand `--format`, validate
+the single global against each subcommand's allowed set, special-case
+export-agents-md's non-`human` default — a deliberate CLI change, own pass.
 **Where:** global `--format` is an unrestricted `String` (`main.rs:54`);
 `alint --format sarif validate-config` → exit 0, silently ignored.
 **Fix:** validate `--format` against the subcommand's allowed set in the

--- a/docs/design/v0.14/post_v0.13_audit.md
+++ b/docs/design/v0.14/post_v0.13_audit.md
@@ -534,14 +534,17 @@ LOW correctness cleanup (L):
   fixer breaks legit emoji ZWJ sequences (scope away from such files);
   grapheme-aware refinement noted as a future, not done (out of contained
   scope). Tests added for all five new codepoints.
-- `[ ]` **L2** `no_case_conflicts.rs:38`, `case.rs:69`,
-  `filename_case.rs:48` — ASCII-only case-folding misses real macOS/NTFS
-  Unicode collisions; `file_ops.rs:112` rename guard false-positives
-  case-only renames on case-insensitive FS. Use Unicode-aware folding;
-  special-case same-inode case-only renames.
-- `[ ]` **L3** `when/lexer.rs:136` `byte as char` lexes string literals
-  as Latin-1 → non-ASCII `when:` comparisons silently never match. Decode
-  UTF-8 properly.
+- `[~]` **L2** `no_case_conflicts` now folds with Unicode `to_lowercase`
+  (not ASCII-only), so `É`/`é` and `Ω`/`ω` collisions are caught — the strict,
+  portable default for a case-conflict detector (test added). **Deferred
+  (rest):** `case.rs`/`filename_case.rs` are *documented* as ASCII-scoped by
+  design (camel/pascal/snake are defined on ASCII letters), so Unicode-izing
+  them is a semantics change, not a bug fix; the `file_ops.rs` same-inode
+  rename special-case is filesystem-semantics needing cross-platform care.
+  Both want a deliberate pass.
+- `[x]` **L3** the `when:` lexer now decodes the full UTF-8 scalar instead of
+  casting one byte to `char` (Latin-1 mojibake), so a non-ASCII literal like
+  `== "café"` matches. Escapes still work; tests cover accents, Cyrillic, emoji.
 - `[x]` **L4** `FilePrependFixer`/`FileAppendFixer` (backing
   `file_header`/`file_footer`) gained an idempotency guard: if the file
   already begins/ends with exactly the content, the fixer skips instead of
@@ -558,9 +561,12 @@ LOW correctness cleanup (L):
   resolving to the empty string on timeout — making the doc's long-standing
   timeout claim true instead of weakening it. Output is also capped (1 MiB).
   Tests (injectable timeout) cover both the timeout and the capture paths.
-- `[ ]` **L7** non-`NotFound` `fs::read` errors silently swallowed
-  (`engine.rs:499`, `rule.rs:490`, `facts.rs:254`) — distinguish
-  `NotFound` (skip) from real I/O errors (surface).
+- `[x]` **L7** a shared `walker::read_or_skip` now skips a genuinely-absent
+  file silently (the benign deleted-mid-walk race) but logs any *other* read
+  error (permission/I-O) at `warn`, so it's observable with `-v`/`RUST_LOG`
+  instead of silently mistaken for "file absent". Used at all three sites
+  (`engine.rs`, `rule.rs`, `facts.rs`). The run stays resilient (no abort on
+  one bad file — the long-standing per-file-read contract), only louder.
 - `[x]` **L8** `render_path` now does a single left-to-right scan into a fresh
   buffer (matching known `{token}`s by prefix), so a value substituted for one
   token is never re-scanned for another — a repo file literally named
@@ -586,8 +592,12 @@ LOW correctness cleanup (L):
   Truncation past the generous cap is silent-but-bounded; surfacing it to the
   caller (a user-facing note) needs `SpawnOutcome` plumbing — noted as a
   follow-up. (`command.rs` already capped its own drain.)
-- `[ ]` **L13** `command.rs:112,153` no `--`/`./` guard before path
-  tokens → leading-dash filenames become options. Insert `--` or `./`.
+- `[x]` **L13** new `template::render_path_argv` (used by the `command` rule)
+  prefixes `./` when substituting a path token turns a *non-flag* argv template
+  into a leading-dash string — so a repo file named `--write` rendered from
+  `{path}` can't flip `prettier --check {path}` into a destructive `--write`.
+  A flag the user wrote (`--check`, `--file={path}`) is left untouched. Test
+  added; the sibling spawning kinds don't render paths into argv.
 - `[x]` **L14** (decision: document + consider warn) Documented the empty /
   exclude-only `paths` = match-all (fail-open) behavior authoritatively on the
   `Scope` type + `matches` (the spec sites): an explicit `paths: []` applies to

--- a/docs/design/v0.14/post_v0.13_audit.md
+++ b/docs/design/v0.14/post_v0.13_audit.md
@@ -542,10 +542,12 @@ LOW correctness cleanup (L):
 - `[ ]` **L3** `when/lexer.rs:136` `byte as char` lexes string literals
   as Latin-1 → non-ASCII `when:` comparisons silently never match. Decode
   UTF-8 properly.
-- `[ ]` **L4** `file_header`/`file_footer` append/prepend fixers don't
-  verify the regex is satisfied → can stack duplicates across `--fix`
-  runs (`file_starts_with` refuses a fixer for exactly this reason).
-  Make them verify-then-skip or refuse like the siblings.
+- `[x]` **L4** `FilePrependFixer`/`FileAppendFixer` (backing
+  `file_header`/`file_footer`) gained an idempotency guard: if the file
+  already begins/ends with exactly the content, the fixer skips instead of
+  stacking a duplicate on every `--fix` (the failure mode when the configured
+  content doesn't satisfy the rule's pattern, so the violation never clears).
+  Both the on-disk `apply` and the editor `fix_edit` paths. Tests added.
 - `[x]` **L5** Cache temp file is now PID+counter-unique (`extends/cache.rs`,
   + cleanup-on-failed-rename), so concurrent runs caching the same SRI don't
   race a fixed `<sri>.yml.tmp`. The local-extends recursion is depth-capped
@@ -556,9 +558,12 @@ LOW correctness cleanup (L):
 - `[ ]` **L7** non-`NotFound` `fs::read` errors silently swallowed
   (`engine.rs:499`, `rule.rs:490`, `facts.rs:254`) — distinguish
   `NotFound` (skip) from real I/O errors (surface).
-- `[ ]` **L8** `template.rs:71` `render_path` re-substitutes injected
-  `{ext}`/`{dir}` tokens from repo-named paths → wrong path for forbidding
-  rules. Single left-to-right scan into a fresh buffer.
+- `[x]` **L8** `render_path` now does a single left-to-right scan into a fresh
+  buffer (matching known `{token}`s by prefix), so a value substituted for one
+  token is never re-scanned for another — a repo file literally named
+  `a{ext}.c` (stem `a{ext}`) no longer has its embedded `{ext}` wrongly
+  expanded by the later `{ext}` pass. Unknown `{tokens}` still preserved. Test
+  added.
 - `[x]` **L9** `levenshtein_suggestion` skips any candidate whose length
   differs from the unknown field by more than `MAX_SUGGEST_DISTANCE` (2)
   *before* building the O(n*m) matrix — edit distance >= length diff, so this
@@ -566,8 +571,10 @@ LOW correctness cleanup (L):
   real field is short -> no matrix built). Test added.
 - `[ ]` **L10** `eval.rs:61` `null matches …` hard-errors while `null ==`
   is falsy — make `matches` on a missing fact falsy (or document).
-- `[ ]` **L11** `jsonpath_diagnostics.rs:34` dashed-key hint fires inside
-  string literals (cosmetic); skip quoted spans.
+- `[x]` **L11** the dashed-key hint now matches against a copy with quoted
+  string literals masked to spaces (byte-length-preserving, escape-aware), so a
+  dash *inside* a literal (`@.x == 'a.dashed-value'`) no longer triggers a
+  false hint; a genuine dashed key alongside a literal still does. Tests added.
 - `[x]` **L12** `spawn.rs` captures each child stream through `capture_capped`
   (64 MiB cap + drain-excess-to-sink, preserving the concurrent-drain
   no-deadlock property) so a runaway/compromised generator can't OOM the run.

--- a/docs/design/v0.14/post_v0.13_audit.md
+++ b/docs/design/v0.14/post_v0.13_audit.md
@@ -546,9 +546,11 @@ LOW correctness cleanup (L):
   verify the regex is satisfied → can stack duplicates across `--fix`
   runs (`file_starts_with` refuses a fixer for exactly this reason).
   Make them verify-then-skip or refuse like the siblings.
-- `[ ]` **L5** extends cache fixed `<sri>.yml.tmp` temp name races
-  concurrent runs (`extends/cache.rs:83`); unbounded acyclic local-extends
-  recursion (`loader.rs:48`). PID/rand-suffix the temp; add a depth cap.
+- `[x]` **L5** Cache temp file is now PID+counter-unique (`extends/cache.rs`,
+  + cleanup-on-failed-rename), so concurrent runs caching the same SRI don't
+  race a fixed `<sri>.yml.tmp`. The local-extends recursion is depth-capped
+  (`MAX_EXTENDS_DEPTH = 64`, checked via `visiting.len()`) so a hostile deep
+  acyclic chain errors instead of overflowing the stack. Tests added.
 - `[ ]` **L6** `custom` fact has no timeout despite the doc claiming one
   (`facts.rs:134`); implement a timeout or fix the doc.
 - `[ ]` **L7** non-`NotFound` `fs::read` errors silently swallowed
@@ -557,14 +559,21 @@ LOW correctness cleanup (L):
 - `[ ]` **L8** `template.rs:71` `render_path` re-substitutes injected
   `{ext}`/`{dir}` tokens from repo-named paths → wrong path for forbidding
   rules. Single left-to-right scan into a fresh buffer.
-- `[ ]` **L9** `did_you_mean.rs:105` levenshtein matrix unbounded on a
-  huge unknown-field name; cap input length.
+- `[x]` **L9** `levenshtein_suggestion` skips any candidate whose length
+  differs from the unknown field by more than `MAX_SUGGEST_DISTANCE` (2)
+  *before* building the O(n*m) matrix — edit distance >= length diff, so this
+  is correctness-preserving and bounds a hostile multi-KB field name (every
+  real field is short -> no matrix built). Test added.
 - `[ ]` **L10** `eval.rs:61` `null matches …` hard-errors while `null ==`
   is falsy — make `matches` on a missing fact falsy (or document).
 - `[ ]` **L11** `jsonpath_diagnostics.rs:34` dashed-key hint fires inside
   string literals (cosmetic); skip quoted spans.
-- `[ ]` **L12** `spawn.rs:89,96` unbounded `read_to_end` on child output
-  — cap with a loud over-cap note (trust-gated, so low risk).
+- `[x]` **L12** `spawn.rs` captures each child stream through `capture_capped`
+  (64 MiB cap + drain-excess-to-sink, preserving the concurrent-drain
+  no-deadlock property) so a runaway/compromised generator can't OOM the run.
+  Truncation past the generous cap is silent-but-bounded; surfacing it to the
+  caller (a user-facing note) needs `SpawnOutcome` plumbing — noted as a
+  follow-up. (`command.rs` already capped its own drain.)
 - `[ ]` **L13** `command.rs:112,153` no `--`/`./` guard before path
   tokens → leading-dash filenames become options. Insert `--` or `./`.
 - `[ ]` **L14** `scope.rs:45` empty `paths: []` is fail-open (match-all);

--- a/docs/design/v0.14/post_v0.13_audit.md
+++ b/docs/design/v0.14/post_v0.13_audit.md
@@ -54,7 +54,7 @@ three classes at once.
 | 3 | HIGH — correctness | H3, H4 | `[x]` |
 | 4 | MEDIUM — security cluster | M1–M8 | `[~]` (M1/M2/M5/M6/M7/M8 done; M3,M4 deferred) |
 | 5 | MEDIUM — output / CLI / baseline | M9–M14 | `[~]` (M9/M10/M12/M14 done; M11,M13 deferred) |
-| 6 | Docs + LOW cleanup + dogfooding (alint) | D1–D12, L1–L14 | `[~]` (D1–D10,D12 done; D11 + L/dogfood deferred) |
+| 6 | Docs + LOW cleanup + dogfooding (alint) | D1–D12, L1–L14 | `[~]` (D1–D10,D12 + L1,L3–L14 done; L2 partial; D11 + Dog1/Dog2 deferred) |
 | 7 | alint.org drift | W1–W7 | `[x]` (W1–W5,W7 done on the site branch; W6 partial) |
 
 Phases land security-first. Each is one atomic commit (or a small group)

--- a/docs/design/v0.14/post_v0.13_audit.md
+++ b/docs/design/v0.14/post_v0.13_audit.md
@@ -52,7 +52,7 @@ three classes at once.
 | 1 | CRITICAL — spawn-gate RCE | C1, C2 | `[x]` |
 | 2 | HIGH — security | H1, H2, H5 | `[x]` |
 | 3 | HIGH — correctness | H3, H4 | `[x]` |
-| 4 | MEDIUM — security cluster | M1–M8 | `[~]` (M1/M6/M7 done; M2–M5,M8 deferred) |
+| 4 | MEDIUM — security cluster | M1–M8 | `[~]` (M1/M2/M5/M6/M7 done; M3,M4,M8 deferred) |
 | 5 | MEDIUM — output / CLI / baseline | M9–M14 | `[~]` (M9/M12 done; M10,M11,M13,M14 deferred) |
 | 6 | Docs + LOW cleanup + dogfooding (alint) | D1–D12, L1–L14 | `[~]` (D1–D10,D12 done; D11 + L/dogfood deferred) |
 | 7 | alint.org drift | W1–W7 | `[x]` (W1–W5,W7 done on the site branch; W6 partial) |
@@ -296,18 +296,25 @@ the way `https_only(true)` would. An `extends:` URL is SRI-pinned to
 specific content, so it must be the final resource; a redirect now
 surfaces as a clear status error.
 
-### M2 — `extends:` target paths are unconfined `[-]`
-**Where:** `loader.rs:192` (`resolve_relative`). `extends:
-[/etc/hostname]` or `../../x` is read and YAML-parse errors echo content
-→ exfil. **Fix:** confine local extends-target resolution to the repo
-root (reuse `normalize_confined`), subject to the same top-level-only
-trust as `allow_out_of_root`. **Deferred (design call):** confining
-`extends:` would break a legitimate monorepo `extends: [../shared/base.yml]`
-unless `allow_out_of_root` is honored here too, and the exploit needs an
-attacker-controlled local config already inside a trusted chain (narrow).
-Wants the confine-vs-`allow_out_of_root` decision; a lighter alternative
-is to stop echoing file content in extends parse errors. Tracked for the
-focused extends pass.
+### M2 — `extends:` target paths are unconfined `[x]`
+**Where:** `loader.rs` (`resolve_relative` / `load_recursive`). `extends:
+[/etc/hostname]` or `../../x` was read and YAML-parse errors echo content
+→ exfil. **Decision (user):** *Confine + `allow_out_of_root`.*
+**Done:** `load_recursive` now threads a confinement root — the top-level
+config's directory — and a new `confine_extends_target` rejects any local
+`extends:` target that resolves outside it. Both sides are `canonicalize`d,
+so `..`, `.`, and symlinks are resolved (a symlink inside the tree pointing
+out is caught too); a missing target defers to the existing not-found error
+rather than being mislabelled an escape. The boundary is the config's *dir*
+(not the lint root), so a `-c` pointing at an external bundle still works
+while a sub-config in the chain can't escape that bundle. The top-level
+`allow_out_of_root: true` (the blanket `All` form only — a `Selective`
+allowlist names rule kinds/ids and has no meaning for an extends *path*)
+lifts it for the whole chain; sub-configs still can't set the flag
+(`reject_allow_out_of_root_in`). Nested configs reject `extends:` outright,
+so no confinement is needed there. Tests: 4 unit (`confine_*`) + 2
+integration (`local_extends_outside_lint_root_is_rejected`,
+`local_extends_out_of_root_allowed_with_top_level_flag`).
 
 ### M3 — per-file reads bypass the 256 MiB OOM guard `[-]`
 **Where:** `structured_path.rs:365,376`, `core/engine.rs:499`,

--- a/docs/design/v0.14/post_v0.13_audit.md
+++ b/docs/design/v0.14/post_v0.13_audit.md
@@ -53,7 +53,7 @@ three classes at once.
 | 2 | HIGH — security | H1, H2, H5 | `[x]` |
 | 3 | HIGH — correctness | H3, H4 | `[x]` |
 | 4 | MEDIUM — security cluster | M1–M8 | `[~]` (M1/M2/M5/M6/M7/M8 done; M3,M4 deferred) |
-| 5 | MEDIUM — output / CLI / baseline | M9–M14 | `[~]` (M9/M12 done; M10,M11,M13,M14 deferred) |
+| 5 | MEDIUM — output / CLI / baseline | M9–M14 | `[~]` (M9/M10/M12/M14 done; M11,M13 deferred) |
 | 6 | Docs + LOW cleanup + dogfooding (alint) | D1–D12, L1–L14 | `[~]` (D1–D10,D12 done; D11 + L/dogfood deferred) |
 | 7 | alint.org drift | W1–W7 | `[x]` (W1–W5,W7 done on the site branch; W6 partial) |
 
@@ -462,21 +462,27 @@ export-agents-md's non-`human` default — a deliberate CLI change, own pass.
 **Fix:** validate `--format` against the subcommand's allowed set in the
 handler (fail loudly on an unsupported value regardless of position).
 
-### M14 — baseline first-offender masking under-disclosed `[-]`
-**Deferred (doc + decision):** the disclosure note lands in
-`docs/design/baseline.md` §4, which the parallel doc-drift pass touches —
-do after merge. The keying question (switch `line_max_width` /
-`file_content_forbidden` to a path key, or keep + document the fail-closed
-churn) is the open decision below.
+### M14 — baseline first-offender masking under-disclosed `[x]`
+**Decision (user):** *Doc + path-key the two kinds.*
 **Where:** first-offender/first-match kinds (`no_trailing_whitespace`,
 `line_endings`, `line_max_width`, `file_content_forbidden`) emit only the
-first offender per file, so a *new* same-file offense is never emitted
-once baselined. `docs/design/baseline.md:266` calls the masking window
-"narrowest possible"; §4 doesn't list this for the content-keyed pair.
-**Fix:** document the file-level acceptance window honestly in
-`baseline.md` §4; assess whether `line_max_width`/`file_content_forbidden`
-should switch to a path key for consistency with the other two (or accept
-the churn). Likely a doc + small keying change, not a deep redesign.
+first offender per file. The first two were already path-keyed; the latter
+two fell to the default *line-content* discriminator — inconsistent, and
+churny (editing the offending line re-fires). **Done (code):**
+`line_max_width` + `file_content_forbidden` now set
+`.with_baseline_key(crate::slash(path))`, mirroring the other two, so all
+four share a `(rule, file)` identity. Compatible with the dynamic
+`coverage_audit_baseline_safety` invariant (non-empty key, no collision,
+not message-reliant) — audit still green. **Done (docs):** reconciled the
+self-contradiction in `baseline.md` §2.4 (it listed `line_max_width` as
+both a path-keyed first-offender candidate *and* a content-keyed
+"default covers it" rule) — moved both kinds to the first-offender bucket;
+§3.2 now scopes "narrowest possible window" to content-keyed rules; §4
+gains an explicit **file-level acceptance window** disclosure for the
+path-keyed first-offender rules (honest about the wider-than-content
+window + why it's the right trade vs. churn). Test:
+`line_max_width_first_offender_keyed_on_file_no_content_churn` proves the
+edit-the-offending-line case no longer re-fires.
 
 ---
 

--- a/docs/design/v0.14/post_v0.13_audit.md
+++ b/docs/design/v0.14/post_v0.13_audit.md
@@ -52,7 +52,7 @@ three classes at once.
 | 1 | CRITICAL — spawn-gate RCE | C1, C2 | `[x]` |
 | 2 | HIGH — security | H1, H2, H5 | `[x]` |
 | 3 | HIGH — correctness | H3, H4 | `[x]` |
-| 4 | MEDIUM — security cluster | M1–M8 | `[~]` (M1/M2/M5/M6/M7 done; M3,M4,M8 deferred) |
+| 4 | MEDIUM — security cluster | M1–M8 | `[~]` (M1/M2/M5/M6/M7/M8 done; M3,M4 deferred) |
 | 5 | MEDIUM — output / CLI / baseline | M9–M14 | `[~]` (M9/M12 done; M10,M11,M13,M14 deferred) |
 | 6 | Docs + LOW cleanup + dogfooding (alint) | D1–D12, L1–L14 | `[~]` (D1–D10,D12 done; D11 + L/dogfood deferred) |
 | 7 | alint.org drift | W1–W7 | `[x]` (W1–W5,W7 done on the site branch; W6 partial) |
@@ -371,17 +371,25 @@ A 19-digit author-time panics. Reachable via `git_blame_age` on an
 untrusted repo. **Done:** `UNIX_EPOCH.checked_add(...)`; on overflow the
 block is dropped (matching the adjacent posture), no panic.
 
-### M8 — terminal-escape injection in the human formatter `[-]`
-**Severity:** Medium (needs a TTY / `--color=always`; CI formats are
-already safe). **Where:** `output/human.rs:85,162,331,360,446`
-(unsanitized paths/messages). A repo file named with `\x1b[…]` can hide
-findings or forge an "all passed" banner when a human lints an untrusted
-repo. **Fix:** a control-char/ANSI sanitizer applied to all attacker-
-controlled spans (paths, messages, snippets) on the human/compact/fix
-paths; preserve intentional styling emitted by alint itself. **Deferred:**
-needs a shared sanitizer across three render paths with care not to strip
-alint's own styling; conditional on a TTY / `--color=always` (every CI
-format is already neutralized). Wants its own focused pass. Tracked.
+### M8 — terminal-escape injection in the human formatter `[x]`
+**Severity:** Medium. **Where:** `output/human.rs` (unsanitized
+paths/messages). A repo file named with `\x1b[…]` can hide findings or
+forge an "all passed" banner when a human lints an untrusted repo.
+**Done:** new `output/sanitize.rs` with `sanitize_terminal(&str) -> Cow`
+— replaces every control char (C0, DEL, C1) *except* the intentional `\n`
+(which `wrap_message` honors as a paragraph break) with a visible, inert
+`\xNN` escape; borrows unchanged on clean input so the common path
+allocates nothing. Applied to all attacker-controlled spans on the three
+render paths: the grouped section-header path label, the wrapped violation
+message (sanitized before `wrap_message`, so the embedded `kind: command`
+subprocess output is neutralized too), the compact `<path>` + `<message>`,
+and the fix `content` (sanitized whole — alint's styling is applied as
+separate tokens, never inside `content`). Runs unconditionally (not
+TTY-gated), so output is byte-identical to a terminal or a pipe — which
+also keeps the trycmd snapshots stable (verified: no drift). alint's own
+SGR is untouched. Tests: 5 unit (`sanitize::tests`) + 3 end-to-end
+(`*_format_neutralizes_terminal_escapes`, asserting a raw `\x1b[2J`
+clear-screen never survives while its `\x1b[2J` text form does).
 
 ---
 

--- a/docs/design/v0.14/post_v0.13_audit.md
+++ b/docs/design/v0.14/post_v0.13_audit.md
@@ -553,8 +553,11 @@ LOW correctness cleanup (L):
   race a fixed `<sri>.yml.tmp`. The local-extends recursion is depth-capped
   (`MAX_EXTENDS_DEPTH = 64`, checked via `visiting.len()`) so a hostile deep
   acyclic chain errors instead of overflowing the stack. Tests added.
-- `[ ]` **L6** `custom` fact has no timeout despite the doc claiming one
-  (`facts.rs:134`); implement a timeout or fix the doc.
+- `[x]` **L6** `run_custom` now spawns + drains on a thread + waits on a
+  30s deadline (matching the `command` rule's default), killing the child and
+  resolving to the empty string on timeout — making the doc's long-standing
+  timeout claim true instead of weakening it. Output is also capped (1 MiB).
+  Tests (injectable timeout) cover both the timeout and the capture paths.
 - `[ ]` **L7** non-`NotFound` `fs::read` errors silently swallowed
   (`engine.rs:499`, `rule.rs:490`, `facts.rs:254`) — distinguish
   `NotFound` (skip) from real I/O errors (surface).
@@ -569,8 +572,10 @@ LOW correctness cleanup (L):
   *before* building the O(n*m) matrix — edit distance >= length diff, so this
   is correctness-preserving and bounds a hostile multi-KB field name (every
   real field is short -> no matrix built). Test added.
-- `[ ]` **L10** `eval.rs:61` `null matches …` hard-errors while `null ==`
-  is falsy — make `matches` on a missing fact falsy (or document).
+- `[x]` **L10** `matches` on a missing fact (Null LHS) is now falsy, mirroring
+  how `null == "x"` is falsy (`==`/`!=` are total) — instead of a hard error.
+  A non-string *value* (bool/int/list) is still a config-type error. The
+  more-lenient direction, so no previously-valid config breaks. Test added.
 - `[x]` **L11** the dashed-key hint now matches against a copy with quoted
   string literals masked to spaces (byte-length-preserving, escape-aware), so a
   dash *inside* a literal (`@.x == 'a.dashed-value'`) no longer triggers a
@@ -583,8 +588,14 @@ LOW correctness cleanup (L):
   follow-up. (`command.rs` already capped its own drain.)
 - `[ ]` **L13** `command.rs:112,153` no `--`/`./` guard before path
   tokens → leading-dash filenames become options. Insert `--` or `./`.
-- `[ ]` **L14** `scope.rs:45` empty `paths: []` is fail-open (match-all);
-  document, and consider warning.
+- `[x]` **L14** (decision: document + consider warn) Documented the empty /
+  exclude-only `paths` = match-all (fail-open) behavior authoritatively on the
+  `Scope` type + `matches` (the spec sites): an explicit `paths: []` applies to
+  the whole tree, not nothing. The exclude-only idiom (`["!vendor/**"]`) is
+  *intentionally* fail-open, so a load-time warning must target only the
+  truly-empty case — that needs an absent-vs-`[]` signal at the spec layer + a
+  load-warning channel the loader doesn't expose yet, so it's a tracked
+  follow-up (considered, deferred with reason).
 
 Dogfooding (Dog):
 


### PR DESCRIPTION
Deferred-tail follow-ups from the post-v0.13 adversarial audit
(`docs/design/v0.14/post_v0.13_audit.md`). Each item is one logical commit
with code + tests + CHANGELOG + plan-doc flip.

## MEDIUM (contained)
- **M2** — confine local `extends:` targets to the top-level config's dir
  (canonicalize-based; symlink-aware); `allow_out_of_root: true` lifts it.
- **M5** — auto-anchor bare `git_no_denied_paths` patterns to any depth.
- **M8** — neutralize terminal escapes in the human/compact/fix output.
- **M10** — per-report `occurrence` discriminator in the GitLab fingerprint
  (Code-Climate uniqueness); ADR-0006 reconciled with baseline.md.
- **M14** — path-key `line_max_width`/`file_content_forbidden` (consistent
  with the other first-offender rules); baseline.md §2.4/§3.2/§4 reconciled +
  file-level acceptance-window disclosure.

## LOW cluster (L1–L14)
- **L1** completed Trojan-Source bidi (ALM/LRM/RLM) + zero-width (WJ, MVS) sets.
- **L4** idempotency guard on the prepend/append (header/footer) fixers.
- **L5** `extends:` depth cap + PID-unique cache temp name.
- **L6** real 30s timeout for `custom` facts (the doc had long promised it).
- **L7** loud (`warn`) on a non-`NotFound` file read, not silent.
- **L8** single-scan `render_path` (no token re-substitution).
- **L9** bound the levenshtein matrix on a huge unknown field name.
- **L10** `when:` `matches` on a missing fact is falsy, not a hard error.
- **L11** mask string literals in the JSONPath dashed-key hint.
- **L12** cap a spawned child's captured output at 64 MiB (drain the excess).
- **L13** `./`-guard `command` argv against a filename masquerading as an option.
- **L3** decode `when:` string literals as UTF-8 (was Latin-1 mojibake).
- **L2** (partial) Unicode case-fold in `no_case_conflicts`.

## Verification
67 test binaries green · `cargo fmt --check` clean · `clippy --workspace
--all-targets` 0 warnings · **dogfood clean** (only the two pre-existing
`rust-file-max-lines` warnings, tracked as Dog2).

## Deferred (tracked in the plan doc, with rationale)
Dog1/Dog2, M3 (cross-crate OOM cap), M4 (`no_symlinks` walker), M11 (exit 3
error-model), M13 (`--format` CLI surface), L2-remainder (case.rs is
documented-ASCII by design; `file_ops` inode special-case), D11.