### PR TITLE
fix(output): non-UTF-8 paths no longer break json/agent + weird-path × format matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   still renders `human` / `json` / `markdown`; the error points `agent` users at
   `check --format agent`, whose per-violation `fix_command` drives the agentic
   fix loop. (E2E sweep)
+- **`json` / `agent` output survives a non-UTF-8 filename.** Both serialized the
+  violation path through serde's strict `&Path` impl, which *errors* on a
+  non-UTF-8 path (legal on Unix) — so a single oddly-named file made `alint
+  check --format json` (or `--format agent`) abort with `exit 2: "path contains
+  invalid UTF-8 characters"` while every other format rendered it fine. Both now
+  render the path lossily (invalid bytes → U+FFFD), consistent with SARIF /
+  GitLab / JUnit / GitHub / Markdown / human. Surfaced by a new weird-path ×
+  output-format matrix that renders a violation path carrying each format's
+  metacharacters, a control byte, and a non-UTF-8 byte through all eight
+  formats. (E2E sweep)
 - **Exit code `3` (internal error) is now actually produced.** The README
   documented `3` for an internal alint error vs `2` for a config/usage error,
   but every error funnelled to `2`, so a script could never tell "fix your

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,11 +125,13 @@ version = "0.13.0"
 dependencies = [
  "alint-core",
  "alint-dsl",
+ "alint-output",
  "alint-rules",
  "alint-testkit",
  "dir-test",
  "jsonschema",
  "proptest",
+ "roxmltree",
  "serde",
  "serde_json",
  "serde_yaml_ng",

--- a/crates/alint-e2e/Cargo.toml
+++ b/crates/alint-e2e/Cargo.toml
@@ -14,11 +14,13 @@ publish = false
 [dev-dependencies]
 alint-core.workspace = true
 alint-dsl.workspace = true
+alint-output.workspace = true
 alint-rules.workspace = true
 alint-testkit.workspace = true
 dir-test.workspace = true
 jsonschema.workspace = true
 proptest.workspace = true
+roxmltree.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_yaml_ng.workspace = true

--- a/crates/alint-e2e/tests/output_weird_paths.rs
+++ b/crates/alint-e2e/tests/output_weird_paths.rs
@@ -1,0 +1,158 @@
+//! Weird-path × output-format matrix.
+//!
+//! A repo file path is attacker-influenced text — anyone who can add a file
+//! names it — and it flows verbatim into every renderer. Each of the eight
+//! output formats has its own quoting rules: JSON string escapes, SARIF
+//! percent-encoded URIs, XML attribute entities (`JUnit`), GitHub
+//! `::`-annotation escapes, Markdown inline code. A path carrying that format's
+//! metacharacters, a control byte, or (on Unix) a non-UTF-8 byte must never
+//! corrupt the output or, worse, abort it.
+//!
+//! The matrix renders a one-violation report anchored on each weird path
+//! through all eight formats and asserts:
+//!   * the render **succeeds and is non-empty** — the regression guard for the
+//!     `json` / `agent` formats, which used to *error* (`exit 2:
+//!     "path contains invalid UTF-8 characters"`) on a non-UTF-8 path because
+//!     they serialized `&Path` through serde's strict impl; and
+//!   * the structured formats stay **well-formed** — every JSON-family output
+//!     parses as JSON, the `JUnit` output parses as XML.
+//!
+//! Renderers are driven through the public [`alint_output::Format`] API on
+//! synthetic reports, so the awkward cases (control bytes, non-UTF-8) are
+//! exercised deterministically without depending on the filesystem. The
+//! end-to-end path (real files → real binary) is covered by
+//! `alint::tests::weird_path_formats_cli`.
+
+use alint_core::{Level, Report, RuleResult, Violation};
+use alint_output::Format;
+use std::path::PathBuf;
+
+const FORMATS: &[(&str, Format)] = &[
+    ("human", Format::Human),
+    ("json", Format::Json),
+    ("sarif", Format::Sarif),
+    ("github", Format::Github),
+    ("markdown", Format::Markdown),
+    ("junit", Format::Junit),
+    ("gitlab", Format::Gitlab),
+    ("agent", Format::Agent),
+];
+
+/// A one-violation error report anchored on `path`.
+fn report_for(path: PathBuf) -> Report {
+    let v = Violation::new("weird path finding")
+        .with_path(path)
+        .with_location(1, 1);
+    let rr = RuleResult::new("weird-path".into(), Level::Error, None, vec![v], false);
+    Report { results: vec![rr] }
+}
+
+/// Render `report` as `fmt`. The `expect` is itself an assertion: a renderer
+/// that returns `Err` on any path is the bug this file guards against.
+fn render(fmt: Format, report: &Report) -> Vec<u8> {
+    let mut buf = Vec::new();
+    fmt.write(report, &mut buf)
+        .expect("a renderer must never error on a weird path");
+    buf
+}
+
+/// Portable weird paths (all valid UTF-8), each exercising some format's
+/// metacharacters or a control byte.
+fn utf8_cases() -> Vec<(&'static str, PathBuf)> {
+    vec![
+        ("space", PathBuf::from("dir with space/my file.txt")),
+        ("latin", PathBuf::from("café/résumé.md")),
+        ("cjk", PathBuf::from("文書/日本語.md")),
+        ("emoji", PathBuf::from("📁/🚀.txt")),
+        ("dquote", PathBuf::from(r#"he said "hi".txt"#)),
+        ("backslash", PathBuf::from(r"a\b\c.txt")),
+        ("angle_amp", PathBuf::from("a<b>&c.txt")),
+        ("pipe_tick", PathBuf::from("a|b`c.txt")),
+        ("punct", PathBuf::from("a,b:c%d#e.txt")),
+        // ESC + CSI clear-screen: a terminal-injection attempt via a filename.
+        ("ctrl_esc", PathBuf::from("a\u{1b}[2Jb.txt")),
+        ("newline", PathBuf::from("a\nb.txt")),
+    ]
+}
+
+fn assert_valid_json(label: &str, fmt: &str, bytes: &[u8]) {
+    if let Err(e) = serde_json::from_slice::<serde_json::Value>(bytes) {
+        panic!(
+            "[{fmt}/{label}] output is not valid JSON: {e}\n---\n{}\n---",
+            String::from_utf8_lossy(bytes)
+        );
+    }
+}
+
+fn assert_valid_xml(label: &str, fmt: &str, bytes: &[u8]) {
+    let text = std::str::from_utf8(bytes)
+        .unwrap_or_else(|e| panic!("[{fmt}/{label}] XML output is not UTF-8: {e}"));
+    if let Err(e) = roxmltree::Document::parse(text) {
+        panic!("[{fmt}/{label}] output is not well-formed XML: {e}\n---\n{text}\n---");
+    }
+}
+
+/// Structural validation appropriate to each format.
+fn assert_wellformed(label: &str, fmt_name: &str, fmt: Format, bytes: &[u8]) {
+    assert!(!bytes.is_empty(), "[{fmt_name}/{label}] empty output");
+    match fmt {
+        Format::Json | Format::Sarif | Format::Gitlab | Format::Agent => {
+            assert_valid_json(label, fmt_name, bytes);
+        }
+        Format::Junit => assert_valid_xml(label, fmt_name, bytes),
+        Format::Human | Format::Github | Format::Markdown => {
+            // Text formats: must stay valid UTF-8 with no raw NUL — a control
+            // byte from the path can't smuggle a bare NUL into the stream.
+            let text = std::str::from_utf8(bytes)
+                .unwrap_or_else(|e| panic!("[{fmt_name}/{label}] output is not UTF-8: {e}"));
+            assert!(
+                !text.contains('\u{0}'),
+                "[{fmt_name}/{label}] output contains a raw NUL byte"
+            );
+        }
+    }
+}
+
+#[test]
+fn every_format_handles_utf8_weird_paths() {
+    for (label, path) in utf8_cases() {
+        let report = report_for(path);
+        for (fmt_name, fmt) in FORMATS {
+            let bytes = render(*fmt, &report);
+            assert_wellformed(label, fmt_name, *fmt, &bytes);
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn every_format_handles_a_non_utf8_path() {
+    use std::os::unix::ffi::OsStringExt;
+    // A path with an invalid UTF-8 byte (0xFF) — legal on Unix. `json` / `agent`
+    // used to abort the whole document here (serde's strict `&Path`); every
+    // format must now render it lossily (invalid bytes → U+FFFD), exactly as
+    // SARIF / GitLab / JUnit / GitHub always have.
+    let path = PathBuf::from(std::ffi::OsString::from_vec(b"bad\xffname.txt".to_vec()));
+    let report = report_for(path);
+    for (fmt_name, fmt) in FORMATS {
+        let bytes = render(*fmt, &report);
+        assert_wellformed("non_utf8", fmt_name, *fmt, &bytes);
+    }
+}
+
+#[test]
+fn json_family_round_trips_a_utf8_weird_path() {
+    // For a valid-UTF-8 path the lossy conversion is a no-op, so the JSON
+    // string must decode back to the exact path — metacharacters and all.
+    let path = "café/a b\"c`.txt";
+    let report = report_for(PathBuf::from(path));
+
+    let j: serde_json::Value = serde_json::from_slice(&render(Format::Json, &report)).unwrap();
+    assert_eq!(j["results"][0]["violations"][0]["path"], path);
+
+    let g: serde_json::Value = serde_json::from_slice(&render(Format::Gitlab, &report)).unwrap();
+    assert_eq!(g[0]["location"]["path"], path);
+
+    let a: serde_json::Value = serde_json::from_slice(&render(Format::Agent, &report)).unwrap();
+    assert_eq!(a["violations"][0]["file"], path);
+}

--- a/crates/alint-output/src/agent.rs
+++ b/crates/alint-output/src/agent.rs
@@ -23,6 +23,7 @@
 //! are non-breaking; field removals or semantic changes bump the
 //! version.
 
+use std::borrow::Cow;
 use std::io::Write;
 use std::path::Path;
 
@@ -57,8 +58,12 @@ struct BySeverity {
 struct AgentViolation<'a> {
     rule_id: &'a str,
     severity: &'static str,
+    // Lossy UTF-8: a non-UTF-8 repo path (legal on Unix) must not error the
+    // whole document the way serde's `&Path` serializer does. Matches the
+    // human `agent_instruction` (built from `path.display()`) and every other
+    // renderer. Invalid bytes → U+FFFD.
     #[serde(skip_serializing_if = "Option::is_none")]
-    file: Option<&'a Path>,
+    file: Option<Cow<'a, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     line: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -111,7 +116,7 @@ pub fn write_agent(report: &Report, w: &mut dyn Write) -> std::io::Result<()> {
             violations.push(AgentViolation {
                 rule_id: r.rule_id.as_ref(),
                 severity: severity_str(r.level),
-                file: v.path.as_deref(),
+                file: v.path.as_deref().map(Path::to_string_lossy),
                 line: v.line,
                 column: v.column,
                 human_message: v.message.as_ref(),

--- a/crates/alint-output/src/json.rs
+++ b/crates/alint-output/src/json.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::io::Write;
 use std::path::Path;
 
@@ -5,6 +6,15 @@ use alint_core::{FixReport, FixStatus, Level, Report};
 use serde::Serialize;
 
 use crate::BaselineMarks;
+
+/// Render a violation path as a (possibly lossy) UTF-8 string. A repo file
+/// whose name isn't valid UTF-8 — legal on Unix — must not fail the whole
+/// document: serde's `&Path` serializer *errors* on non-UTF-8, so route
+/// through `to_string_lossy` (invalid bytes → U+FFFD) instead, matching
+/// every other renderer (SARIF, GitLab, `JUnit`, GitHub, human).
+fn lossy_path(path: Option<&Path>) -> Option<Cow<'_, str>> {
+    path.map(Path::to_string_lossy)
+}
 
 #[derive(Serialize)]
 struct JsonReport<'a> {
@@ -36,7 +46,7 @@ struct Summary {
 struct JsonBaselined<'a> {
     id: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
-    path: Option<&'a Path>,
+    path: Option<Cow<'a, str>>,
     message: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     line: Option<usize>,
@@ -67,7 +77,7 @@ struct JsonResult<'a> {
 #[derive(Serialize)]
 struct JsonViolation<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    path: Option<&'a Path>,
+    path: Option<Cow<'a, str>>,
     message: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     line: Option<usize>,
@@ -109,7 +119,7 @@ pub fn write_json_with_baseline(
                 .violations
                 .iter()
                 .map(|v| JsonViolation {
-                    path: v.path.as_deref(),
+                    path: lossy_path(v.path.as_deref()),
                     message: v.message.as_ref(),
                     line: v.line,
                     column: v.column,
@@ -119,7 +129,7 @@ pub fn write_json_with_baseline(
                 .notes
                 .iter()
                 .map(|v| JsonViolation {
-                    path: v.path.as_deref(),
+                    path: lossy_path(v.path.as_deref()),
                     message: v.message.as_ref(),
                     line: v.line,
                     column: v.column,
@@ -136,7 +146,7 @@ pub fn write_json_with_baseline(
                 .flat_map(|(rr, m)| {
                     m.suppressed.iter().map(move |sf| JsonBaselined {
                         id: rr.rule_id.as_ref(),
-                        path: sf.violation.path.as_deref(),
+                        path: lossy_path(sf.violation.path.as_deref()),
                         message: sf.violation.message.as_ref(),
                         line: sf.violation.line,
                         column: sf.violation.column,
@@ -183,7 +193,7 @@ struct JsonFixRuleResult<'a> {
 #[derive(Serialize)]
 struct JsonFixItem<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    path: Option<&'a Path>,
+    path: Option<Cow<'a, str>>,
     message: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     line: Option<usize>,
@@ -211,7 +221,7 @@ pub fn write_fix_json(report: &FixReport, w: &mut dyn Write) -> std::io::Result<
                         FixStatus::Unfixable => ("unfixable", None),
                     };
                     JsonFixItem {
-                        path: it.violation.path.as_deref(),
+                        path: lossy_path(it.violation.path.as_deref()),
                         message: it.violation.message.as_ref(),
                         line: it.violation.line,
                         column: it.violation.column,

--- a/crates/alint/tests/weird_path_formats_cli.rs
+++ b/crates/alint/tests/weird_path_formats_cli.rs
@@ -1,0 +1,157 @@
+//! Weird filenames × output formats — end-to-end through the real binary.
+//!
+//! The library-level renderer matrix lives in
+//! `alint-e2e::tests::output_weird_paths`; this file proves the same property
+//! survives the *whole* pipeline (walker → engine → CLI renderer) with real
+//! files on disk. Its headline case is the regression that motivated the fix:
+//! a repo containing a single non-UTF-8 filename used to make
+//! `alint check --format json` (and `--format agent`) abort with
+//! `exit 2: "path contains invalid UTF-8 characters"` while every other format
+//! worked — one oddly-named file rendered the JSON output unusable.
+//!
+//! `#![cfg(unix)]` — non-UTF-8 filenames are a Unix concern, and several of the
+//! UTF-8 cases (`"`, `\`, `<`) aren't even legal on Windows.
+
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::Output;
+
+fn alint_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_alint"))
+}
+
+fn run(dir: &Path, args: &[&str]) -> Output {
+    std::process::Command::new(alint_bin())
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("spawn alint")
+}
+
+/// A repo whose one rule fires on every `*.txt` containing `FIXME`, so each
+/// weird-named file yields exactly one path-bearing violation.
+fn repo() -> tempfile::TempDir {
+    let dir = tempfile::Builder::new()
+        .prefix("alint-weirdpath-")
+        .tempdir()
+        .unwrap();
+    std::fs::write(
+        dir.path().join(".alint.yml"),
+        "version: 1\nrules:\n  - id: no-fixme\n    kind: file_content_forbidden\n    \
+         paths: \"**/*.txt\"\n    pattern: \"FIXME\"\n    level: error\n",
+    )
+    .unwrap();
+    dir
+}
+
+/// JSON-family formats whose stdout must parse as JSON.
+const JSON_FORMATS: &[&str] = &["json", "sarif", "gitlab", "agent"];
+/// Formats that emit non-JSON but must still not crash.
+const TEXT_FORMATS: &[&str] = &["human", "github", "markdown", "junit"];
+
+#[test]
+fn weird_utf8_filenames_render_across_all_formats() {
+    let dir = repo();
+    // Realistic weird-but-legal (on Unix) filenames, each a format's headache.
+    for name in [
+        "my file.txt",      // space
+        "café.txt",         // non-ASCII UTF-8
+        "文書.txt",         // CJK
+        "🚀.txt",           // emoji (multi-byte)
+        "quote\".txt",      // double quote (JSON string / XML attr)
+        "back\\slash.txt",  // backslash (JSON escape)
+        "angle<>&.txt",     // XML/HTML metacharacters
+        "pipe|tick`.txt",   // markdown table / inline code
+        "comma,colon:.txt", // github annotation separators
+        "pct%hash#.txt",    // URI-reserved
+    ] {
+        std::fs::write(dir.path().join(name), "FIXME\n").unwrap();
+    }
+
+    for fmt in JSON_FORMATS.iter().chain(TEXT_FORMATS) {
+        let out = run(dir.path(), &["check", ".", "--format", fmt]);
+        // Violations exist → exit 1. The failure we guard against is exit 2
+        // (renderer aborted) — never acceptable here.
+        assert_ne!(
+            out.status.code(),
+            Some(2),
+            "[{fmt}] aborted (exit 2) on weird UTF-8 filenames; stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            !out.stdout.is_empty(),
+            "[{fmt}] produced no output for weird filenames"
+        );
+        if JSON_FORMATS.contains(fmt) {
+            serde_json::from_slice::<serde_json::Value>(&out.stdout).unwrap_or_else(|e| {
+                panic!(
+                    "[{fmt}] stdout is not valid JSON: {e}\n{}",
+                    String::from_utf8_lossy(&out.stdout)
+                )
+            });
+        }
+    }
+}
+
+// Linux-only: staging this end-to-end needs a filesystem that stores a
+// filename with an invalid UTF-8 byte. Linux (ext4/tmpfs/…) does; macOS's
+// APFS/HFS+ reject non-UTF-8 names outright, so the `fs::write` would fail
+// there before the renderer is ever exercised. The renderer-level guarantee
+// for a non-UTF-8 path is proven filesystem-free (an in-memory `OsString`)
+// by `alint-e2e::output_weird_paths::every_format_handles_a_non_utf8_path`,
+// which runs on every Unix.
+#[cfg(target_os = "linux")]
+#[test]
+fn non_utf8_filename_does_not_break_json_or_agent() {
+    use std::os::unix::ffi::OsStrExt;
+    let dir = repo();
+    // A filename with an invalid UTF-8 byte (0xFF). Legal on Linux filesystems.
+    let mut name = std::ffi::OsString::from("bad");
+    name.push(std::ffi::OsStr::from_bytes(b"\xff"));
+    name.push("name.txt");
+    std::fs::write(dir.path().join(&name), "FIXME\n").unwrap();
+
+    // The two formats that used to abort: assert they now exit 1 (violations
+    // found, not a usage error) AND emit parseable JSON carrying the lossy path.
+    for (fmt, ptr) in [
+        ("json", &["results", "0", "violations", "0", "path"][..]),
+        ("agent", &["violations", "0", "file"][..]),
+    ] {
+        let out = run(dir.path(), &["check", ".", "--format", fmt]);
+        assert_eq!(
+            out.status.code(),
+            Some(1),
+            "[{fmt}] a non-UTF-8 filename must not abort output; got exit {:?}, stderr: {}",
+            out.status.code(),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let v: serde_json::Value =
+            serde_json::from_slice(&out.stdout).expect("output must be valid JSON");
+        // Walk the pointer to the path/file field and confirm the lossy render
+        // preserved the ASCII tail (invalid byte → U+FFFD replacement).
+        let mut cur = &v;
+        for key in ptr {
+            cur = key
+                .parse::<usize>()
+                .map_or_else(|_| &cur[key], |idx| &cur[idx]);
+        }
+        let rendered = cur.as_str().expect("path field is a JSON string");
+        assert!(
+            rendered.contains("name.txt") && rendered.contains('\u{fffd}'),
+            "[{fmt}] expected a lossy path (…\u{fffd}…name.txt), got {rendered:?}"
+        );
+    }
+
+    // And every other format still works too (they always did — a guard that
+    // the fix didn't regress them).
+    for fmt in ["sarif", "gitlab", "junit", "github", "markdown", "human"] {
+        let out = run(dir.path(), &["check", ".", "--format", fmt]);
+        assert_ne!(
+            out.status.code(),
+            Some(2),
+            "[{fmt}] regressed on a non-UTF-8 filename; stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}

--- a/docs/design/architecture/DIAGRAMS.md
+++ b/docs/design/architecture/DIAGRAMS.md
@@ -141,6 +141,7 @@ graph TB
   AlintTooling.Bench -.-> AlintCli.Rules
   AlintTooling.E2e -.-> AlintCli.Core
   AlintTooling.E2e -.-> AlintCli.Dsl
+  AlintTooling.E2e -.-> AlintCli.Output
   AlintTooling.E2e -.-> AlintCli.Rules
   AlintTooling.E2e -.-> AlintTooling.Testkit
   AlintTooling.Testkit -.-> AlintCli.Core

--- a/docs/design/architecture/model/crate-graph.gen.c4
+++ b/docs/design/architecture/model/crate-graph.gen.c4
@@ -29,6 +29,7 @@ model {
   alint.cli.dsl -[dev]-> alint.cli.rules
   alint.tooling.e2e -[dev]-> alint.cli.core
   alint.tooling.e2e -[dev]-> alint.cli.dsl
+  alint.tooling.e2e -[dev]-> alint.cli.output
   alint.tooling.e2e -[dev]-> alint.cli.rules
   alint.tooling.e2e -[dev]-> alint.tooling.testkit
   alint.tooling.xtask -[dev]-> alint.cli.dsl


### PR DESCRIPTION
## What

The weird-path × output-format matrix (second follow-up test item from the
post-v0.13 e2e sweep) — which immediately surfaced **a real bug**.

## The bug

A repo file path flows verbatim into every renderer, but `json` and `agent`
serialized it through serde's `impl Serialize for Path`, which **errors** on a
path that isn't valid UTF-8 (legal on Unix). So a repo containing a single
oddly-named file made:

```
$ alint check --format json     # or --format agent
alint: writing output: path contains invalid UTF-8 characters   (exit 2)
```

…while every other format (SARIF/GitLab/JUnit/GitHub/Markdown/human) rendered it
fine. One weird filename rendered the machine-readable output unusable.

**Fix:** both now render the path lossily via `to_string_lossy` (invalid bytes →
U+FFFD), matching the other six formats — a lossy path beats no output. The field
type moves `Option<&Path>` → `Option<Cow<str>>`, so valid-UTF-8 paths (the common
case) still borrow with no allocation and are byte-identical.

## Tests added

**`crates/alint-e2e/tests/output_weird_paths.rs`** — library matrix via the public
`Format` API on synthetic reports (so control bytes / non-UTF-8 are deterministic,
no filesystem):
- `every_format_handles_utf8_weird_paths` — space, Latin, CJK, emoji, `"`, `\`,
  `<>&`, `` |` ``, `,:%#`, ESC clear-screen, newline × all 8 formats; JSON-family
  parses, JUnit parses as XML, text formats stay UTF-8 with no raw NUL.
- `every_format_handles_a_non_utf8_path` *(Unix)* — a `0xFF`-byte path through all
  8; the regression guard (json/agent used to error here).
- `json_family_round_trips_a_utf8_weird_path` — a UTF-8 path with metacharacters
  decodes back exactly through json/gitlab/agent.

**`crates/alint/tests/weird_path_formats_cli.rs`** *(Unix)* — the same property
end-to-end through the real binary with real files, headlined by
`non_utf8_filename_does_not_break_json_or_agent`: `--format json`/`agent` now exit
1 (violations) with valid JSON carrying the lossy path, not exit 2.

## Scope / notes

- Production change is small and mechanical (json.rs + agent.rs path field → lossy
  `Cow<str>`); no behavior change for valid-UTF-8 paths.
- Adds `alint-output` + `roxmltree` (already workspace-pinned) as `alint-e2e`
  dev-deps for the matrix.
- Local preflight (fmt/clippy/test/doc/version-pins/dep-floors/dogfood) all green.
