### PR TITLE
docs: reconcile status/plan/tracking after the v0.14 hardening work

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -77,7 +77,7 @@ points are explicit.
    **Why `Cargo.lock` is in the stage list.** When
    `[workspace.package].version` bumps, the workspace internal-crate
    entries in `Cargo.lock` (`alint`, `alint-core`, `alint-dsl`,
-   `alint-rules`, `alint-output`, `alint-bench`, `alint-e2e`,
+   `alint-rules`, `alint-output`, `alint-lsp`, `alint-bench`, `alint-e2e`,
    `alint-testkit`) need to track. `bump-version.sh` refreshes the
    lockfile via `cargo metadata --offline` as part of the bump; the
    refresh must be committed alongside `Cargo.toml`, or CI's

--- a/docs/design/ROADMAP.md
+++ b/docs/design/ROADMAP.md
@@ -177,11 +177,17 @@ on it for adoption, they can lint without it.
   dependency allowlist, and the ASF compliance-bundle over-fire
   fix.
 
-- **v0.14, WASM plugins.** Bumped again to make room for the
-  engineering-foundations program, which took the v0.13.0 cut.
-  `wasmtime` host, signed plugin registry, blessed
-  examples (mock-ratio checker, near-dup detector,
-  debug-statement stripper).
+- **v0.14, Security and correctness hardening.** Baseline /
+  grandfathering mode plus the post-v0.13 security + correctness audit
+  (two spawn-gate RCE bypasses closed, path confinement made
+  symlink-aware) and the follow-on e2e-sweep + adversarial-review
+  fixes. See `v0.14/README.md`.
+
+- **Future / backlog, WASM plugins.** A `wasm` plugin kind on a
+  `wasmtime` host with a stable WIT interface, a filesystem sandbox, a
+  signed plugin registry, and blessed examples (mock-ratio checker,
+  near-dup detector, debug-statement stripper). Unpinned from a
+  version until the engine work is scheduled.
 
 - **v1.0, Stability.** DSL committed, plugin ABI committed,
   `alint-core` public API frozen, docs site committed.
@@ -1362,23 +1368,28 @@ two of the project's own drift gates — the site's version-pin consistency chec
 alint's `prose-no-em-dash` rule, dogfooded on the site's prose — caught drift that
 very change introduced, and it was fixed before the next release.
 
-## v0.14: WASM plugins
-<!-- roadmap-public: blurb="A wasm plugin kind on a wasmtime host with a stable WIT interface, a filesystem sandbox, and a signed plugin registry." -->
+## v0.14: Security and correctness hardening
+<!-- roadmap-public: blurb="Baseline grandfathering mode plus the post-v0.13 security and correctness audit: two spawn-gate RCE bypasses closed, path confinement made symlink-aware, and the fail-loudly contract tightened across output, CLI, and baseline handling." -->
 
-Bumped again to make room for the engineering-foundations program, which
-took the v0.13.0 cut; otherwise unchanged from the previous post-v0.11 scope.
+The cut that re-grounds alint's trustworthy-governance claims in what the code
+actually guarantees. Two strands: baseline / grandfathering mode (adopt alint
+on a legacy repo as a blocking gate), and a 12-agent adversarial audit of alint
++ alint.org that closed two spawn-gate RCE bypasses (templates + nested
+configs, the recurring `gff` shape), made path confinement symlink-aware, and
+fixed a long tail of output / CLI / baseline correctness. A follow-on
+feature-by-feature e2e sweep and an adversarial review of the remediation
+closed seven more real bugs, each with a revert-sensitive regression test. See
+[`v0.14/README.md`](v0.14/README.md) and CHANGELOG `[Unreleased]`.
 
-- `wasm` plugin kind with a `wasmtime` host, stable WIT
-  interface. Plugins receive their config *post-interpolation*
-  per the v0.11 variable-expansion work, the host resolves
-  `{{env.X}}` references before passing the config dict to the
-  guest, so plugins never see (and can't accidentally exfiltrate)
-  the raw env namespace.
-- Plugin registry scaffolding with signature verification.
-- Bless a few canonical agent-aware semantic plugins
-  (mock-ratio checker, file-similarity / near-dup detector,
-  debug-statement auto-stripper) as documented examples, not
-  bundled, to keep the binary lean.
+- Baseline mode (`alint baseline` + `check --baseline`); design in ADR-0006.
+- Spawn gate re-run on the finalized, template-expanded rule set, tagged by
+  provenance (closes the templates + nested-config bypasses and the `gff`
+  class at once).
+- Path confinement resolves symlinks for config-derived reads; local
+  `extends:` targets confined to the config's directory.
+- Output / CLI / baseline hardening: non-UTF-8 paths no longer crash `json` /
+  `agent`, exit code 3 for internal errors, `fix --format` gated, SARIF /
+  GitLab / JUnit correctness, and the baseline artifact kept out of the walk.
 
 ## v1.0: Stability
 <!-- roadmap-public: blurb="A committed DSL and plugin ABI, a frozen alint-core public API, and a versioned documentation site." -->
@@ -1393,3 +1404,24 @@ took the v0.13.0 cut; otherwise unchanged from the previous post-v0.11 scope.
   deprecation-warning overlap window of one minor release is
   enough for a feature that shipped four days before its
   successor.
+
+## Future / backlog
+<!-- roadmap-public: blurb="A wasm plugin kind on a wasmtime host with a stable WIT interface, a filesystem sandbox, and a signed plugin registry, unpinned from a numbered release until the engine work is scheduled." -->
+
+Scope that is real but deliberately unpinned from a numbered cut, sequenced
+against demand rather than a date.
+
+### WASM plugins
+
+Held the v0.14 slot until the security + correctness hardening pass took it;
+now unversioned until the engine work is scheduled.
+
+- `wasm` plugin kind with a `wasmtime` host, stable WIT interface. Plugins
+  receive their config *post-interpolation* per the v0.11 variable-expansion
+  work: the host resolves `{{env.X}}` references before passing the config
+  dict to the guest, so plugins never see (and can't accidentally exfiltrate)
+  the raw env namespace.
+- Plugin registry scaffolding with signature verification.
+- Bless a few canonical agent-aware semantic plugins (mock-ratio checker,
+  file-similarity / near-dup detector, debug-statement auto-stripper) as
+  documented examples, not bundled, to keep the binary lean.

--- a/docs/design/deterministic-perf-gating.md
+++ b/docs/design/deterministic-perf-gating.md
@@ -1,6 +1,6 @@
 # Deterministic performance gating
 
-**Status:** IN PROGRESS (design approved 2026-06-07)
+**Status:** Implemented — advisory gate live (design approved 2026-06-07); flip to enforcing pending.
 
 ## Motivation
 

--- a/docs/design/v0.14/README.md
+++ b/docs/design/v0.14/README.md
@@ -1,6 +1,7 @@
 # v0.14 — Hardening pass
 
-Status: **In progress.** The v0.14 cut has two halves:
+Status: **In progress** — the hardening remediation is complete; the cut awaits
+its release mechanics. The v0.14 cut has three strands:
 
 1. **Baseline / grandfathering mode** — already landed on CHANGELOG
    `[Unreleased]` (slices 1–4, audit follow-ups #88–#94). Design:
@@ -12,6 +13,16 @@ Status: **In progress.** The v0.14 cut has two halves:
    presence of in-repo symlinks, and a long tail of correctness, output,
    CLI, doc-drift and site-drift findings. The remediation is tracked,
    finding-by-finding, in [`post_v0.13_audit.md`](./post_v0.13_audit.md).
+   **As of 2026-07-03 all CRITICAL + HIGH findings and the full M1–M14
+   cluster have landed**; only the deferred-with-rationale tail remains.
+3. **Post-v0.13 e2e sweep + adversarial-review remediation** (#111–#116) —
+   a feature-by-feature test of everything since v0.13 found five more real
+   bugs (baseline self-lint, a flat-`when:` DoS abort, a non-UTF-8 output
+   crash, a silent `fix --format` degrade, a non-convergent fixer), and an
+   adversarial review of that whole remediation found + fixed two more (the
+   baseline walk-exclusion was `check`-only and over-excluding; a vacuous
+   M5 regression test). Each fix ships with a revert-sensitive test; all
+   tracked in CHANGELOG `[Unreleased]`.
 
 ## Why a hardening pass headlines v0.14
 

--- a/docs/design/v0.14/post_v0.13_audit.md
+++ b/docs/design/v0.14/post_v0.13_audit.md
@@ -43,6 +43,17 @@ point. The keystone fix re-runs the gate on the **finalized,
 template-expanded** rule set, tagged by provenance, which closes all
 three classes at once.
 
+**Remediation status (updated 2026-07-03).** Everything above **landed**: all
+CRITICAL (C1–C2) and HIGH (H1–H5) findings plus the full M1–M14 cluster. The
+only open items are the tracked deferrals — M4 escaping-symlink *detection*, M6
+tracked/changed-path collapse, M3-F2 (TOCTOU) + M3-F7, D11, L2, W6, and H6 —
+each with rationale inline. The findings below read as the audit originally
+recorded them (present-tense "is a bypass" = as-found, not as-shipped); the
+per-finding `[x]`/`[~]`/`[-]` markers and the phase plan are the live status.
+Follow-on work surfaced *after* this audit (the post-v0.13 e2e sweep and the
+adversarial review of the remediation, PRs #111–#116) is tracked in the
+CHANGELOG `[Unreleased]`, not here.
+
 ---
 
 ## Phase plan
@@ -52,7 +63,7 @@ three classes at once.
 | 1 | CRITICAL — spawn-gate RCE | C1, C2 | `[x]` |
 | 2 | HIGH — security | H1, H2, H5 | `[x]` |
 | 3 | HIGH — correctness | H3, H4 | `[x]` |
-| 4 | MEDIUM — security cluster | M1–M8 | `[~]` (M1/M2/M3/M5/M6/M7/M8 done; M4 partial — dir symlinks done, escaping deferred) |
+| 4 | MEDIUM — security cluster | M1–M8 | `[~]` (M1/M2/M3/M5/M7/M8 done; M4 partial — dir symlinks done, escaping deferred; M6 partial — commit-lint bypass closed, tracked/changed-path collapse deferred) |
 | 5 | MEDIUM — output / CLI / baseline | M9–M14 | `[x]` (M9–M14 all done) |
 | 6 | Docs + LOW cleanup + dogfooding (alint) | D1–D12, L1–L14 | `[~]` (D1–D10,D12 + L1,L3–L14 + Dog1/Dog2 done; L2 partial; D11 deferred) |
 | 7 | alint.org drift | W1–W7 | `[x]` (W1–W5,W7 done on the site branch; W6 partial) |
@@ -353,7 +364,10 @@ that H1/ADR-0004 close — needs a "yielded but non-readable" entry concept
 `is_symlink` flag the per-file read path honors). That's a
 security-sensitive walk/read-path change that genuinely wants its own
 reviewed pass; rushing it risks reintroducing the confinement threat.
-Tracked.
+Tracked. **The user-facing gap is now closed** (review follow-up, #116):
+`docs/rules.md`'s `no_symlinks` section documents that an escaping symlink is
+pruned pre-index and not flagged, so a reader adopting the rule as a guardrail
+isn't misled while the *detection* stays deferred.
 
 ### M5 — `git_no_denied_paths` denylist root-anchors bare literals `[x]`
 **Where:** `git_no_denied_paths.rs`. For a *secrets* control, a bare *literal*

--- a/roadmap.json
+++ b/roadmap.json
@@ -81,15 +81,21 @@
     },
     {
       "version": "0.14",
-      "title": "WASM plugins",
+      "title": "Security and correctness hardening",
       "kind": "release",
-      "blurb": "A wasm plugin kind on a wasmtime host with a stable WIT interface, a filesystem sandbox, and a signed plugin registry."
+      "blurb": "Baseline grandfathering mode plus the post-v0.13 security and correctness audit: two spawn-gate RCE bypasses closed, path confinement made symlink-aware, and the fail-loudly contract tightened across output, CLI, and baseline handling."
     },
     {
       "version": "1.0",
       "title": "Stability",
       "kind": "release",
       "blurb": "A committed DSL and plugin ABI, a frozen alint-core public API, and a versioned documentation site."
+    },
+    {
+      "version": null,
+      "title": "Future / backlog",
+      "kind": "foundations",
+      "blurb": "A wasm plugin kind on a wasmtime host with a stable WIT interface, a filesystem sandbox, and a signed plugin registry, unpinned from a numbered release until the engine work is scheduled."
     }
   ]
 }


### PR DESCRIPTION
A consistency sweep so every status / plan / tracking surface matches what
actually landed for v0.14 (post-v0.13 audit + e2e sweep + adversarial review,
#110-#116).

**Real inconsistency fixed:** ROADMAP.md + roadmap.json still listed v0.14 as
"WASM plugins", but the hardening pass took that slot. v0.14 is now "Security
and correctness hardening" (versioned); WASM plugins moves to an unversioned
Future / backlog phase. roadmap.json regenerated (gen-roadmap --check green;
AI-signal + doc-links gates pass).

**Also reconciled:**
- post_v0.13_audit.md: "Remediation status" banner on the Verdict (it read as
  if the RCE/confinement findings were still open); fixed the phase-plan table
  where M6 was grouped "done" but its section is `[~]`; noted the #116
  no_symlinks doc caveat in M4.
- docs/design/v0.14/README.md: two halves -> three strands (adds the e2e sweep
  + review remediation); hardening marked complete.
- deterministic-perf-gating.md: Status IN PROGRESS -> Implemented (advisory).
- RELEASING.md: add alint-lsp to the Cargo.lock crate list.

**Decisions applied:** v0.14 framing = hardening / WASM -> Future/backlog;
advisories = CHANGELOG-only (SECURITY.md stays accurate, no change).

**Verified current, no change needed:** CHANGELOG [Unreleased] completeness,
README counts (89 kinds / 13 families / 22 rulesets / 8 formats / 11
subcommands), formal-methods.md H1 lexical-scoping, exit-code docs, crate
lists, MSRV, GOVERNANCE version. Docs-only; local preflight fully green.