### PR TITLE
test(dogfood): exercise the flagship rule families in .alint.yml (Dog1)

### DIFF
--- a/.alint.yml
+++ b/.alint.yml
@@ -274,6 +274,57 @@ rules:
     max: 1
     level: warning
 
+  # --- Flagship families ----------------------------------------------------
+  # Dogfood slices of alint's headline rule families on its own tree, so the
+  # families that make alint more than a filename linter are proven on real
+  # content (and regress here first). Each asserts something genuinely true of
+  # this repo.
+  #
+  # Structured-query: read a value out of a structured file by path and assert
+  # it, precisely (not by a brittle regex). One per format to exercise the
+  # toml / json / yaml query engines.
+  - id: cargo-workspace-resolver-3
+    kind: toml_path_equals
+    paths: Cargo.toml
+    path: "$.workspace.resolver"
+    equals: "3"
+    level: error
+    message: "the workspace must pin resolver = \"3\" (the edition-2024 default)"
+
+  - id: vscode-extension-publisher
+    kind: json_path_equals
+    paths: editors/vscode/package.json
+    path: "$.publisher"
+    equals: "asamarts"
+    level: error
+    message: "the VS Code extension ships under the asamarts marketplace namespace"
+
+  - id: action-is-composite
+    kind: yaml_path_equals
+    paths: action.yml
+    path: "$.runs.using"
+    equals: "composite"
+    level: error
+    message: "the GitHub Action is a composite action (install + run, no Docker image)"
+
+  # Cross-file: derive paths from a manifest and assert they resolve on disk —
+  # the class of check that catches a members list drifting from the tree.
+  - id: workspace-members-resolve
+    kind: registry_paths_resolve
+    source: Cargo.toml
+    extract: { toml: "$.workspace.members[*]" }
+    expect: dir
+    level: error
+    message: "every [workspace] members entry must resolve to a real crate directory"
+
+  # Git-hygiene: no secret-shaped file may be tracked. Bare patterns (no `/`)
+  # auto-anchor to any depth, so a key committed in a subdir can't hide.
+  - id: no-tracked-secrets
+    kind: git_no_denied_paths
+    denied: [id_rsa, id_dsa, "*.pem", "*.p12", "*.pfx"]
+    level: error
+    message: "no private-key / secret-shaped file may be committed to the repository"
+
   # --- Bundled ruleset shape ---------------------------------------------
   # Each YAML under crates/alint-dsl/rulesets/v1/ is the source of truth for
   # one bundled ruleset AND the source of truth for that ruleset's docs page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,6 +326,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Internal
 
+- Expanded the dogfood config (`.alint.yml`) to exercise alint's flagship rule
+  families on its own tree (Dog1): structured-query (`toml`/`json`/`yaml_path_equals`
+  over `Cargo.toml`, the VS Code `package.json`, and `action.yml`), cross-file
+  (`registry_paths_resolve` on the `[workspace] members`), and git-hygiene
+  (`git_no_denied_paths` for secret-shaped files). Each was negative-tested to
+  confirm it fires when broken; the dogfood stays green (46/46).
 - Split the two source files over the self-lint's `rust-file-max-lines`
   threshold so the dogfood is fully green (Dog2, no behavior change):
   `alint-dsl/src/lib.rs`'s test module moved to `src/tests.rs`, and

--- a/docs/design/v0.14/post_v0.13_audit.md
+++ b/docs/design/v0.14/post_v0.13_audit.md
@@ -54,7 +54,7 @@ three classes at once.
 | 3 | HIGH — correctness | H3, H4 | `[x]` |
 | 4 | MEDIUM — security cluster | M1–M8 | `[~]` (M1/M2/M5/M6/M7/M8 done; M3,M4 deferred) |
 | 5 | MEDIUM — output / CLI / baseline | M9–M14 | `[~]` (M9/M10/M12/M14 done; M11,M13 deferred) |
-| 6 | Docs + LOW cleanup + dogfooding (alint) | D1–D12, L1–L14 | `[~]` (D1–D10,D12 + L1,L3–L14 + Dog2 done; L2 partial; D11 + Dog1 deferred) |
+| 6 | Docs + LOW cleanup + dogfooding (alint) | D1–D12, L1–L14 | `[~]` (D1–D10,D12 + L1,L3–L14 + Dog1/Dog2 done; L2 partial; D11 deferred) |
 | 7 | alint.org drift | W1–W7 | `[x]` (W1–W5,W7 done on the site branch; W6 partial) |
 
 Phases land security-first. Each is one atomic commit (or a small group)
@@ -609,13 +609,20 @@ LOW correctness cleanup (L):
 
 Dogfooding (Dog):
 
-- `[-]` **Dog1** `.alint.yml` exercises 27/89 kinds with zero cross-file,
-  structured-query, or git-hygiene rules (the flagship families) and
-  doesn't extend `monorepo/cargo-workspace` despite being a 9-crate
-  workspace. Add a representative dogfood slice of each flagship family
-  (it doubles as living proof + regression coverage on real content).
-  **Deferred:** a quality/credibility improvement, not a defect; wants a
-  deliberate dogfood-config expansion.
+- `[x]` **Dog1** `.alint.yml` exercised no cross-file, structured-query, or
+  git-hygiene rules — the flagship families. **Done:** added a representative
+  slice, each asserting something genuinely true of this repo (verified by
+  negative-testing that every one *fires* when its assertion is broken):
+  **structured-query** across all three formats — `toml_path_equals`
+  (`$.workspace.resolver == "3"`), `json_path_equals` (the VS Code extension's
+  `$.publisher`), `yaml_path_equals` (`action.yml` `$.runs.using == composite`);
+  **cross-file** — `registry_paths_resolve` asserting every `[workspace]
+  members` entry resolves to a real directory (10 members); **git-hygiene** —
+  `git_no_denied_paths` forbidding secret-shaped tracked files (bare patterns,
+  exercising the M5 any-depth anchoring). Exercised kinds 27 → 32; the dogfood
+  stays fully green (46/46). Not extending `monorepo/cargo-workspace` wholesale:
+  its `member-has-readme` rule would warn on all 9 crates (no per-crate READMEs
+  yet) — a separate quality call, left as a follow-up.
 - `[x]` **Dog2** two files exceeded `rust-file-max-lines`. **Done (split, no
   logic change):** `alint-dsl/src/lib.rs` (2335, mostly a ~1500-line test
   module) → its test module moved to `alint-dsl/src/tests.rs`, leaving lib.rs


### PR DESCRIPTION
Post-v0.13 audit tail (Dog1). The dogfood config exercised no cross-file,
structured-query, or git-hygiene rules — the families that make alint more than
a filename linter. This adds a representative slice, each asserting something
**genuinely true of this repo** (every rule was negative-tested to confirm it
*fires* when its assertion is broken, so none passes vacuously):

- **structured-query** (all three formats): `toml_path_equals`
  (`$.workspace.resolver == "3"`), `json_path_equals` (the VS Code extension's
  `$.publisher`), `yaml_path_equals` (`action.yml` `$.runs.using == composite`).
- **cross-file**: `registry_paths_resolve` asserting every `[workspace] members`
  entry resolves to a real directory (10 members).
- **git-hygiene**: `git_no_denied_paths` forbidding secret-shaped tracked files
  (bare patterns, exercising the M5 any-depth anchoring).

Exercised rule kinds 27 → 32; the dogfood stays fully green (**46/46**).

Not extending `monorepo/cargo-workspace` wholesale: its `member-has-readme` rule
would warn on all 9 crates (no per-crate READMEs yet) — a separate quality call,
left as a follow-up.