### PR TITLE
test(spawn-gate): RCE-canary + drift-guard suite for the process-execution trust gate

### DIFF
--- a/crates/alint-e2e/tests/coverage_audit_spawn_gate.rs
+++ b/crates/alint-e2e/tests/coverage_audit_spawn_gate.rs
@@ -1,0 +1,123 @@
+//! Spawn-gate drift audit — keep the RCE allow-list honest.
+//!
+//! alint refuses a process-spawning rule kind from any untrusted source
+//! (`extends:`, nested config, template, `require:` sub-rule). The set of
+//! spawning kinds is a hand-maintained allow-list,
+//! [`alint_dsl::SPAWNING_RULE_KINDS`]. The rejection logic is thoroughly
+//! tested elsewhere (`alint-dsl` unit tests; the CLI canary in
+//! `alint::tests::spawn_gate`) — but every one of those tests names the
+//! kinds it checks. None of them would catch the failure that actually
+//! shipped once (`gff`): a rule that *spawns a process* but was never added
+//! to the allow-list, so the gate waved it through and adopting a ruleset
+//! became arbitrary code execution.
+//!
+//! This audit is the missing cross-check. It scans the rule sources for the
+//! primitives that actually launch a subprocess and asserts that set of
+//! modules is *exactly* the allow-list — no more (an ungated spawner), no
+//! less (a stale allow-list entry). A new rule that shells out fails here
+//! until its kind is gated.
+
+use std::path::{Path, PathBuf};
+
+/// `crates/alint-rules/src`, resolved relative to this test crate so the
+/// audit is independent of the working directory.
+fn rules_src_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/ parent of alint-e2e")
+        .join("alint-rules/src")
+}
+
+/// Does this source line launch a subprocess? A rule spawns iff it either
+/// constructs a `Command` directly (`Command::new(` — also matches
+/// `StdCommand::new(`, `process::Command::new(`, `tokio::process::…`) or
+/// calls the shared spawn chokepoint (`crate::spawn::run_capturing`).
+/// Line comments are skipped so prose naming the primitive can't trip it.
+///
+/// Heuristic, deliberately: a spawn smuggled behind a bespoke alias
+/// (`use std::process::Command as Cmd; Cmd::new()`) would evade it. That is
+/// acceptable — the audit exists to catch the realistic regression (a new
+/// rule shelling out the ordinary way, à la `gff`), not an adversary editing
+/// alint's own source to hide a spawn from its own test suite.
+fn line_spawns(line: &str) -> bool {
+    let code = line.trim_start();
+    if code.starts_with("//") {
+        return false;
+    }
+    code.contains("Command::new(") || code.contains("crate::spawn::run_capturing")
+}
+
+/// Module file stems under `alint-rules/src` that reach a spawn primitive,
+/// excluding the shared `spawn.rs` helper itself (it *is* the chokepoint,
+/// not a rule kind). Sorted.
+fn spawning_module_stems() -> Vec<String> {
+    let mut stems = Vec::new();
+    for entry in std::fs::read_dir(rules_src_dir()).expect("read alint-rules/src") {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .expect("utf-8 file stem")
+            .to_string();
+        if stem == "spawn" {
+            continue; // the helper, not a rule
+        }
+        let text = std::fs::read_to_string(&path).expect("read rule source");
+        if text.lines().any(line_spawns) {
+            stems.push(stem);
+        }
+    }
+    stems.sort();
+    stems
+}
+
+#[test]
+fn spawning_allowlist_matches_the_rules_that_actually_spawn() {
+    let found = spawning_module_stems();
+
+    // The allow-list as module stems. Each spawning kind lives in a module
+    // named for the kind (`command` → command.rs, etc.); the audit relies on
+    // that convention and calls it out if it ever breaks.
+    let mut expected: Vec<String> = alint_dsl::SPAWNING_RULE_KINDS
+        .iter()
+        .map(|k| (*k).to_string())
+        .collect();
+    expected.sort();
+
+    assert_eq!(
+        found, expected,
+        "\n\nSPAWN-GATE DRIFT — the rule modules that launch a subprocess do not \
+         match alint_dsl::SPAWNING_RULE_KINDS.\n\
+         \n  modules that actually spawn : {found:?}\
+         \n  SPAWNING_RULE_KINDS (as .rs) : {expected:?}\n\
+         \nIf you added a rule that shells out, add its kind to SPAWNING_RULE_KINDS \
+         (crates/alint-dsl/src/lib.rs) — without it, an `extends:`'d or nested \
+         ruleset can run the rule as arbitrary code (the `gff` regression class). \
+         If you removed a spawner, drop its stale allow-list entry. If a spawning \
+         module is not named `<kind>.rs`, teach this audit the mapping."
+    );
+}
+
+#[test]
+fn spawning_allowlist_is_non_empty_and_each_entry_has_a_module() {
+    // Cheap companion: a typo'd or emptied allow-list is itself a security
+    // regression (it would silently stop gating). Pin that every entry names
+    // a real rule module.
+    assert!(
+        !alint_dsl::SPAWNING_RULE_KINDS.is_empty(),
+        "SPAWNING_RULE_KINDS is empty — the process-spawn trust gate would gate nothing"
+    );
+    let src = rules_src_dir();
+    for kind in alint_dsl::SPAWNING_RULE_KINDS {
+        let module = src.join(format!("{kind}.rs"));
+        assert!(
+            module.exists(),
+            "SPAWNING_RULE_KINDS names {kind:?} but {} does not exist — stale or \
+             mistyped allow-list entry",
+            module.display()
+        );
+    }
+}

--- a/crates/alint/tests/spawn_gate.rs
+++ b/crates/alint/tests/spawn_gate.rs
@@ -1,0 +1,235 @@
+//! Spawn-gate RCE canary — end-to-end, through the real `alint` binary.
+//!
+//! alint's process-execution trust boundary: a rule kind that shells out
+//! (`command`, `command_idempotent`, `generated_file_fresh` — the
+//! `alint_dsl::SPAWNING_RULE_KINDS` allow-list) may be declared **only** in
+//! the user's own top-level config. Introducing one through any *untrusted*
+//! channel — an `extends:`'d ruleset, a `templates:` block, a `require:`
+//! sub-rule, or a nested `.alint.yml` — must be refused, because anyone who
+//! can land such a config (open a PR, publish a ruleset) would otherwise gain
+//! arbitrary code execution on every `alint check`.
+//!
+//! The DSL-level gate logic is unit-tested in `alint-dsl` (it asserts
+//! `load()` returns an `Err`). What those tests can't prove is the property
+//! that actually matters: driving the **real binary**, the smuggled command
+//! *never runs*. So every case here arms a canary — the smuggled command is
+//! `touch <sentinel>` — and asserts the sentinel file does not exist after the
+//! run. A `positive_control` test first proves the canary mechanism is real:
+//! the identical command, declared in the *trusted* top-level config, DOES
+//! create its sentinel. Without that control, "sentinel absent" could pass
+//! vacuously (e.g. a malformed command that never touches anything).
+//!
+//! `#![cfg(unix)]` — the canary uses `/bin/sh` + `touch`.
+
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::Output;
+
+fn alint_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_alint"))
+}
+
+fn run(dir: &Path, args: &[&str]) -> Output {
+    std::process::Command::new(alint_bin())
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("spawn alint")
+}
+
+/// The rule fields (minus `id:`) for a spawning `kind` whose `command`
+/// touches `sentinel`. Each kind gets exactly the fields it needs so a
+/// rejection can never be mistaken for a schema error. A new spawning kind
+/// added to the allow-list forces a body here — the `panic!` keeps this
+/// matrix from silently skipping it.
+fn spawn_rule_fields(kind: &str, sentinel: &Path) -> Vec<String> {
+    let mut lines = vec![format!("kind: {kind}")];
+    match kind {
+        "command" => lines.push("paths: \"**/*\"".to_string()),
+        "generated_file_fresh" => lines.push("file: out.txt".to_string()),
+        "command_idempotent" => {}
+        other => panic!(
+            "unhandled spawning kind {other:?}; add its minimal fields to spawn_rule_fields \
+             so the spawn-gate canary matrix covers it"
+        ),
+    }
+    // Flow-sequence (JSON-in-YAML) keeps quoting simple. tempfile paths are
+    // random alphanumerics under /tmp — no shell-unsafe characters.
+    lines.push(format!(
+        "command: [\"sh\", \"-c\", \"touch {}\"]",
+        sentinel.display()
+    ));
+    lines.push("level: error".to_string());
+    lines
+}
+
+/// Indent every line by `n` spaces (blank lines left empty).
+fn indent(lines: &[String], n: usize) -> String {
+    let pad = " ".repeat(n);
+    lines
+        .iter()
+        .map(|l| format!("{pad}{l}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Assert `alint check` refused to load (exit 2, "arbitrary code" in the
+/// diagnostic) and — the security property — the canary never fired.
+fn assert_refused_no_rce(vector: &str, kind: &str, dir: &Path, sentinel: &Path) {
+    let out = run(dir, &["check", "."]);
+    let code = out.status.code();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        code,
+        Some(2),
+        "[{vector}/{kind}] expected exit 2 (config refused), got {code:?}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("arbitrary code"),
+        "[{vector}/{kind}] rejection should explain the RCE risk; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains(kind),
+        "[{vector}/{kind}] rejection should name the offending kind; stderr: {stderr}"
+    );
+    assert!(
+        !sentinel.exists(),
+        "[{vector}/{kind}] RCE: the smuggled `touch` ran — the gate did not block execution"
+    );
+}
+
+/// A throwaway repo with one data file (so a `paths: **/*` rule would have
+/// something to run on) and an out-of-band sentinel path that starts absent.
+fn scaffold() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::Builder::new()
+        .prefix("alint-spawngate-")
+        .tempdir()
+        .expect("tempdir");
+    std::fs::write(dir.path().join("data.txt"), "hi\n").unwrap();
+    let sentinel = dir.path().join("SENTINEL");
+    (dir, sentinel)
+}
+
+/// The spawning kinds, read from the crate under test so this matrix tracks
+/// the allow-list automatically.
+fn spawning_kinds() -> &'static [&'static str] {
+    alint_dsl::SPAWNING_RULE_KINDS
+}
+
+// ─── Positive control — the canary mechanism is real ────────────────────
+
+#[test]
+fn positive_control_trusted_top_level_command_executes() {
+    // The SAME `touch <sentinel>` command, declared in the user's own
+    // top-level config (the one allowed place), must actually run — proving
+    // the sentinel assertions below aren't vacuous and that we don't
+    // over-reject the legitimate case.
+    let (dir, sentinel) = scaffold();
+    let body = format!(
+        "version: 1\nrules:\n  - id: canary\n{}\n",
+        indent(&spawn_rule_fields("command", &sentinel), 4)
+    );
+    std::fs::write(dir.path().join(".alint.yml"), body).unwrap();
+
+    let out = run(dir.path(), &["check", "."]);
+    assert!(
+        sentinel.exists(),
+        "positive control failed: a trusted top-level command rule did not run \
+         (canary mechanism is broken, making the rejection tests vacuous). \
+         exit={:?} stderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ─── Untrusted vectors — every spawning kind must be refused ────────────
+
+#[test]
+fn spawning_kind_via_extends_rules_is_refused() {
+    // Primary vector: a spawning `kind:` sitting directly in an `extends:`'d
+    // ruleset's `rules:`. Covered for every allow-listed kind.
+    for &kind in spawning_kinds() {
+        let (dir, sentinel) = scaffold();
+        let base = format!(
+            "version: 1\nrules:\n  - id: smuggled\n{}\n",
+            indent(&spawn_rule_fields(kind, &sentinel), 4)
+        );
+        std::fs::write(dir.path().join("base.yml"), base).unwrap();
+        std::fs::write(
+            dir.path().join(".alint.yml"),
+            "version: 1\nextends: [./base.yml]\nrules: []\n",
+        )
+        .unwrap();
+        assert_refused_no_rce("extends-rules", kind, dir.path(), &sentinel);
+    }
+}
+
+#[test]
+fn spawning_kind_via_extends_template_is_refused() {
+    // C1 bypass: a spawning kind hidden in an inherited `templates:` block,
+    // pulled in by a `kind`-less `extends_template:` that expands *after* the
+    // top-level `rules[].kind` gate.
+    for &kind in spawning_kinds() {
+        let (dir, sentinel) = scaffold();
+        let base = format!(
+            "version: 1\ntemplates:\n  - id: t\n{}\nrules:\n  - id: smuggled\n    extends_template: t\n",
+            indent(&spawn_rule_fields(kind, &sentinel), 4)
+        );
+        std::fs::write(dir.path().join("base.yml"), base).unwrap();
+        std::fs::write(
+            dir.path().join(".alint.yml"),
+            "version: 1\nextends: [./base.yml]\nrules: []\n",
+        )
+        .unwrap();
+        assert_refused_no_rce("extends-template", kind, dir.path(), &sentinel);
+    }
+}
+
+#[test]
+fn spawning_kind_via_extends_require_block_is_refused() {
+    // Third vector: buried in a `require:` sub-rule of a `for_each_dir`, whose
+    // nested `kind` flattens into the parent's options — the top-level `kind`
+    // check would miss it, so the gate must recurse.
+    for &kind in spawning_kinds() {
+        let (dir, sentinel) = scaffold();
+        // Fields align at 8 spaces; turn the first (`kind:`) into the `- `
+        // list item by swapping its leading indent for `      - ` (same width),
+        // leaving the rest at 8 so they stay inside the one require entry.
+        let fields = indent(&spawn_rule_fields(kind, &sentinel), 8);
+        let fields = fields.replacen("        kind:", "      - kind:", 1);
+        let base = format!(
+            "version: 1\nrules:\n  - id: outer\n    kind: for_each_dir\n    select: \"**/\"\n    require:\n{fields}\n    level: error\n",
+        );
+        std::fs::write(dir.path().join("base.yml"), base).unwrap();
+        std::fs::write(
+            dir.path().join(".alint.yml"),
+            "version: 1\nextends: [./base.yml]\nrules: []\n",
+        )
+        .unwrap();
+        assert_refused_no_rce("extends-require", kind, dir.path(), &sentinel);
+    }
+}
+
+#[test]
+fn spawning_kind_via_nested_config_is_refused() {
+    // C2 bypass: a nested `.alint.yml` is as untrusted as an `extends:`'d
+    // ruleset (anyone opening a monorepo PR can add one), so it may not
+    // declare a spawning kind either.
+    for &kind in spawning_kinds() {
+        let (dir, sentinel) = scaffold();
+        std::fs::write(
+            dir.path().join(".alint.yml"),
+            "version: 1\nnested_configs: true\nrules: []\n",
+        )
+        .unwrap();
+        let pkg = dir.path().join("packages/foo");
+        std::fs::create_dir_all(&pkg).unwrap();
+        let nested = format!(
+            "version: 1\nrules:\n  - id: smuggled\n{}\n",
+            indent(&spawn_rule_fields(kind, &sentinel), 4)
+        );
+        std::fs::write(pkg.join(".alint.yml"), nested).unwrap();
+        assert_refused_no_rce("nested-config", kind, dir.path(), &sentinel);
+    }
+}


### PR DESCRIPTION
## What

A dedicated **spawn-gate rejection suite** — the first of the follow-up
test-expansion opportunities flagged by the post-v0.13 e2e sweep (#111).

alint's process-execution trust boundary: a rule kind that shells out
(`command`, `command_idempotent`, `generated_file_fresh` — the
`alint_dsl::SPAWNING_RULE_KINDS` allow-list) may be declared **only** in the
user's own top-level config. Introducing one through any untrusted channel —
an `extends:`'d ruleset, a `templates:` block, a `require:` sub-rule, or a
nested `.alint.yml` — must be refused, or adopting a published ruleset / merging
a monorepo PR becomes arbitrary code execution.

The gate logic was already well tested at the DSL `load()` level. Two gaps
remained — **both of the kind that let `gff` ship a spawning rule ungated with
no test catching it**:

1. Every existing test asserts `load()` returns `Err(<string>)`. None drives
   the real binary to prove the smuggled command **never executes**.
2. Every existing test *names* the kinds it checks, so a **new** spawning rule
   that forgot the allow-list would pass all of them.

## Added

**`crates/alint/tests/spawn_gate.rs` — CLI RCE canary** (drives `CARGO_BIN_EXE_alint`)
- **Positive control**: a *trusted* top-level `command` rule with `touch <sentinel>`
  actually creates its sentinel — proving the canary is real and the rejection
  assertions can't pass vacuously.
- **Rejection matrix**: every `SPAWNING_RULE_KINDS` kind × every untrusted vector
  (extends `rules:`, extends `templates:`, extends `require:`, nested config)
  arms the smuggle as `touch <sentinel>` and asserts **exit 2 + "arbitrary code"
  diagnostic + sentinel absent** — 12 combinations proving the command never runs.

**`crates/alint-e2e/tests/coverage_audit_spawn_gate.rs` — drift guard** (the gff catcher)
- Scans the rule sources for the actual spawn primitives (`Command::new(` / the
  shared `crate::spawn::run_capturing` chokepoint) and asserts that set of modules
  is **exactly** `SPAWNING_RULE_KINDS` — no ungated spawner, no stale entry.
- Companion check: the allow-list is non-empty and each entry names a real module.

## Why it's non-vacuous

- The canary's **positive control** proves a trusted command *does* create its
  sentinel, so "sentinel absent" is a real signal.
- The drift guard was **mutation-verified**: dropping an orphan module containing
  `Command::new(` into the rules source makes it fail with a clear mismatch
  (`modules that actually spawn: [__mutation_probe…, command, …]`), green again on
  removal. This is the test that would have caught `gff`.

Both suites read `alint_dsl::SPAWNING_RULE_KINDS`, so they track the allow-list
automatically: a new spawning kind forces a minimal body in the canary matrix
(`panic!` on an unhandled kind) and a matching module for the drift guard.

## Scope

Test-only — no production code changed. Local preflight (fmt/clippy/test/doc/
version-pins/dep-floors/dogfood) all green.
