### PR TITLE
fix: remediate the adversarial review of #110–#115 (baseline bugs, M5 vacuity, drift-guard, polish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   file suppresses the total, not the last writer's count); regeneration is
   byte-identical across runs and its guard counts new *occurrences* (a higher
   count on an existing finding is fresh debt too, not just new fingerprints).
-  The baseline file is excluded from the walk, so a broad-glob content rule
-  (`**/*.json`, `line_max_width`, …) can't lint alint's own JSON-Lines artifact
-  as a new violation — the adopt-flow stays clean.
+  The baseline file is excluded from the walk by `check`, `baseline`, and
+  `fix` alike, so a broad-glob content rule (`**/*.json`, `line_max_width`, …)
+  can't lint alint's own JSON-Lines artifact as a new violation — the adopt-flow
+  stays clean, regeneration doesn't see the artifact as fresh debt, and `fix`
+  never rewrites it. The exclusion is root-anchored, so a same-named baseline in
+  a subdirectory is still linted (its real violations aren't silently dropped).
   See `docs/design/baseline.md` / ADR-0006.
 - `--only <RULE_ID>` on `check` and `fix` (repeatable): restrict the run to the
   named rule id(s) from the effective config. An id that matches no loaded rule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,11 +356,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `+`) aborted the run; the addition is now checked and a malformed timestamp
   is dropped. (M7)
 - **`git_no_denied_paths` denylist patterns are anchored to any depth.** A
-  bare denied pattern (no `/`) like `*.pem` or `id_rsa` was root-anchored by
-  globset, so `secrets/server.pem` evaded the denylist — a dangerous default
-  for a secrets control. Bare patterns are now auto-anchored to `**/<pattern>`
-  (matching any depth, root included); explicit-path patterns
-  (`secrets/*.key`, `**/*.pem`) are taken as written. (M5)
+  bare denied *literal* (no `/`, no wildcard) like `id_rsa` was root-anchored by
+  globset, so a tracked `secrets/id_rsa` evaded the denylist — a dangerous
+  default for a secrets control. (A bare *wildcard* like `*.pem` already crosses
+  `/` in globset, so it was never the gap — an earlier note over-generalised.)
+  Bare patterns are now auto-anchored to `**/<pattern>` (matching any depth,
+  root included — a no-op for wildcards, the real fix for literals); explicit-path
+  patterns (`secrets/*.key`, `**/*.pem`) are taken as written. (M5)
 - **Completed the Unicode control-character sets for the obfuscation rules.**
   `no_bidi_controls` now also flags the implicit directional marks U+061C
   (ALM), U+200E (LRM), and U+200F (RLM) — completing the Trojan-Source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   output-format matrix that renders a violation path carrying each format's
   metacharacters, a control byte, and a non-UTF-8 byte through all eight
   formats. (E2E sweep)
+- **Markdown output no longer splits a heading on a newline-in-path.** A file
+  whose name contains a `\n`/`\r` (legal on Unix) broke out of the `## \`path\``
+  inline-code heading, orphaning the rest onto a following line. `md_inline_code`
+  now collapses those control chars to a space (inline code is single-line), and
+  the weird-path matrix asserts every Markdown heading stays complete. (review
+  follow-up)
 - **Exit code `3` (internal error) is now actually produced.** The README
   documented `3` for an internal alint error vs `2` for a config/usage error,
   but every error funnelled to `2`, so a script could never tell "fix your

--- a/crates/alint-e2e/scenarios/check/git/git_no_denied_paths_fires_on_nested_secret.yml
+++ b/crates/alint-e2e/scenarios/check/git/git_no_denied_paths_fires_on_nested_secret.yml
@@ -1,34 +1,35 @@
 name: git_no_denied_paths fires on a nested secret via a bare (any-depth) pattern
-# M5 regression (post-v0.13 audit): a *bare* denied pattern (no `/`) like
-# `*.pem` was root-anchored by globset, so a tracked `secrets/server.pem`
-# evaded the denylist — a dangerous miss for a secrets control. Bare patterns
-# now auto-anchor to `**/<pattern>`, matching at any depth. Pre-fix this
-# scenario finds no violation and fails; the existing root-level `.env`
-# scenario would pass even with the bug, so this nested case is the real guard.
+# M5 regression (post-v0.13 audit). A bare *literal* denied pattern (no `/`, no
+# wildcard) like `id_rsa` is anchored by globset to the repo root only, so a
+# tracked `secrets/id_rsa` evaded the denylist — a dangerous miss for a secrets
+# control. Bare patterns now auto-anchor to `**/<pattern>`, matching at any
+# depth. This scenario uses `id_rsa` deliberately: a bare *wildcard* like `*.pem`
+# already crosses `/` in globset (so it was never the gap), whereas a bare
+# literal is the case the fix actually changes — reverting `anchor_denied_pattern`
+# turns this scenario red, where a `*.pem`/nested-`.pem` fixture would not.
 tags: [check, git_no_denied_paths, git, failing]
 
 given:
   tree:
     README.md: "# demo\n"
     secrets:
-      server.pem: "-----BEGIN PRIVATE KEY-----\n"
+      id_rsa: "-----BEGIN OPENSSH PRIVATE KEY-----\n"
   config: |
     version: 1
-    respect_gitignore: false
     rules:
       - id: no-tracked-keys
         kind: git_no_denied_paths
         denied:
-          - "*.pem"
           - "id_rsa"
+          - "*.pem"
         level: error
   git:
     init: true
-    add: [README.md, secrets/server.pem]
+    add: [README.md, secrets/id_rsa]
     commit: true
 
 when: [check]
 
 expect:
   - violations:
-      - {rule: no-tracked-keys, level: error, path: secrets/server.pem}
+      - {rule: no-tracked-keys, level: error, path: secrets/id_rsa}

--- a/crates/alint-e2e/tests/coverage_audit_spawn_gate.rs
+++ b/crates/alint-e2e/tests/coverage_audit_spawn_gate.rs
@@ -28,62 +28,107 @@ fn rules_src_dir() -> PathBuf {
         .join("alint-rules/src")
 }
 
+/// The callable `fn` surface of the shared spawn chokepoint (`spawn.rs`),
+/// extracted dynamically. A rule that calls any of these launches a process,
+/// so reading them from the source (rather than hard-coding `run_capturing`)
+/// means a *new* chokepoint entry point — `run_streaming`, `run_with_stdin`, …
+/// — is covered the moment it lands, without editing this audit.
+fn spawn_helper_fns(src: &Path) -> Vec<String> {
+    let text = std::fs::read_to_string(src.join("spawn.rs")).expect("read spawn.rs");
+    let mut names = Vec::new();
+    for line in text.lines() {
+        let l = line.trim_start();
+        // Only the callable-from-a-rule surface (`pub` / `pub(crate)`); a
+        // private helper can't be reached cross-module anyway.
+        for prefix in ["pub(crate) fn ", "pub fn "] {
+            if let Some(rest) = l.strip_prefix(prefix)
+                && let Some(name) = rest.split('(').next()
+            {
+                let name = name.trim();
+                if !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                    names.push(name.to_string());
+                }
+                break;
+            }
+        }
+    }
+    assert!(
+        !names.is_empty(),
+        "no pub(crate)/pub fn found in spawn.rs — the chokepoint scan would be blind"
+    );
+    names
+}
+
 /// Does this source line launch a subprocess? A rule spawns iff it either
 /// constructs a `Command` directly (`Command::new(` — also matches
-/// `StdCommand::new(`, `process::Command::new(`, `tokio::process::…`) or
-/// calls the shared spawn chokepoint (`crate::spawn::run_capturing`).
-/// Line comments are skipped so prose naming the primitive can't trip it.
+/// `StdCommand::new(`, `process::Command::new(`, `tokio::process::…`) or calls
+/// one of the shared chokepoint's `fn`s (`crate::spawn::<fn>(`). Line comments
+/// are skipped so prose naming the primitive can't trip it.
 ///
 /// Heuristic, deliberately: a spawn smuggled behind a bespoke alias
 /// (`use std::process::Command as Cmd; Cmd::new()`) would evade it. That is
-/// acceptable — the audit exists to catch the realistic regression (a new
-/// rule shelling out the ordinary way, à la `gff`), not an adversary editing
-/// alint's own source to hide a spawn from its own test suite.
-fn line_spawns(line: &str) -> bool {
+/// acceptable — the audit exists to catch the realistic regression (a new rule
+/// shelling out the ordinary way, à la `gff`), not an adversary editing alint's
+/// own source to hide a spawn from its own test suite.
+fn line_spawns(line: &str, helpers: &[String]) -> bool {
     let code = line.trim_start();
     if code.starts_with("//") {
         return false;
     }
-    code.contains("Command::new(") || code.contains("crate::spawn::run_capturing")
+    if code.contains("Command::new(") {
+        return true;
+    }
+    helpers
+        .iter()
+        .any(|h| code.contains(&format!("crate::spawn::{h}(")))
 }
 
-/// Module file stems under `alint-rules/src` that reach a spawn primitive,
-/// excluding the shared `spawn.rs` helper itself (it *is* the chokepoint,
-/// not a rule kind). Sorted.
-fn spawning_module_stems() -> Vec<String> {
-    let mut stems = Vec::new();
-    for entry in std::fs::read_dir(rules_src_dir()).expect("read alint-rules/src") {
-        let path = entry.unwrap().path();
-        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
-            continue;
-        }
-        let stem = path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .expect("utf-8 file stem")
-            .to_string();
-        if stem == "spawn" {
-            continue; // the helper, not a rule
-        }
-        let text = std::fs::read_to_string(&path).expect("read rule source");
-        if text.lines().any(line_spawns) {
-            stems.push(stem);
+/// Every `.rs` under `alint-rules/src` — **recursively**, so a rule split into
+/// a `foo/mod.rs` + submodules can't hide a spawn from the flat top level —
+/// that reaches a spawn primitive, as a path relative to `src/` (e.g.
+/// `command.rs`, `foo/mod.rs`). Excludes the shared `spawn.rs` helper itself
+/// (it *is* the chokepoint, not a rule kind). Sorted.
+fn spawning_module_paths() -> Vec<String> {
+    let src = rules_src_dir();
+    let helpers = spawn_helper_fns(&src);
+    let spawn_helper = src.join("spawn.rs");
+    let mut found = Vec::new();
+    let mut stack = vec![src.clone()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("read alint-rules/src dir") {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|e| e.to_str()) != Some("rs") || path == spawn_helper {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path).expect("read rule source");
+            if text.lines().any(|l| line_spawns(l, &helpers)) {
+                let rel = path
+                    .strip_prefix(&src)
+                    .expect("under src")
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                found.push(rel);
+            }
         }
     }
-    stems.sort();
-    stems
+    found.sort();
+    found
 }
 
 #[test]
 fn spawning_allowlist_matches_the_rules_that_actually_spawn() {
-    let found = spawning_module_stems();
+    let found = spawning_module_paths();
 
-    // The allow-list as module stems. Each spawning kind lives in a module
-    // named for the kind (`command` → command.rs, etc.); the audit relies on
-    // that convention and calls it out if it ever breaks.
+    // The allow-list as `src`-relative module paths. Each spawning kind lives in
+    // a top-level module named for the kind (`command` → command.rs, etc.); the
+    // audit relies on that convention and calls it out if it ever breaks.
     let mut expected: Vec<String> = alint_dsl::SPAWNING_RULE_KINDS
         .iter()
-        .map(|k| (*k).to_string())
+        .map(|k| format!("{k}.rs"))
         .collect();
     expected.sort();
 
@@ -97,7 +142,8 @@ fn spawning_allowlist_matches_the_rules_that_actually_spawn() {
          (crates/alint-dsl/src/lib.rs) — without it, an `extends:`'d or nested \
          ruleset can run the rule as arbitrary code (the `gff` regression class). \
          If you removed a spawner, drop its stale allow-list entry. If a spawning \
-         module is not named `<kind>.rs`, teach this audit the mapping."
+         module is not named `<kind>.rs` at the top level, teach this audit the \
+         mapping."
     );
 }
 
@@ -120,4 +166,41 @@ fn spawning_allowlist_is_non_empty_and_each_entry_has_a_module() {
             module.display()
         );
     }
+}
+
+#[test]
+fn spawn_detection_is_dynamic_and_precise() {
+    // Guards the scan's own robustness (adversarial review of #112):
+    // the chokepoint fn set is read from spawn.rs (not hard-coded), so a future
+    // entry point is covered; and a bare timeout-const reference is not a spawn.
+    let helpers = spawn_helper_fns(&rules_src_dir());
+    assert!(
+        helpers.iter().any(|h| h == "run_capturing"),
+        "spawn.rs's real fn surface should be discovered, got {helpers:?}"
+    );
+
+    // A hypothetical future chokepoint fn is detected the moment it exists —
+    // no edit to this audit needed.
+    let future = ["run_capturing".to_string(), "run_streaming".to_string()];
+    assert!(
+        line_spawns("        crate::spawn::run_streaming(argv)?;", &future),
+        "a new chokepoint fn must be caught once spawn.rs exports it"
+    );
+
+    // Direct construction is always caught (alias `StdCommand` included).
+    assert!(line_spawns(
+        "    let mut cmd = StdCommand::new(program);",
+        &helpers
+    ));
+    // A reference to the timeout *const* (not a fn call) is NOT a spawn —
+    // guards against a false RED that a bare `crate::spawn::` prefix would cause.
+    assert!(!line_spawns(
+        "            .unwrap_or(crate::spawn::DEFAULT_SPAWN_TIMEOUT_SECS),",
+        &helpers
+    ));
+    // Prose mentioning the primitive is ignored.
+    assert!(!line_spawns(
+        "        // eventually calls Command::new( for you",
+        &helpers
+    ));
 }

--- a/crates/alint-e2e/tests/output_weird_paths.rs
+++ b/crates/alint-e2e/tests/output_weird_paths.rs
@@ -109,6 +109,18 @@ fn assert_wellformed(label: &str, fmt_name: &str, fmt: Format, bytes: &[u8]) {
                 !text.contains('\u{0}'),
                 "[{fmt_name}/{label}] output contains a raw NUL byte"
             );
+            // Markdown: a control char in the path must not split the `## `
+            // heading — each heading line stays complete (ends with its
+            // `(count)` suffix). A bare "valid UTF-8 + no NUL" check misses a
+            // newline-in-path that splits `## \`a` / `b.txt\` (1)` across lines.
+            if matches!(fmt, Format::Markdown) {
+                for line in text.lines() {
+                    assert!(
+                        !line.starts_with("## ") || line.trim_end().ends_with(')'),
+                        "[{fmt_name}/{label}] a control char split a Markdown heading: {line:?}"
+                    );
+                }
+            }
         }
     }
 }

--- a/crates/alint-output/src/markdown.rs
+++ b/crates/alint-output/src/markdown.rs
@@ -293,7 +293,11 @@ fn md_escape(s: &str) -> String {
 /// disallowed by the schema. Net: this only matters for
 /// truly adversarial inputs.
 fn md_inline_code(s: &str) -> String {
-    s.replace('`', "ʼ")
+    // Inline code is single-line by definition: a `\n`/`\r` (legal in a path on
+    // Unix) would break out of the span and split the enclosing `## ` heading,
+    // so collapse them to a space. A backtick would close the span early, so
+    // swap in the modifier-letter look-alike.
+    s.replace(['\r', '\n'], " ").replace('`', "ʼ")
 }
 
 /// Escape a URL for use in a markdown link target.

--- a/crates/alint-rules/src/git_no_denied_paths.rs
+++ b/crates/alint-rules/src/git_no_denied_paths.rs
@@ -125,7 +125,9 @@ impl Rule for GitNoDeniedPathsRule {
 /// already names a path (`secrets/*.key`, `**/*.pem`) is taken as written.
 /// `**/` matches zero or more segments, so the anchored form still catches
 /// the root-level file. This is the secure default for a denylist: a bare
-/// `*.pem` should ban a `.pem` anywhere in the tree, not only at the root.
+/// *literal* like `id_rsa` should ban that file anywhere in the tree, not only
+/// at the root — globset root-anchors a bare literal. (A bare *wildcard* like
+/// `*.pem` already spans depths in globset, so anchoring it is a no-op.)
 fn anchor_denied_pattern(pattern: &str) -> std::borrow::Cow<'_, str> {
     if pattern.contains('/') {
         std::borrow::Cow::Borrowed(pattern)
@@ -154,11 +156,13 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
 
     let mut builder = GlobSetBuilder::new();
     for pattern in &opts.denied {
-        // Auto-anchor a *bare* pattern (no `/`) so it matches at ANY depth.
-        // globset otherwise root-anchors it, so `*.pem` would miss
-        // `secrets/server.pem` — a dangerous default for a *security*
-        // denylist (M5). `denied_src` keeps the original spelling for the
-        // violation message.
+        // Auto-anchor a *bare* pattern (no `/`) to `**/…` so it matches at ANY
+        // depth. The real gap this closes is bare *literals*: globset anchors
+        // `id_rsa` to the repo root, so a tracked `secrets/id_rsa` would evade a
+        // *security* denylist (M5). A bare *wildcard* like `*.pem` already
+        // crosses `/` in globset (default `literal_separator = false`), so
+        // anchoring it is a harmless no-op that keeps the mental model uniform.
+        // The original spelling is kept for the violation message.
         let effective = anchor_denied_pattern(pattern);
         let glob = Glob::new(&effective).map_err(|e| {
             Error::rule_config(&spec.id, format!("invalid denied pattern `{pattern}`: {e}"))
@@ -213,18 +217,41 @@ mod tests {
     }
 
     #[test]
-    fn extension_glob_matches_root_basename() {
-        // `*.env` is a basename pattern: it matches `.env` at
-        // the repo root but not under subdirectories (globset's
-        // `*` doesn't cross `/`). Users who want recursive
-        // matching write `**/.env`.
-        let set = build_set(&["*.env"]);
-        assert!(!set.matches(std::path::Path::new(".env")).is_empty());
+    fn bare_wildcard_crosses_slashes_bare_literal_does_not() {
+        // The globset semantics behind M5 (default `literal_separator = false`):
+        // a bare *wildcard* `*.env` DOES cross `/`, so it already matches at any
+        // depth — it was never the M5 gap. A bare *literal* is what globset
+        // root-anchors, so `id_rsa` alone misses `secrets/id_rsa` — the real gap
+        // `anchor_denied_pattern` closes. (`config/.envrc` is unmatched by
+        // *suffix*, not by `/`.)
+        let wild = build_set(&["*.env"]);
         assert!(
-            set.matches(std::path::Path::new("config/.envrc"))
-                .is_empty()
+            !wild.matches(std::path::Path::new(".env")).is_empty(),
+            "root .env"
         );
-        assert!(set.matches(std::path::Path::new("README.md")).is_empty());
+        assert!(
+            !wild
+                .matches(std::path::Path::new("config/app.env"))
+                .is_empty(),
+            "*.env crosses / to a nested .env"
+        );
+        assert!(
+            wild.matches(std::path::Path::new("config/.envrc"))
+                .is_empty(),
+            "unmatched by suffix"
+        );
+        assert!(wild.matches(std::path::Path::new("README.md")).is_empty());
+
+        let lit = build_set(&["id_rsa"]);
+        assert!(
+            !lit.matches(std::path::Path::new("id_rsa")).is_empty(),
+            "root literal"
+        );
+        assert!(
+            lit.matches(std::path::Path::new("secrets/id_rsa"))
+                .is_empty(),
+            "a bare literal is root-anchored — the real M5 gap"
+        );
     }
 
     #[test]

--- a/crates/alint/src/main.rs
+++ b/crates/alint/src/main.rs
@@ -794,7 +794,30 @@ fn baseline_walk_exclude(root: &Path, baseline: &Path) -> Option<String> {
     let root_abs = root.canonicalize().ok()?;
     let base_abs = baseline.canonicalize().ok()?;
     let rel = base_abs.strip_prefix(&root_abs).ok()?;
-    Some(rel.to_string_lossy().replace('\\', "/"))
+    // Root-anchored (leading `/`): the walker turns this into an override
+    // `!/…` that matches ONLY the baseline at the repo root, never a same-named
+    // file in a subdirectory. Without the anchor a separator-less pattern
+    // matches at any depth, silently dropping a real violation in e.g.
+    // `sub/.alint-baseline.json`.
+    Some(format!("/{}", rel.to_string_lossy().replace('\\', "/")))
+}
+
+/// Append the [`baseline_walk_exclude`] pattern for `baseline` (when set) to
+/// `extra_ignores`, so `check` / `baseline` / `fix` all keep alint's own
+/// committed JSON-Lines artifact out of the walk. A broad-glob content rule
+/// (`**/*.json`, `line_max_width`, `no_trailing_whitespace`, …) would otherwise
+/// flag it — breaking the adopt-flow for `check`, making `baseline`
+/// regeneration see the artifact as fresh debt, and letting `fix` rewrite it.
+fn exclude_baseline_from_walk(
+    extra_ignores: &mut Vec<String>,
+    root: &Path,
+    baseline: Option<&Path>,
+) {
+    if let Some(bp) = baseline
+        && let Some(rel) = baseline_walk_exclude(root, bp)
+    {
+        extra_ignores.push(rel);
+    }
 }
 
 fn cmd_check(path: &Path, changed: &ChangedMode, only: &[String], cli: &Cli) -> Result<ExitCode> {
@@ -825,17 +848,9 @@ fn cmd_check(path: &Path, changed: &ChangedMode, only: &[String], cli: &Cli) -> 
     } else {
         loaded.respect_gitignore
     };
-    // Exclude alint's own baseline file from the walk. It's a committed
-    // JSON-Lines artifact, so a broad-glob content rule (`**/*.json`,
-    // `line_max_width`, `no_trailing_whitespace`, …) would otherwise flag it as
-    // a NEW violation the baseline can't contain — breaking the canonical
-    // adopt-flow (`check` → `baseline` → `check --baseline` never reaches 0).
+    // Keep alint's own baseline artifact out of the walk (see the helper).
     let mut extra_ignores = loaded.extra_ignores;
-    if let Some(bp) = effective_baseline.as_deref()
-        && let Some(rel) = baseline_walk_exclude(path, bp)
-    {
-        extra_ignores.push(rel);
-    }
+    exclude_baseline_from_walk(&mut extra_ignores, path, effective_baseline.as_deref());
     let walk_opts = WalkOptions {
         respect_gitignore: effective_gitignore,
         extra_ignores,
@@ -1064,16 +1079,34 @@ fn cmd_baseline(
         );
     }
     let loaded = load_rules(path, cli)?;
+
+    // Output path precedence: --output (as given) > `baseline:` config key
+    // (resolved against the repo root) > the default `.alint-baseline.json`.
+    // So `alint baseline` and `alint check` agree on the same file by default.
+    // Resolved up front so it can be excluded from the walk below — otherwise
+    // a regeneration re-lints the existing artifact and reports it as new debt.
+    let out_path = output.map_or_else(
+        || {
+            loaded
+                .baseline
+                .as_ref()
+                .map_or_else(|| path.join(".alint-baseline.json"), |b| path.join(b))
+        },
+        Path::to_path_buf,
+    );
+
     let engine = Engine::from_entries(loaded.entries, loaded.registry)
         .with_facts(loaded.facts)
         .with_vars(loaded.vars);
+    let mut extra_ignores = loaded.extra_ignores;
+    exclude_baseline_from_walk(&mut extra_ignores, path, Some(&out_path));
     let walk_opts = WalkOptions {
         respect_gitignore: if cli.no_gitignore {
             false
         } else {
             loaded.respect_gitignore
         },
-        extra_ignores: loaded.extra_ignores,
+        extra_ignores,
     };
     let index = walk(path, &walk_opts).context("walking repository")?;
     let report = engine.run(path, &index).context("running rules")?;
@@ -1095,19 +1128,6 @@ fn cmd_baseline(
     }
     let new_baseline =
         Baseline::from_fingerprints(Some(env!("CARGO_PKG_VERSION").to_string()), items);
-
-    // Output path precedence: --output (as given) > `baseline:` config key
-    // (resolved against the repo root) > the default `.alint-baseline.json`.
-    // So `alint baseline` and `alint check` agree on the same file by default.
-    let out_path = output.map_or_else(
-        || {
-            loaded
-                .baseline
-                .as_ref()
-                .map_or_else(|| path.join(".alint-baseline.json"), |b| path.join(b))
-        },
-        Path::to_path_buf,
-    );
 
     // Regeneration guard: refuse to grandfather NEW debt without
     // --accept-new. Pruning stale entries is always allowed.
@@ -1227,9 +1247,17 @@ fn cmd_fix(
     } else {
         loaded.respect_gitignore
     };
+    // Keep the baseline artifact out of the walk so a broad content-fixer can't
+    // rewrite alint's own committed JSON-Lines file (mirrors `check`/`baseline`).
+    let effective_baseline = cli
+        .baseline
+        .clone()
+        .or_else(|| loaded.baseline.as_ref().map(|b| path.join(b)));
+    let mut extra_ignores = loaded.extra_ignores;
+    exclude_baseline_from_walk(&mut extra_ignores, path, effective_baseline.as_deref());
     let walk_opts = WalkOptions {
         respect_gitignore: effective_gitignore,
-        extra_ignores: loaded.extra_ignores,
+        extra_ignores,
     };
 
     let index = walk(path, &walk_opts).context("walking repository")?;

--- a/crates/alint/src/main.rs
+++ b/crates/alint/src/main.rs
@@ -1661,6 +1661,9 @@ struct LoadedConfig {
 ///   `&&` → `and` keyword hints, etc.)
 /// - `2` — invocation error (file missing, etc.) — propagated by
 ///   `main`'s top-level error handler.
+/// - `3` — internal error (e.g. a bundled ruleset shipped inside the binary
+///   fails to parse) — classified by `error_is_internal`, distinguishing an
+///   alint bug from a user-fixable config problem (M11).
 fn cmd_validate_config(path: Option<PathBuf>, format: &str, cli: &Cli) -> Result<ExitCode> {
     // Fail loudly on a format this subcommand can't render, rather than
     // silently falling through to human output (M13) — mirroring how

--- a/crates/alint/tests/baseline_cli.rs
+++ b/crates/alint/tests/baseline_cli.rs
@@ -669,7 +669,10 @@ fn nested_same_named_baseline_is_not_over_excluded() {
         String::from_utf8_lossy(&compact.stderr)
     );
     assert!(
-        String::from_utf8_lossy(&compact.stdout).contains("sub/.alint-baseline.json"),
+        // Normalise separators — Windows reports `sub\.alint-baseline.json`.
+        String::from_utf8_lossy(&compact.stdout)
+            .replace('\\', "/")
+            .contains("sub/.alint-baseline.json"),
         "the nested file's TOPSECRET must be reported, not over-excluded"
     );
 }

--- a/crates/alint/tests/baseline_cli.rs
+++ b/crates/alint/tests/baseline_cli.rs
@@ -583,3 +583,93 @@ fn baseline_file_is_excluded_from_the_walk() {
         "the baseline file must not be flagged"
     );
 }
+
+#[test]
+fn baseline_regen_and_fix_also_exclude_the_artifact() {
+    // Regression (adversarial review of #111): the walk-exclusion was
+    // `check`-only. With a committed `baseline:` config key, `baseline`
+    // regeneration must not treat its own JSON-Lines artifact as fresh debt
+    // (was exit 2), and `fix` must not lint/rewrite it (was flagged).
+    let d = tempfile::tempdir().unwrap();
+    let root = d.path();
+    std::fs::write(root.join("package.json"), "{\"license\":\"BAD\"}\n").unwrap();
+    std::fs::write(
+        root.join(".alint.yml"),
+        "version: 1\n\
+         baseline: .alint-baseline.json\n\
+         rules:\n\
+         \x20 - id: lic\n\
+         \x20   kind: json_path_equals\n\
+         \x20   paths: [\"**/*.json\"]\n\
+         \x20   path: \"$.license\"\n\
+         \x20   equals: \"MIT\"\n\
+         \x20   level: error\n",
+    )
+    .unwrap();
+    assert_eq!(code(&run(root, &["baseline"])), 0, "snapshot existing debt");
+    // Regeneration must stay exit 0 — the just-written artifact isn't new debt.
+    let regen = run(root, &["baseline"]);
+    assert_eq!(
+        code(&regen),
+        0,
+        "regen must not grandfather its own artifact; stderr={}",
+        String::from_utf8_lossy(&regen.stderr)
+    );
+    // fix must not mention / lint the artifact.
+    let fixout = run(root, &["fix", "--dry-run"]);
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&fixout.stdout),
+        String::from_utf8_lossy(&fixout.stderr)
+    );
+    assert!(
+        !combined.contains(".alint-baseline.json"),
+        "fix must not flag the baseline artifact; got:\n{combined}"
+    );
+}
+
+#[test]
+fn nested_same_named_baseline_is_not_over_excluded() {
+    // Regression (adversarial review of #111): the exclusion pattern was
+    // separator-less, so `!.alint-baseline.json` matched at ANY depth — a real
+    // violation in a nested file sharing the basename was silently dropped. The
+    // pattern is now root-anchored (`!/…`), so only the root artifact is skipped.
+    let d = tempfile::tempdir().unwrap();
+    let root = d.path();
+    std::fs::write(
+        root.join(".alint.yml"),
+        "version: 1\n\
+         baseline: .alint-baseline.json\n\
+         rules:\n\
+         \x20 - id: no-secret\n\
+         \x20   kind: file_content_forbidden\n\
+         \x20   paths: [\"**/*.json\"]\n\
+         \x20   pattern: \"TOPSECRET\"\n\
+         \x20   level: error\n",
+    )
+    .unwrap();
+    std::fs::write(root.join("data.txt"), "clean\n").unwrap();
+    assert_eq!(
+        code(&run(root, &["baseline"])),
+        0,
+        "empty baseline (clean tree)"
+    );
+    // A nested file that shares the basename, carrying a real secret.
+    std::fs::create_dir(root.join("sub")).unwrap();
+    std::fs::write(
+        root.join("sub/.alint-baseline.json"),
+        "{\"k\":\"TOPSECRET\"}\n",
+    )
+    .unwrap();
+    let compact = run(root, &["check", "--compact"]);
+    assert_eq!(
+        code(&compact),
+        1,
+        "the nested same-named file's violation must still fire; stderr={}",
+        String::from_utf8_lossy(&compact.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&compact.stdout).contains("sub/.alint-baseline.json"),
+        "the nested file's TOPSECRET must be reported, not over-excluded"
+    );
+}

--- a/docs/design/v0.14/post_v0.13_audit.md
+++ b/docs/design/v0.14/post_v0.13_audit.md
@@ -355,15 +355,21 @@ security-sensitive walk/read-path change that genuinely wants its own
 reviewed pass; rushing it risks reintroducing the confinement threat.
 Tracked.
 
-### M5 — `git_no_denied_paths` denylist is root-anchored `[x]`
-**Where:** `git_no_denied_paths.rs`. For a *secrets* control, `*.pem` /
-`id_rsa` matched only the repo root, so `secrets/server.pem` evaded.
+### M5 — `git_no_denied_paths` denylist root-anchors bare literals `[x]`
+**Where:** `git_no_denied_paths.rs`. For a *secrets* control, a bare *literal*
+like `id_rsa` matched only the repo root, so a tracked `secrets/id_rsa` evaded.
+(Correction from the adversarial review of the fix: a bare *wildcard* like
+`*.pem` already crosses `/` under globset's default `literal_separator = false`,
+so it was never the gap — only bare literals are root-anchored. The original
+"`*.pem` matched only root" write-up over-generalised.)
 **Done (maintainer chose auto-anchor):** a bare denied pattern (no `/`) is
-rewritten to `**/<pattern>` so it bans a match at any depth; explicit-path
-patterns (`secrets/*.key`, `**/*.pem`) are taken as written; the violation
-message keeps the original spelling. The semantics change (a bare `*.env`
-now matches any depth) is the intended secure default for a denylist.
-Tested (`anchor_denied_pattern` + a nested-match check).
+rewritten to `**/<pattern>` so it bans a match at any depth — a no-op for
+wildcards, the real fix for literals; explicit-path patterns (`secrets/*.key`,
+`**/*.pem`) are taken as written; the violation message keeps the original
+spelling. Tested: `anchor_denied_pattern` unit +
+`bare_wildcard_crosses_slashes_bare_literal_does_not` (documents the real
+globset semantics) + the `git_no_denied_paths_fires_on_nested_secret` scenario,
+which uses `id_rsa` so reverting the anchoring turns it red.
 
 ### M6 — non-UTF-8 git data silently collapses checks `[~]`
 **Where:** `core/git.rs:60,135` (one non-UTF-8 path → whole tracked/

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -648,6 +648,8 @@ All rules in this family are no-ops on Windows — the +x bit and symlinks don't
 
 Flag tracked paths that are symbolic links. Symlinks are a portability footgun: Windows NTFS needs admin rights to create them, git-for-Windows can silently flatten them, CI runners vary.
 
+Caveat: a symlink whose target escapes the repository root (`link -> /etc`) is pruned by the walker *before* indexing, so it is **not** flagged — the rule reports in-tree symlinks (to files or directories), not escaping ones. The escaping symlink can't be read out-of-root either (path confinement blocks that), so this is a reporting gap, not a disclosure one; recording escaping symlinks safely is a tracked follow-up.
+
 ```yaml
 - id: no-symlinks
   kind: no_symlinks


### PR DESCRIPTION
## What

Remediation for the findings from the adversarial review of the last five PRs
(#110, #111, #112, #113, #115). Four phased commits, ordered by severity.

## 1 · `fix(baseline)` — #111, two real MED bugs (production)

The baseline walk-exclusion was **`check`-only**:
- `alint baseline` regeneration re-linted its own just-written JSON-Lines
  artifact and reported it as fresh debt (exit 2); `alint fix` re-linted / could
  rewrite it. Factored a shared `exclude_baseline_from_walk` and applied it in
  `cmd_baseline` (resolved output path, moved above the walk) and `cmd_fix`.
- The exclude pattern was separator-less (`!.alint-baseline.json`), matching at
  **any depth** — a real violation in a nested same-named file
  (`sub/.alint-baseline.json`) was silently dropped. Now root-anchored (`!/…`).

Both reproduced before/after; +2 CLI regression tests; CHANGELOG corrected.

## 2 · `test(audit)` — #115, M5 scenario was vacuous

globset's `*` crosses `/` by default, so `*.pem` **already** matched
`secrets/server.pem` — reverting `anchor_denied_pattern` left the scenario green.
The fix is load-bearing only for bare **literals**. Rewrote the scenario to use
`id_rsa` + `secrets/id_rsa` (verified non-vacuous via a clean-room globset
check), and corrected the factual "`*.pem` was root-anchored" claim that had
propagated into the rule doc comments, the audit doc, the CHANGELOG, and a
misleading unit test (replaced with one documenting the real semantics).

## 3 · `test(spawn-gate)` — #112, drift-guard false-greens

Two mutation-confirmed blind spots in the gff-class backstop:
- non-recursive scan → a subdirectory-module spawner (`src/foo/mod.rs`) evaded.
  Now recursive; mutation-verified it turns RED.
- hardcoded `run_capturing` → a future second chokepoint helper would evade. Now
  the chokepoint fn set is extracted dynamically from `spawn.rs`; matching
  `crate::spawn::<fn>(` also stops a bare timeout-const from causing a false RED.

Adds `spawn_detection_is_dynamic_and_precise` to lock both.

## 4 · `fix(output)+docs` — #110/#113 hardening (low-priority)

- A newline-in-path split the Markdown `## \`path\`` heading; `md_inline_code`
  now collapses `\r`/`\n` (inline code is single-line), and the weird-path
  matrix asserts every heading stays complete (was a test blind spot).
- Documented the `no_symlinks` escaping-symlink gap in `docs/rules.md`; added
  the exit-3 line to `cmd_validate_config`'s doc comment.

## Not changed (reviewed, correctly-disclosed residual)

The #110 M3 over-cap fail-open + missing observability, the #113 baseline lossy
collision, and #113's overall fix (verified **complete** — no missed serde
`&Path` site) were confirmed sound / already disclosed. No HIGH findings.

Local preflight (fmt/clippy/test/doc/version-pins/dep-floors/dogfood) all green.
