### PR TITLE
fix: close 5 real bugs from the post-v0.13 e2e sweep

### DIFF
--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -92,3 +92,41 @@ jobs:
           # (i.e. when HEAD is 0.X+1, this sits at v0.X) so
           # the test catches CLI/.alint.yml drift one release out.
           version: v0.12.0
+
+  action-config-single:
+    name: config input (single path)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: alint check with an explicit config path
+        uses: ./
+        with:
+          # The repo lints clean against its own `.alint.yml` (the
+          # action-default job proves that via auto-discovery); passing it
+          # explicitly through the `config:` input exercises the
+          # single-`--config` path end to end.
+          config: .alint.yml
+
+  action-config-multi-rejected:
+    name: config input (multiple paths rejected)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: alint rejects two config paths
+        id: multi
+        continue-on-error: true
+        uses: ./
+        with:
+          # `--config` is single-valued; two paths must fail, not silently use
+          # the first. Regression guard that the action honors the CLI's H4
+          # contract (compose via `extends:`, not repeated `--config`).
+          config: |
+            .alint.yml
+            .alint.yml
+      - name: assert the action failed loudly
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.multi.outcome }}" != "failure" ]; then
+            echo "::error::action accepted two config paths; expected a hard failure (exit 2)" >&2
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   sensitive across the subcommand boundary, so `-c base.yml -c override.yml`
   could use `base`. A second `--config` is now a hard error pointing at
   `extends:` for composition, and the help text is corrected. (H4)
+- **The GitHub Action's `config:` input matches the single-valued `--config`.**
+  The action advertised "config file path(s), one per line" and emitted one
+  `--config` per line — but the H4 fix above made a second `--config` a hard
+  error, so any workflow passing two config paths broke (exit 2 from the
+  binary). The input is now documented as a single path pointing at `extends:`
+  for composition, and the action rejects more than one path itself with a clear
+  GitHub-annotated `::error::` rather than surfacing a raw CLI stderr. New
+  `action-selftest` jobs cover both the single-path happy path and the
+  multi-path rejection. (E2E sweep)
 - **A long flat `when:` chain fails loudly instead of aborting the process.**
   The expression parser capped `(`/`[`/call nesting at depth 64, but a *flat*
   chain — `a and a and …` (or `or`) — is parsed iteratively and never re-enters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   fell through to human output; it now fails loudly (exit 2) for any format
   other than `human` / `json`, regardless of flag position — matching how
   `list` / `facts` / `explain` already gate their formats. (M13)
+- **`fix` rejects an output format it can't render, before touching files.**
+  `alint fix --format sarif` (or `github` / `junit` / `gitlab` / `agent`)
+  silently degraded to human output with a *success* exit code — those formats
+  describe findings, not fixes, and have no fix-report renderer. It now fails
+  loudly (exit 2), and because `fix` mutates the tree the gate runs *before* any
+  fix is applied, so a rejected format never leaves a half-fixed repo. `fix`
+  still renders `human` / `json` / `markdown`; the error points `agent` users at
+  `check --format agent`, whose per-violation `fix_command` drives the agentic
+  fix loop. (E2E sweep)
 - **Exit code `3` (internal error) is now actually produced.** The README
   documented `3` for an internal alint error vs `2` for a config/usage error,
   but every error funnelled to `2`, so a script could never tell "fix your

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   file suppresses the total, not the last writer's count); regeneration is
   byte-identical across runs and its guard counts new *occurrences* (a higher
   count on an existing finding is fresh debt too, not just new fingerprints).
+  The baseline file is excluded from the walk, so a broad-glob content rule
+  (`**/*.json`, `line_max_width`, …) can't lint alint's own JSON-Lines artifact
+  as a new violation — the adopt-flow stays clean.
   See `docs/design/baseline.md` / ADR-0006.
 - `--only <RULE_ID>` on `check` and `fix` (repeatable): restrict the run to the
   named rule id(s) from the effective config. An id that matches no loaded rule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,21 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   sensitive across the subcommand boundary, so `-c base.yml -c override.yml`
   could use `base`. A second `--config` is now a hard error pointing at
   `extends:` for composition, and the help text is corrected. (H4)
+- **A long flat `when:` chain fails loudly instead of aborting the process.**
+  The expression parser capped `(`/`[`/call nesting at depth 64, but a *flat*
+  chain — `a and a and …` (or `or`) — is parsed iteratively and never re-enters
+  the guarded recursion, so it slipped past the cap. An adversarial ~100k-operator
+  `when:` from an untrusted `extends:` ruleset built a deeply left-nested AST that
+  overflowed the stack on its recursive `Drop`/eval — an uncatchable abort, the
+  strongest determinism violation. Both chain loops now bound length the same way
+  nesting is bounded, so the chain fails with a normal parse error. (H5)
+- **The zero-width fixer strips the full set the rule flags.**
+  `no_zero_width_chars` flags U+2060 (WORD JOINER) and U+180E (MONGOLIAN VOWEL
+  SEPARATOR) alongside U+200B/C/D and body-internal U+FEFF, but the
+  `file_strip_zero_width` fixer hard-coded only the latter four — so a file
+  containing U+2060/U+180E was reported on every run yet never repaired, and
+  `--fix` never converged. Both fix paths now defer to the rule's own
+  `is_flagged_zero_width`, so detector and fixer can't drift apart again. (L1)
 - **`file_header` / `file_footer` fixers no longer stack duplicates.** When a
   configured header/footer's content didn't satisfy the rule's own pattern,
   the violation never cleared, so each `--fix` re-prepended/appended it. The

--- a/action.yml
+++ b/action.yml
@@ -21,8 +21,11 @@ inputs:
     default: "."
   config:
     description: |
-      Extra config file path(s), one per line. Leave empty to let alint
-      auto-discover `.alint.yml` at the lint root.
+      A single extra config file path. Leave empty to let alint
+      auto-discover `.alint.yml` at the lint root. `--config` is
+      single-valued — to compose several configs, use `extends:` inside
+      your config rather than listing multiple paths here (passing more
+      than one is a hard error, matching the CLI).
     required: false
     default: ""
   format:
@@ -143,10 +146,21 @@ runs:
         cli_args=(--format "$ALINT_FORMAT")
 
         if [ -n "$ALINT_CONFIG" ]; then
+          # `--config` is single-valued (compose via `extends:` in the config,
+          # not repeated flags). The input can arrive multi-line from a YAML
+          # block scalar; accept a lone non-empty line and reject two — matching
+          # the CLI's hard error, but with a clearer GitHub-annotated message
+          # instead of a raw "second --config" stderr from the binary.
+          config_path=""
           while IFS= read -r cfg; do
             [ -z "$cfg" ] && continue
-            cli_args+=(--config "$cfg")
+            if [ -n "$config_path" ]; then
+              echo "::error::the alint action's \`config:\` input takes a single path; use \`extends:\` inside your config to compose several (alint's --config is single-valued)." >&2
+              exit 2
+            fi
+            config_path="$cfg"
           done <<< "$ALINT_CONFIG"
+          [ -n "$config_path" ] && cli_args+=(--config "$config_path")
         fi
 
         if [ "$ALINT_FAIL_ON_WARNING" = "true" ]; then

--- a/crates/alint-core/src/config.rs
+++ b/crates/alint-core/src/config.rs
@@ -546,9 +546,9 @@ pub struct FileNormalizeLineEndingsFixSpec {}
 pub struct FileStripBidiFixSpec {}
 
 /// Empty marker. Behavior: remove every zero-width character
-/// (U+200B / U+200C / U+200D / U+FEFF) from the file's content,
-/// *except* a leading BOM (U+FEFF at position 0) — that's the
-/// responsibility of the `no_bom` rule.
+/// (U+200B / U+200C / U+200D / U+2060 / U+180E / U+FEFF) from the
+/// file's content, *except* a leading BOM (U+FEFF at position 0) —
+/// that's the responsibility of the `no_bom` rule.
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct FileStripZeroWidthFixSpec {}

--- a/crates/alint-core/src/when/mod.rs
+++ b/crates/alint-core/src/when/mod.rs
@@ -548,22 +548,22 @@ mod tests {
     }
 
     #[test]
-    fn long_and_chain_is_an_eval_error_not_a_stack_overflow() {
+    fn long_flat_chain_is_a_parse_error_not_a_stack_overflow() {
         // A flat `a and a and …` chain parses iteratively but builds a tall
-        // left-nested tree; `eval` recurses on tree height, so a crafted
-        // chain must bail with an error rather than abort the process.
-        let chain = vec!["facts.x"; 10_000].join(" and ");
-        let expr = parse(&chain).expect("a flat and-chain parses");
-        let (facts, vars) = env();
-        let err = expr
-            .evaluate(&WhenEnv {
-                facts: &facts,
-                vars: &vars,
-                iter: None,
-                env: None,
-            })
-            .unwrap_err();
-        assert!(matches!(err, WhenError::Eval(_)), "{err:?}");
+        // left-nested tree that a later recursive Drop / eval would overflow
+        // the stack on (H5 flat-chain gap — `parse_or`/`parse_and` are `while`
+        // loops that never re-enter the `parse_expr` depth guard). The parser
+        // now bounds the chain length, so it fails loudly at PARSE — before the
+        // overflowing tree is ever built (only a ≤64-deep partial AST is dropped).
+        let chain = vec!["facts.x == 1"; 10_000].join(" and ");
+        let err = parse(&chain).unwrap_err();
+        assert!(matches!(err, WhenError::Parse { .. }), "{err:?}");
+        // And an `or`-chain is bounded the same way.
+        let or_chain = vec!["facts.x == 1"; 10_000].join(" or ");
+        assert!(matches!(
+            parse(&or_chain).unwrap_err(),
+            WhenError::Parse { .. }
+        ));
     }
 
     // ─── env namespace ───────────────────────────────────────────

--- a/crates/alint-core/src/when/parser.rs
+++ b/crates/alint-core/src/when/parser.rs
@@ -68,17 +68,27 @@ impl Parser {
         }
     }
 
+    /// Deepen the tracked expression depth by one and fail loudly past
+    /// `MAX_DEPTH`. The chain loops (`parse_or`/`parse_and`) call this per
+    /// operator so a long *flat* chain is bounded too — they're iterative and
+    /// never re-enter `parse_expr`, where the paren/bracket re-entry guard
+    /// lives (H5 flat-chain gap).
+    fn bump_depth(&mut self) -> Result<(), WhenError> {
+        self.depth += 1;
+        if self.depth > MAX_DEPTH {
+            self.depth -= 1;
+            return Err(self.err("expression nests too deeply (max depth 64)"));
+        }
+        Ok(())
+    }
+
     pub(super) fn parse_expr(&mut self) -> Result<WhenExpr, WhenError> {
         // Bound recursion before descending: `parse_primary` re-enters
         // `parse_expr` for every `(`, `[` and call-arg list, so this is the
         // single re-entry point. Deep input fails loudly here instead of
         // overflowing the stack. Decrement on the way out so sibling
         // sub-expressions (list items, call args) don't accumulate depth.
-        self.depth += 1;
-        if self.depth > MAX_DEPTH {
-            self.depth -= 1;
-            return Err(self.err("expression nests too deeply (max depth 64)"));
-        }
+        self.bump_depth()?;
         let result = self.parse_or();
         self.depth -= 1;
         result
@@ -88,6 +98,12 @@ impl Parser {
         let mut left = self.parse_and()?;
         while matches!(self.peek(), Some(Tok::KwOr)) {
             self.advance();
+            // Each `or` deepens the left-nested AST by one. Bound the chain
+            // here (this loop is iterative, so it doesn't re-enter `parse_expr`
+            // where the depth guard lives): a long flat `a or a or …` chain
+            // would otherwise build a tree that abandons the stack on its
+            // recursive Drop / eval later (H5 flat-chain gap).
+            self.bump_depth()?;
             let right = self.parse_and()?;
             left = WhenExpr::Or(Box::new(left), Box::new(right));
         }
@@ -98,6 +114,8 @@ impl Parser {
         let mut left = self.parse_not()?;
         while matches!(self.peek(), Some(Tok::KwAnd)) {
             self.advance();
+            // See `parse_or`: bound the flat `a and a and …` chain (H5).
+            self.bump_depth()?;
             let right = self.parse_not()?;
             left = WhenExpr::And(Box::new(left), Box::new(right));
         }

--- a/crates/alint-rules/src/fixers/strip.rs
+++ b/crates/alint-rules/src/fixers/strip.rs
@@ -35,15 +35,21 @@ impl Fixer for FileStripBidiFixer {
     }
 }
 
-/// Strips zero-width characters (U+200B / U+200C / U+200D, plus
-/// body-internal U+FEFF — a leading BOM is preserved so
+/// Strips zero-width characters (U+200B / U+200C / U+200D / U+2060 /
+/// U+180E, plus body-internal U+FEFF — a leading BOM is preserved so
 /// `no_bom` can own that concern).
+///
+/// The flagged set is not hard-coded here: both fix paths defer to the
+/// detector's [`crate::no_zero_width_chars::is_flagged_zero_width`], so the
+/// fixer can never strip a narrower set than the rule flags — that skew
+/// made `--fix` non-convergent (U+2060 / U+180E were reported every run but
+/// never removed) until the two were unified.
 #[derive(Debug)]
 pub struct FileStripZeroWidthFixer;
 
 impl Fixer for FileStripZeroWidthFixer {
     fn describe(&self) -> String {
-        "strip zero-width characters (U+200B/C/D, body-internal U+FEFF)".to_string()
+        "strip zero-width characters (U+200B/C/D, U+2060, U+180E, body-internal U+FEFF)".to_string()
     }
 
     fn apply(&self, violation: &Violation, ctx: &FixContext<'_>) -> Result<FixOutcome> {
@@ -52,7 +58,10 @@ impl Fixer for FileStripZeroWidthFixer {
             "stripped zero-width chars from",
             violation,
             ctx,
-            |c| matches!(c, '\u{200B}' | '\u{200C}' | '\u{200D}' | '\u{FEFF}'),
+            // `is_leading_feff = false`: a leading BOM is already exempted by
+            // `preserve_leading_feff` in `filter_chars`, so the predicate only
+            // needs to flag body-internal U+FEFF.
+            |c| crate::no_zero_width_chars::is_flagged_zero_width(c, false),
             /* preserve_leading_feff = */ true,
         )
     }
@@ -61,7 +70,7 @@ impl Fixer for FileStripZeroWidthFixer {
         char_filter_edit(
             violation,
             bytes,
-            |c| matches!(c, '\u{200B}' | '\u{200C}' | '\u{200D}' | '\u{FEFF}'),
+            |c| crate::no_zero_width_chars::is_flagged_zero_width(c, false),
             true,
         )
     }
@@ -259,6 +268,49 @@ mod tests {
             panic!("expected SetContent");
         };
         assert_eq!(content, "\u{FEFF}ab".as_bytes());
+    }
+
+    #[test]
+    fn zero_width_fix_edit_strips_word_joiner_and_mongolian_vowel_sep() {
+        // Regression (L1): the detector flags U+2060 (WORD JOINER) and U+180E
+        // (MONGOLIAN VOWEL SEPARATOR), but the fixer used to hard-code only
+        // U+200B/C/D/FEFF, so a file containing 2060/180E was reported every
+        // run yet never repaired — `--fix` never converged.
+        let edit = FileStripZeroWidthFixer
+            .fix_edit(
+                &v(),
+                "a\u{2060}b\u{180E}c".as_bytes(),
+                std::path::Path::new("/r"),
+            )
+            .unwrap();
+        let FixEdit::SetContent { content, .. } = edit else {
+            panic!("expected SetContent");
+        };
+        assert_eq!(content, b"abc");
+    }
+
+    #[test]
+    fn zero_width_fix_converges_leaving_nothing_the_detector_flags() {
+        // The fix output must be a fixed point of the detector: run the fixer,
+        // then assert no surviving char is still flagged (a leading BOM aside).
+        // This is the invariant that keeps the fixer and rule from drifting.
+        let input = "\u{FEFF}x\u{200B}y\u{200C}z\u{200D}w\u{2060}v\u{180E}u\u{FEFF}t";
+        let edit = FileStripZeroWidthFixer
+            .fix_edit(&v(), input.as_bytes(), std::path::Path::new("/r"))
+            .unwrap();
+        let FixEdit::SetContent { content, .. } = edit else {
+            panic!("expected SetContent");
+        };
+        let out = std::str::from_utf8(&content).unwrap();
+        assert_eq!(out, "\u{FEFF}xyzwvut");
+        for (i, c) in out.chars().enumerate() {
+            let is_leading_feff = i == 0 && c == '\u{FEFF}';
+            assert!(
+                !crate::no_zero_width_chars::is_flagged_zero_width(c, is_leading_feff),
+                "fixer left a flagged char U+{:04X} at {i}",
+                c as u32
+            );
+        }
     }
 
     #[test]

--- a/crates/alint/src/main.rs
+++ b/crates/alint/src/main.rs
@@ -785,6 +785,18 @@ fn require_directory(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// The baseline file's path relative to the lint `root`, as a walk-exclude
+/// pattern — so a broad-glob content rule can't lint alint's own committed
+/// JSON-Lines baseline artifact as a spurious "new" violation. Returns `None`
+/// when the baseline lives outside the lint root (then it isn't walked anyway)
+/// or doesn't exist yet (the missing-baseline error surfaces at load time).
+fn baseline_walk_exclude(root: &Path, baseline: &Path) -> Option<String> {
+    let root_abs = root.canonicalize().ok()?;
+    let base_abs = baseline.canonicalize().ok()?;
+    let rel = base_abs.strip_prefix(&root_abs).ok()?;
+    Some(rel.to_string_lossy().replace('\\', "/"))
+}
+
 fn cmd_check(path: &Path, changed: &ChangedMode, only: &[String], cli: &Cli) -> Result<ExitCode> {
     require_directory(path)?;
     let loaded = load_rules(path, cli)?;
@@ -792,6 +804,9 @@ fn cmd_check(path: &Path, changed: &ChangedMode, only: &[String], cli: &Cli) -> 
     // The `--baseline` flag (used as given) overrides it; either one turns on
     // baseline suppression. No silent auto-detect of `.alint-baseline.json`.
     let config_baseline = loaded.baseline.as_ref().map(|b| path.join(b));
+    // Resolved early (was below the walk) so the baseline file can be excluded
+    // from the walk. The `--baseline` flag (used as given) overrides the key.
+    let effective_baseline = cli.baseline.clone().or(config_baseline);
     let entries = apply_only_filter(loaded.entries, only)?;
     let rule_count = entries.len();
     let mut engine = Engine::from_entries(entries, loaded.registry)
@@ -810,9 +825,20 @@ fn cmd_check(path: &Path, changed: &ChangedMode, only: &[String], cli: &Cli) -> 
     } else {
         loaded.respect_gitignore
     };
+    // Exclude alint's own baseline file from the walk. It's a committed
+    // JSON-Lines artifact, so a broad-glob content rule (`**/*.json`,
+    // `line_max_width`, `no_trailing_whitespace`, …) would otherwise flag it as
+    // a NEW violation the baseline can't contain — breaking the canonical
+    // adopt-flow (`check` → `baseline` → `check --baseline` never reaches 0).
+    let mut extra_ignores = loaded.extra_ignores;
+    if let Some(bp) = effective_baseline.as_deref()
+        && let Some(rel) = baseline_walk_exclude(path, bp)
+    {
+        extra_ignores.push(rel);
+    }
     let walk_opts = WalkOptions {
         respect_gitignore: effective_gitignore,
-        extra_ignores: loaded.extra_ignores,
+        extra_ignores,
     };
 
     let index = walk(path, &walk_opts).context("walking repository")?;
@@ -825,7 +851,6 @@ fn cmd_check(path: &Path, changed: &ChangedMode, only: &[String], cli: &Cli) -> 
     // Baseline suppression (when --baseline is in effect): grandfather
     // recorded violations, leaving only new ones to format + gate on.
     let mut strict_stale_fail = false;
-    let effective_baseline = cli.baseline.clone().or(config_baseline);
     let (report, baseline_marks) = if let Some(baseline_path) = &effective_baseline {
         let baseline = load_baseline(baseline_path)?;
         let mut reader = FileReader::new(path);

--- a/crates/alint/src/main.rs
+++ b/crates/alint/src/main.rs
@@ -1192,6 +1192,26 @@ fn cmd_fix(
     cli: &Cli,
 ) -> Result<ExitCode> {
     require_directory(path)?;
+    // Gate the output format *before* touching the tree: `fix` mutates files,
+    // so a format we can't render must fail here, not after the write. Only
+    // `human`, `json`, and `markdown` have dedicated fix-report renderers. The
+    // finding-oriented formats (SARIF / GitHub / JUnit / GitLab) and the
+    // check-side `agent` format would otherwise degrade *silently* to human
+    // output with exit 0 — a machine consumer asking for `sarif` and getting
+    // human text is the same trap M13 closed for `validate-config`. Fail loudly
+    // instead, and point `agent` at its real home: `check --format agent`
+    // (whose per-violation `fix_command` drives the agentic fix loop; `fix`
+    // itself has no agent report).
+    let format: Format = cli.format.parse().map_err(|e: String| anyhow::anyhow!(e))?;
+    if !matches!(format, Format::Human | Format::Json | Format::Markdown) {
+        bail!(
+            "`alint fix` supports only `--format human`, `--format json`, or \
+             `--format markdown` (got {fmt:?}); the SARIF/GitHub/JUnit/GitLab/agent \
+             formats describe findings, not fixes — run `alint check --format {fmt}` \
+             for those",
+            fmt = cli.format,
+        );
+    }
     let loaded = load_rules(path, cli)?;
     let entries = apply_only_filter(loaded.entries, only)?;
     let mut engine = Engine::from_entries(entries, loaded.registry)
@@ -1217,7 +1237,6 @@ fn cmd_fix(
         .fix(path, &index, dry_run)
         .context("applying fixes")?;
 
-    let format: Format = cli.format.parse().map_err(|e: String| anyhow::anyhow!(e))?;
     let (mut out, opts) = render_env(cli)?;
     format
         .write_fix_with_options(&report, &mut out, opts)

--- a/crates/alint/tests/baseline_cli.rs
+++ b/crates/alint/tests/baseline_cli.rs
@@ -542,3 +542,44 @@ fn changed_scoped_run_does_not_false_fail_strict_baseline() {
         "no stale warning should fire under --changed: {stderr}",
     );
 }
+
+#[test]
+fn baseline_file_is_excluded_from_the_walk() {
+    // Regression (E2E-found): alint's own committed `.alint-baseline.json` is
+    // JSON-Lines, so a broad-glob rule (`**/*.json`, or any `**` content rule)
+    // would lint it as a NEW violation the baseline can't contain — the
+    // canonical adopt-flow (check -> baseline -> check --baseline) then never
+    // reaches exit 0. The baseline file must be excluded from the walk.
+    let d = tempfile::tempdir().unwrap();
+    let root = d.path();
+    std::fs::write(root.join("package.json"), "{\"license\":\"BAD\"}\n").unwrap();
+    std::fs::write(
+        root.join(".alint.yml"),
+        "version: 1\n\
+         rules:\n\
+         \x20 - id: lic\n\
+         \x20   kind: json_path_equals\n\
+         \x20   paths: [\"**/*.json\"]\n\
+         \x20   path: \"$.license\"\n\
+         \x20   equals: \"MIT\"\n\
+         \x20   level: error\n",
+    )
+    .unwrap();
+    assert_eq!(code(&run(root, &["check"])), 1, "dirty before baseline");
+    assert_eq!(code(&run(root, &["baseline"])), 0, "snapshot it");
+    let out = run(root, &["check", "--baseline", ".alint-baseline.json"]);
+    assert_eq!(
+        code(&out),
+        0,
+        "adopt-flow must reach exit 0; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let compact = run(
+        root,
+        &["check", "--baseline", ".alint-baseline.json", "--compact"],
+    );
+    assert!(
+        !String::from_utf8_lossy(&compact.stdout).contains(".alint-baseline.json"),
+        "the baseline file must not be flagged"
+    );
+}

--- a/crates/alint/tests/cli_format_contract.rs
+++ b/crates/alint/tests/cli_format_contract.rs
@@ -16,7 +16,15 @@
 //!   structured `fix_command` argv *and* any `` `alint …` `` command
 //!   inside an `agent_instruction` — must parse against the real CLI.
 //!
-//! Both gates drive the actual binary (`CARGO_BIN_EXE_alint`) so they
+//! * **G1c — `fix` never silently degrades an output format.** `fix`
+//!   only renders `human` / `json` / `markdown`; the finding-oriented
+//!   formats (SARIF / GitHub / `JUnit` / GitLab) and the check-side
+//!   `agent` format used to fall through to human text with a *success*
+//!   exit code. Because `fix` mutates the tree, the invariant is
+//!   stricter than for read-only subcommands: an unrenderable format
+//!   must fail (exit 2) *before* any file is touched.
+//!
+//! All gates drive the actual binary (`CARGO_BIN_EXE_alint`) so they
 //! exercise the same clap surface and renderers users hit.
 
 use std::path::{Path, PathBuf};
@@ -208,4 +216,59 @@ fn agent_format_only_emits_runnable_commands() {
         checked_prose,
         "fixture produced no agent_instruction with an `alint …` command"
     );
+}
+
+// ─── G1c — `fix` rejects formats it can't render, before mutating ───
+
+/// The finding-oriented formats (SARIF / GitHub / `JUnit` / GitLab) and the
+/// check-side `agent` format have no fix-report renderer. `fix` used to
+/// degrade them *silently* to human output with a success exit code; it must
+/// now fail loudly (exit 2). And because `fix` mutates the tree, the reject
+/// must land *before* any fix is applied — hence a non-dry-run invocation
+/// here, asserting the fixable file is left byte-for-byte untouched.
+#[test]
+fn fix_rejects_unrenderable_formats_without_mutating() {
+    let dir = fixture();
+    let bad = dir.path().join("bad.md");
+    let original = std::fs::read(&bad).unwrap();
+
+    for fmt in ["sarif", "github", "junit", "gitlab", "agent"] {
+        let out = run(dir.path(), &["fix", "--format", fmt]);
+        assert_eq!(
+            out.status.code(),
+            Some(2),
+            "`alint fix --format {fmt}` must exit 2, not silently degrade to human"
+        );
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("supports only"),
+            "`alint fix --format {fmt}` should name the supported set; stderr: {stderr}"
+        );
+        assert_eq!(
+            std::fs::read(&bad).unwrap(),
+            original,
+            "`alint fix --format {fmt}` mutated the tree before rejecting the format"
+        );
+    }
+}
+
+/// Guard against over-rejection: the three formats `fix` *can* render must
+/// still pass the gate. `json` must additionally be real JSON on stdout.
+#[test]
+fn fix_accepts_its_renderable_formats() {
+    let dir = fixture();
+    for fmt in ["human", "json", "markdown"] {
+        let out = run(dir.path(), &["fix", "--dry-run", "--format", fmt]);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            !stderr.contains("supports only"),
+            "`alint fix --format {fmt}` was wrongly rejected; stderr: {stderr}"
+        );
+        if fmt == "json" {
+            assert!(
+                serde_json::from_slice::<serde_json::Value>(&out.stdout).is_ok(),
+                "`alint fix --dry-run --format json` stdout was not JSON"
+            );
+        }
+    }
 }

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -537,7 +537,7 @@ Flag Trojan-Source bidi override characters (U+202A–202E, U+2066–2069). Defe
 
 ### `no_zero_width_chars`
 
-Flag body-internal zero-width characters (U+200B, U+200C, U+200D, and non-leading U+FEFF). A leading U+FEFF is `no_bom`'s concern.
+Flag body-internal zero-width characters (U+200B, U+200C, U+200D, U+2060, U+180E, and non-leading U+FEFF). A leading U+FEFF is `no_bom`'s concern.
 
 ```yaml
 - id: no-zwsp


### PR DESCRIPTION
## What

Fixes the **five real bugs** surfaced by the post-v0.13 end-to-end sweep
(real filesystem + CLI + CI/tool integrations, across every output format) —
each invisible to the existing unit tests, each with a new regression test.

| # | Severity | Bug | Fix |
|---|----------|-----|-----|
| 1 | — | `check --baseline` could lint alint's own `.alint-baseline.json` as a *new* violation under a broad-glob content rule (`**/*.json`) | Exclude the baseline file from the walk |
| 3 | **HIGH (H5)** | A ~100k-operator *flat* `when:` chain (`a and a and …`) from an untrusted `extends:` ruleset overflowed the stack → uncatchable abort (exit 134) | Bound flat-chain length in the parse loops, same as nesting depth |
| 2 | — | The GitHub Action's `config:` advertised "path(s), one per line" and emitted one `--config` each — but H4 made a 2nd `--config` a hard error, breaking any multi-path workflow | `config:` is single-valued, points at `extends:`; action rejects >1 path with a clear `::error::` |
| 5 | — | `fix --format sarif` (+ github/junit/gitlab/agent) silently degraded to human output with exit 0 | Reject unrenderable formats (exit 2) **before** mutating the tree — same gate M13 gave `validate-config` |
| 4 | LOW (L1) | `file_strip_zero_width` stripped only U+200B/C/D/FEFF but the rule *flags* U+2060 + U+180E too → `--fix` never converged | Both fix paths defer to the rule's own `is_flagged_zero_width` |

## Why it matters

These are the class of bug a unit test can't catch because they live at the
seams — the CLI's walk vs. the baseline artifact it writes, the Action's shell
vs. the CLI's argument contract, a fixer vs. the detector it's supposed to
undo. H5 in particular is a determinism violation: a published ruleset could
abort a consumer's `alint` process.

## Tests added

- **Bug 1** — `baseline_cli::baseline_file_is_excluded_from_the_walk`: a repo
  with a broad `**/*.json` rule; `check` → 1, `baseline` → 0, `check --baseline`
  → 0, and the baseline file never appears in output.
- **Bug 3** — `when::long_flat_chain_is_a_parse_error_not_a_stack_overflow`:
  10k-operator `and`- and `or`-chains now yield a `Parse` error, not an abort.
- **Bug 2** — two `action-selftest` jobs: single-path happy path
  (`config: .alint.yml`) + multi-path rejection (asserts the step fails).
- **Bug 5** — `cli_format_contract` G1c: a non-dry-run rejection test proving
  the fixable file is left byte-for-byte untouched, plus an over-rejection
  guard for human/json/markdown.
- **Bug 4** — `strip::zero_width_fix_edit_strips_word_joiner_and_mongolian_vowel_sep`
  + a convergence test asserting the fix output is a fixed point of the detector.

## Notes

- `#110` (the audit M-cluster: M3/M4/M11/M13) is the base of this branch.
- Follow-up test-expansion opportunities identified by the sweep but **not**
  in scope here: a spawn-gate rejection suite, a weird-path × format output
  matrix, and dedicated M2/H1/M5 scenario tests.
