### PR TITLE
refactor(rules): git_tracked_only + respect_gitignore are kind-specific options (ADR-0008)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   iff `fix_available`. Lets an agent run the fix programmatically instead of
   parsing the command out of the English `agent_instruction`.
 
+### Changed
+
+- **`git_tracked_only` is now a kind-specific option, rejected off the existence
+  family (ADR-0008).** It moved off the common `RuleSpec` into the `file_exists` /
+  `file_absent` / `dir_exists` / `dir_absent` options, so a rule of any other kind
+  that sets `git_tracked_only:` now fails to load with a clean error instead of
+  silently ignoring it (the fail-loud the field's doc-comment always promised).
+  This is a stricter load: a config that set `git_tracked_only` on a kind that
+  never honored it now errors. `respect_gitignore` moves the opposite way, into
+  the common schema, so it is permitted on any rule (a benign, forward-compatible
+  walker override). The four existence kinds are now schemars-derived, which also
+  fills their previously-empty `git_tracked_only` option descriptions.
+
 ### Fixed
 
 - **Auto-fixers no longer corrupt binaries or risk truncation on failure.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,16 +59,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- **`git_tracked_only` is now a kind-specific option, rejected off the existence
-  family (ADR-0008).** It moved off the common `RuleSpec` into the `file_exists` /
-  `file_absent` / `dir_exists` / `dir_absent` options, so a rule of any other kind
-  that sets `git_tracked_only:` now fails to load with a clean error instead of
-  silently ignoring it (the fail-loud the field's doc-comment always promised).
-  This is a stricter load: a config that set `git_tracked_only` on a kind that
-  never honored it now errors. `respect_gitignore` moves the opposite way, into
-  the common schema, so it is permitted on any rule (a benign, forward-compatible
-  walker override). The four existence kinds are now schemars-derived, which also
-  fills their previously-empty `git_tracked_only` option descriptions.
+- **`git_tracked_only` and `respect_gitignore` are now kind-specific options,
+  rejected off the kinds that honor them (ADR-0008).** Both moved off the common
+  `RuleSpec` into per-kind options: `git_tracked_only` into the four existence
+  kinds (`file_exists` / `file_absent` / `dir_exists` / `dir_absent`), and the
+  per-rule `respect_gitignore` override into `file_exists` alone (the only kind
+  that honors it - the pitfall-#18 escape hatch). A rule that sets either field on
+  a kind that does not honor it now fails to load with a clean error instead of
+  silently ignoring it (the fail-loud the fields' doc-comments always promised).
+  This is a stricter load: configs that set `git_tracked_only` on a non-existence
+  kind, or `respect_gitignore` on any kind but `file_exists`, used to load and
+  no-op and now error. The workspace-level `respect_gitignore:` walker setting is
+  unaffected. The four existence kinds are now schemars-derived, which also fills
+  their previously-empty option descriptions.
 
 ### Fixed
 

--- a/crates/alint-core/src/config.rs
+++ b/crates/alint-core/src/config.rs
@@ -285,19 +285,12 @@ pub struct RuleSpec {
     /// at build time.
     #[serde(default)]
     pub fix: Option<FixSpec>,
-    /// Restrict the rule to files / directories tracked in git's index.
-    /// When `true`, the rule's `paths`-matched entries are intersected
-    /// with the set of git-tracked files; entries that exist in the
-    /// walked tree but aren't in `git ls-files` output are skipped.
-    /// Only meaningful for rule kinds that opt in (currently the
-    /// existence family — `file_exists`, `file_absent`, `dir_exists`,
-    /// `dir_absent`); rule kinds that don't support it surface a clean
-    /// config error when this is `true` so silent mis-configuration
-    /// doesn't slip through.
-    ///
-    /// Default `false`. Has no effect outside a git repo.
-    #[serde(default)]
-    pub git_tracked_only: bool,
+    // `git_tracked_only` is NOT a RuleSpec field: it is a kind-specific option
+    // on the existence family (`file_exists`/`file_absent`/`dir_exists`/
+    // `dir_absent`), declared in each kind's `Options` struct so a rule of any
+    // other kind that sets it is rejected at load by `deny_unknown_fields`
+    // (ADR-0008). The engine reads the `Rule::git_tracked_mode()` trait method,
+    // never a RuleSpec field, so nothing here needs it.
     /// Per-rule override for the workspace-level
     /// `respect_gitignore:` setting. When `Some(false)`, this
     /// rule treats `.gitignore`-listed files as if they were
@@ -724,12 +717,12 @@ impl NestedRuleSpec {
             policy_url: self.policy_url.clone(),
             when: self.when.clone(),
             fix: None,
-            // Nested rules don't currently expose
-            // `git_tracked_only` or `respect_gitignore` from their
-            // parent's spec — both options are meaningful on
-            // top-level rules only for now. If/when `for_each_dir`'s
-            // nested rules need either, plumb them through here.
-            git_tracked_only: false,
+            // `respect_gitignore` is not exposed from a nested rule's parent
+            // spec (top-level-only for now). `git_tracked_only` is now a
+            // kind-specific option (ADR-0008), stripped from the nested `extra`
+            // via PARENT_FIELDS below, so a nested existence rule doesn't
+            // silently inherit it. If/when nested rules need either, plumb them
+            // through here (and, for git_tracked_only, drop it from PARENT_FIELDS).
             respect_gitignore: None,
             scope_filter: self.scope_filter.clone(),
             // `NestedRuleSpec` doesn't name `id`/`level` (synthesized from the
@@ -986,8 +979,15 @@ mod tests {
             other => panic!("unexpected paths shape: {other:?}"),
         }
         assert_eq!(spec.message.as_deref(), Some("missing in packages/foo"));
-        // Nested rules don't propagate git_tracked_only — the
-        // option is meaningful on top-level rules only.
-        assert!(!spec.git_tracked_only);
+        // Nested rules don't propagate git_tracked_only: it is a kind-specific
+        // option (ADR-0008) stripped from the nested `extra` via PARENT_FIELDS,
+        // so it never reaches the leaf rule's options.
+        assert!(
+            !spec
+                .extra
+                .keys()
+                .any(|k| k.as_str() == Some("git_tracked_only")),
+            "git_tracked_only should be stripped from nested extra"
+        );
     }
 }

--- a/crates/alint-core/src/config.rs
+++ b/crates/alint-core/src/config.rs
@@ -285,34 +285,16 @@ pub struct RuleSpec {
     /// at build time.
     #[serde(default)]
     pub fix: Option<FixSpec>,
-    // `git_tracked_only` is NOT a RuleSpec field: it is a kind-specific option
-    // on the existence family (`file_exists`/`file_absent`/`dir_exists`/
-    // `dir_absent`), declared in each kind's `Options` struct so a rule of any
-    // other kind that sets it is rejected at load by `deny_unknown_fields`
-    // (ADR-0008). The engine reads the `Rule::git_tracked_mode()` trait method,
-    // never a RuleSpec field, so nothing here needs it.
-    /// Per-rule override for the workspace-level
-    /// `respect_gitignore:` setting. When `Some(false)`, this
-    /// rule treats `.gitignore`-listed files as if they were
-    /// untracked-but-on-disk: the rule sees them. The canonical
-    /// use case is the bazel-style "tracked AND gitignored"
-    /// pattern (a file like `.bazelversion` ships a default
-    /// upstream and contributors override it locally without
-    /// committing the override) — the workspace walker honours
-    /// the gitignore, so `file_exists` reports "no match"
-    /// against a file that's both on disk AND in `git ls-files`.
-    /// This per-rule knob lets that single rule see the file
-    /// without flipping the workspace-wide setting.
-    ///
-    /// Currently honoured by `file_exists` for literal-path
-    /// patterns (the common case the pitfall surfaced). Other
-    /// rule kinds + glob patterns fall through to the workspace
-    /// setting; future versions will broaden coverage.
-    ///
-    /// Default `None` (inherit the workspace `respect_gitignore`).
-    /// See `docs/development/CONFIG-AUTHORING.md` pitfall #18.
-    #[serde(default)]
-    pub respect_gitignore: Option<bool>,
+    // Neither `git_tracked_only` nor `respect_gitignore` is a RuleSpec field:
+    // both are kind-specific options (ADR-0008). `git_tracked_only` lives in
+    // each existence kind's `Options` struct (`file_exists`/`file_absent`/
+    // `dir_exists`/`dir_absent`) — the engine reads it via the
+    // `Rule::git_tracked_mode()` trait method, never a RuleSpec field.
+    // `respect_gitignore` lives only in `file_exists`'s `Options` — the sole
+    // kind that honours a per-rule override (the bazel-style "tracked AND
+    // gitignored" pitfall #18). Keeping both off `rule_common` means a rule of
+    // any other kind that sets either is rejected at load by
+    // `deny_unknown_fields`, rather than silently ignored.
     /// Per-file ancestor-manifest gate. When set, the rule
     /// only fires on files that have at least one ancestor
     /// directory (including the file's own directory)
@@ -717,13 +699,11 @@ impl NestedRuleSpec {
             policy_url: self.policy_url.clone(),
             when: self.when.clone(),
             fix: None,
-            // `respect_gitignore` is not exposed from a nested rule's parent
-            // spec (top-level-only for now). `git_tracked_only` is now a
-            // kind-specific option (ADR-0008), stripped from the nested `extra`
-            // via PARENT_FIELDS below, so a nested existence rule doesn't
-            // silently inherit it. If/when nested rules need either, plumb them
-            // through here (and, for git_tracked_only, drop it from PARENT_FIELDS).
-            respect_gitignore: None,
+            // `git_tracked_only` and `respect_gitignore` are both kind-specific
+            // options now (ADR-0008), stripped from the nested `extra` via
+            // PARENT_FIELDS below, so a nested existence rule doesn't silently
+            // inherit either. If/when nested rules need one, drop it from
+            // PARENT_FIELDS and let it flow into the leaf's option set.
             scope_filter: self.scope_filter.clone(),
             // `NestedRuleSpec` doesn't name `id`/`level` (synthesized from the
             // parent) or the top-level-only `fix`/git toggles, so a nested

--- a/crates/alint-core/src/registry.rs
+++ b/crates/alint-core/src/registry.rs
@@ -94,7 +94,6 @@ mod tests {
             policy_url: None,
             when: None,
             fix: None,
-            git_tracked_only: false,
             respect_gitignore: None,
             scope_filter: None,
             extra: serde_yaml_ng::Mapping::new(),

--- a/crates/alint-core/src/registry.rs
+++ b/crates/alint-core/src/registry.rs
@@ -94,7 +94,6 @@ mod tests {
             policy_url: None,
             when: None,
             fix: None,
-            respect_gitignore: None,
             scope_filter: None,
             extra: serde_yaml_ng::Mapping::new(),
         }

--- a/crates/alint-dsl/schemas/v1/config.json
+++ b/crates/alint-dsl/schemas/v1/config.json
@@ -662,10 +662,6 @@
         }
       ]
     },
-    "per_rule_respect_gitignore": {
-      "description": "Per-rule override for the workspace-level `respect_gitignore:` setting. When `false`, this rule treats `.gitignore`-listed files as if they were untracked-but-on-disk: the rule sees them. The canonical use case is the bazel-style \"tracked AND gitignored\" pattern (a file like `.bazelversion` ships a default upstream and contributors override it locally without committing the override) — the workspace walker honours the gitignore, so `file_exists` reports \"no match\" against a file that's both on disk AND in `git ls-files`. This per-rule knob lets that single rule see the file without flipping the workspace-wide setting. Currently honoured by `file_exists` for literal-path patterns; other rule kinds + glob patterns fall through to the workspace setting. Default: inherit the workspace `respect_gitignore`. See `docs/development/CONFIG-AUTHORING.md` pitfall #18.",
-      "type": "boolean"
-    },
     "rule": {
       "description": "A rule entry — either a kind-driven rule (with `kind` and the kind-specific fields) or a template instance (with `extends_template` referencing a template id and optional `vars` overrides).",
       "oneOf": [
@@ -867,9 +863,6 @@
           "description": "Link to a human-readable policy justification.",
           "format": "uri",
           "type": "string"
-        },
-        "respect_gitignore": {
-          "$ref": "#/$defs/per_rule_respect_gitignore"
         },
         "scope_filter": {
           "$ref": "#/$defs/scope_filter"
@@ -1299,6 +1292,14 @@
         },
         "paths": {
           "$ref": "#/$defs/paths_spec"
+        },
+        "respect_gitignore": {
+          "default": null,
+          "description": "Per-rule override for the workspace `respect_gitignore` setting. When `false`, this rule's literal-path checks also stat the filesystem directly, so it sees files that are tracked AND `.gitignore`-masked (the bazel-style `.bazelversion` pattern — pitfall #18 in `docs/development/CONFIG-AUTHORING.md`). Honoured only by `file_exists` literal paths; glob patterns fall through to the workspace setting. Default: inherit the workspace `respect_gitignore`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "root_only": {
           "default": false,

--- a/crates/alint-dsl/schemas/v1/config.json
+++ b/crates/alint-dsl/schemas/v1/config.json
@@ -868,6 +868,9 @@
           "format": "uri",
           "type": "string"
         },
+        "respect_gitignore": {
+          "$ref": "#/$defs/per_rule_respect_gitignore"
+        },
         "scope_filter": {
           "$ref": "#/$defs/scope_filter"
         },
@@ -1010,7 +1013,9 @@
     "rule_dir_absent": {
       "properties": {
         "git_tracked_only": {
-          "$ref": "#/$defs/git_tracked_only"
+          "default": false,
+          "description": "Restrict matches to directories that contain at least one git-tracked file. No effect outside a git repo. Default `false`.",
+          "type": "boolean"
         },
         "kind": {
           "const": "dir_absent"
@@ -1020,7 +1025,7 @@
         },
         "root_only": {
           "default": false,
-          "description": "If true, only a directory directly at the repository root is forbidden.",
+          "description": "If true, only a directory directly at the repository root is forbidden; a nested match with the same name is allowed.",
           "type": "boolean",
           "x-since": "0.14"
         }
@@ -1064,7 +1069,9 @@
     "rule_dir_exists": {
       "properties": {
         "git_tracked_only": {
-          "$ref": "#/$defs/git_tracked_only"
+          "default": false,
+          "description": "Restrict matches to directories that contain at least one git-tracked file. No effect outside a git repo. Default `false`.",
+          "type": "boolean"
         },
         "kind": {
           "const": "dir_exists"
@@ -1074,7 +1081,7 @@
         },
         "root_only": {
           "default": false,
-          "description": "If true, only a directory directly at the repository root satisfies the rule.",
+          "description": "If true, only a directory directly at the repository root satisfies the rule; a nested match does not.",
           "type": "boolean",
           "x-since": "0.14"
         }
@@ -1193,7 +1200,9 @@
     "rule_file_absent": {
       "properties": {
         "git_tracked_only": {
-          "$ref": "#/$defs/git_tracked_only"
+          "default": false,
+          "description": "Restrict matches to files tracked in git's index: entries present in the walked tree but not in `git ls-files` are skipped. No effect outside a git repo. Default `false`.",
+          "type": "boolean"
         },
         "kind": {
           "const": "file_absent"
@@ -1203,7 +1212,7 @@
         },
         "root_only": {
           "default": false,
-          "description": "If true, only a file directly at the repository root is forbidden.",
+          "description": "If true, only a file matching `paths` directly at the repository root is forbidden; a nested match with the same name is allowed.",
           "type": "boolean",
           "x-since": "0.14"
         }
@@ -1281,16 +1290,15 @@
     "rule_file_exists": {
       "properties": {
         "git_tracked_only": {
-          "$ref": "#/$defs/git_tracked_only"
+          "default": false,
+          "description": "Restrict matches to files tracked in git's index: entries present in the walked tree but not in `git ls-files` are skipped. No effect outside a git repo. Default `false`.",
+          "type": "boolean"
         },
         "kind": {
           "const": "file_exists"
         },
         "paths": {
           "$ref": "#/$defs/paths_spec"
-        },
-        "respect_gitignore": {
-          "$ref": "#/$defs/per_rule_respect_gitignore"
         },
         "root_only": {
           "default": false,

--- a/crates/alint-rules/src/dir_absent.rs
+++ b/crates/alint-rules/src/dir_absent.rs
@@ -3,15 +3,21 @@
 use alint_core::{Context, Error, Level, PathsSpec, Result, Rule, RuleSpec, Scope, Violation};
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// When `true`, only forbid a directory directly at the repo root; a nested
-    /// directory with the same name is allowed. Mirrors `file_exists`'s
-    /// `root_only`.
+    /// If true, only a directory directly at the repository root is forbidden; a
+    /// nested match with the same name is allowed.
+    #[schemars(extend("x-since" = "0.14"))]
     #[serde(default)]
     root_only: bool,
+    /// Restrict matches to directories that contain at least one git-tracked
+    /// file. No effect outside a git repo. Default `false`.
+    #[serde(default)]
+    git_tracked_only: bool,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct DirAbsentRule {
@@ -104,7 +110,7 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
         scope: Scope::from_spec(spec)?,
         patterns: patterns_of(paths),
         root_only: opts.root_only,
-        git_tracked_only: spec.git_tracked_only,
+        git_tracked_only: opts.git_tracked_only,
     }))
 }
 

--- a/crates/alint-rules/src/dir_exists.rs
+++ b/crates/alint-rules/src/dir_exists.rs
@@ -3,14 +3,21 @@
 use alint_core::{Context, Error, Level, PathsSpec, Result, Rule, RuleSpec, Scope, Violation};
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// When `true`, only a directory directly at the repo root satisfies the
-    /// rule. Mirrors `file_exists`'s `root_only`.
+    /// If true, only a directory directly at the repository root satisfies the
+    /// rule; a nested match does not.
+    #[schemars(extend("x-since" = "0.14"))]
     #[serde(default)]
     root_only: bool,
+    /// Restrict matches to directories that contain at least one git-tracked
+    /// file. No effect outside a git repo. Default `false`.
+    #[serde(default)]
+    git_tracked_only: bool,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct DirExistsRule {
@@ -108,7 +115,7 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
         scope: Scope::from_paths_spec(paths)?,
         patterns: patterns_of(paths),
         root_only: opts.root_only,
-        git_tracked_only: spec.git_tracked_only,
+        git_tracked_only: opts.git_tracked_only,
     }))
 }
 

--- a/crates/alint-rules/src/executable_bit.rs
+++ b/crates/alint-rules/src/executable_bit.rs
@@ -168,6 +168,27 @@ mod tests {
         );
     }
 
+    /// ADR-0008: `respect_gitignore` is a `file_exists`-only option (the
+    /// pitfall-#18 escape hatch), NOT a `rule_common` field. A non-existence
+    /// kind that receives it must reject it at load — the fail-loud it lacked
+    /// while the field lived on `rule_common` (where `no_bom: respect_gitignore`
+    /// validated, loaded, and was silently ignored).
+    #[test]
+    fn build_rejects_respect_gitignore_on_non_existence_kind() {
+        let spec = spec_yaml(
+            "id: t\n\
+             kind: executable_bit\n\
+             paths: \"scripts/**\"\n\
+             require: true\n\
+             respect_gitignore: false\n\
+             level: error\n",
+        );
+        assert!(
+            build(&spec).is_err(),
+            "respect_gitignore must be rejected on a non-existence kind (ADR-0008)"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn evaluate_fires_when_exec_required_but_missing() {

--- a/crates/alint-rules/src/executable_bit.rs
+++ b/crates/alint-rules/src/executable_bit.rs
@@ -147,6 +147,27 @@ mod tests {
         assert!(build(&spec).is_err());
     }
 
+    /// ADR-0008: `git_tracked_only` is a kind-specific option on the existence
+    /// family only. A non-existence kind that receives it must reject it at load
+    /// (via the Options `deny_unknown_fields`) rather than silently ignore it.
+    /// This is the fail-loud the divergence used to lack; if it regresses (e.g.
+    /// `git_tracked_only` drifts back onto `RuleSpec`), this test fails.
+    #[test]
+    fn build_rejects_git_tracked_only_on_non_existence_kind() {
+        let spec = spec_yaml(
+            "id: t\n\
+             kind: executable_bit\n\
+             paths: \"scripts/**\"\n\
+             require: true\n\
+             git_tracked_only: true\n\
+             level: error\n",
+        );
+        assert!(
+            build(&spec).is_err(),
+            "git_tracked_only must be rejected on a non-existence kind (ADR-0008)"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn evaluate_fires_when_exec_required_but_missing() {

--- a/crates/alint-rules/src/file_absent.rs
+++ b/crates/alint-rules/src/file_absent.rs
@@ -248,6 +248,26 @@ mod tests {
         );
     }
 
+    /// ADR-0008: `respect_gitignore` is honoured ONLY by `file_exists` (pitfall
+    /// #18), so it lives solely in `file_exists`'s `Options`. A sibling
+    /// existence kind like `file_absent` must reject it at load rather than
+    /// accept-and-ignore — the subtle case where a user assumes every existence
+    /// kind shares the option.
+    #[test]
+    fn build_rejects_respect_gitignore_sibling_existence_kind() {
+        let spec = spec_yaml(
+            "id: t\n\
+             kind: file_absent\n\
+             paths: \"*.bak\"\n\
+             level: error\n\
+             respect_gitignore: false\n",
+        );
+        assert!(
+            build(&spec).is_err(),
+            "respect_gitignore must be rejected on file_absent (file_exists-only, ADR-0008)"
+        );
+    }
+
     #[test]
     fn rule_advertises_full_index_requirement() {
         // Existence-axis rules opt out of changed-mode

--- a/crates/alint-rules/src/file_absent.rs
+++ b/crates/alint-rules/src/file_absent.rs
@@ -7,14 +7,22 @@ use serde::Deserialize;
 
 use crate::fixers::FileRemoveFixer;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
-    /// When `true`, only forbid matches directly at the repo root; a nested
-    /// file with the same name is allowed. Mirrors `file_exists`'s `root_only`.
+    /// If true, only a file matching `paths` directly at the repository root is
+    /// forbidden; a nested match with the same name is allowed.
+    #[schemars(extend("x-since" = "0.14"))]
     #[serde(default)]
     root_only: bool,
+    /// Restrict matches to files tracked in git's index: entries present in the
+    /// walked tree but not in `git ls-files` are skipped. No effect outside a
+    /// git repo. Default `false`.
+    #[serde(default)]
+    git_tracked_only: bool,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct FileAbsentRule {
@@ -122,7 +130,7 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
         scope: Scope::from_paths_spec(paths)?,
         patterns: patterns_of(paths),
         root_only: opts.root_only,
-        git_tracked_only: spec.git_tracked_only,
+        git_tracked_only: opts.git_tracked_only,
         fixer,
     }))
 }

--- a/crates/alint-rules/src/file_exists.rs
+++ b/crates/alint-rules/src/file_exists.rs
@@ -10,12 +10,20 @@ use serde::Deserialize;
 
 use crate::fixers::FileCreateFixer;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct Options {
+    /// If true, only files directly at the repository root satisfy the rule.
     #[serde(default)]
     root_only: bool,
+    /// Restrict matches to files tracked in git's index: entries present in the
+    /// walked tree but not in `git ls-files` are skipped. No effect outside a
+    /// git repo. Default `false`.
+    #[serde(default)]
+    git_tracked_only: bool,
 }
+
+crate::options_schema_for!(Options);
 
 #[derive(Debug)]
 pub struct FileExistsRule {
@@ -262,7 +270,7 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
         patterns,
         literal_paths,
         root_only: opts.root_only,
-        git_tracked_only: spec.git_tracked_only,
+        git_tracked_only: opts.git_tracked_only,
         respect_gitignore: spec.respect_gitignore,
         fixer,
     }))

--- a/crates/alint-rules/src/file_exists.rs
+++ b/crates/alint-rules/src/file_exists.rs
@@ -21,6 +21,15 @@ struct Options {
     /// git repo. Default `false`.
     #[serde(default)]
     git_tracked_only: bool,
+    /// Per-rule override for the workspace `respect_gitignore` setting. When
+    /// `false`, this rule's literal-path checks also stat the filesystem
+    /// directly, so it sees files that are tracked AND `.gitignore`-masked
+    /// (the bazel-style `.bazelversion` pattern — pitfall #18 in
+    /// `docs/development/CONFIG-AUTHORING.md`). Honoured only by `file_exists`
+    /// literal paths; glob patterns fall through to the workspace setting.
+    /// Default: inherit the workspace `respect_gitignore`.
+    #[serde(default)]
+    respect_gitignore: Option<bool>,
 }
 
 crate::options_schema_for!(Options);
@@ -271,7 +280,7 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
         literal_paths,
         root_only: opts.root_only,
         git_tracked_only: opts.git_tracked_only,
-        respect_gitignore: spec.respect_gitignore,
+        respect_gitignore: opts.respect_gitignore,
         fixer,
     }))
 }

--- a/crates/alint-rules/src/lib.rs
+++ b/crates/alint-rules/src/lib.rs
@@ -146,6 +146,10 @@ pub mod unique_by;
 #[allow(clippy::too_many_lines)]
 pub fn migrated_option_schemas() -> Vec<(&'static str, serde_json::Value)> {
     vec![
+        ("rule_file_exists", file_exists::options_schema()),
+        ("rule_file_absent", file_absent::options_schema()),
+        ("rule_dir_exists", dir_exists::options_schema()),
+        ("rule_dir_absent", dir_absent::options_schema()),
         ("rule_file_header", file_header::options_schema()),
         ("rule_file_footer", file_footer::options_schema()),
         ("rule_file_max_size", file_max_size::options_schema()),

--- a/crates/alint/src/export_agents_md/mod.rs
+++ b/crates/alint/src/export_agents_md/mod.rs
@@ -266,7 +266,6 @@ mod tests {
             policy_url: None,
             when: None,
             fix: None,
-            respect_gitignore: None,
             scope_filter: None,
             extra: serde_yaml_ng::Mapping::new(),
         }

--- a/crates/alint/src/export_agents_md/mod.rs
+++ b/crates/alint/src/export_agents_md/mod.rs
@@ -266,7 +266,6 @@ mod tests {
             policy_url: None,
             when: None,
             fix: None,
-            git_tracked_only: false,
             respect_gitignore: None,
             scope_filter: None,
             extra: serde_yaml_ng::Mapping::new(),

--- a/docs/adr/0008-git-tracked-only-is-a-kind-option.md
+++ b/docs/adr/0008-git-tracked-only-is-a-kind-option.md
@@ -1,0 +1,109 @@
+---
+status: accepted
+date: 2026-07-04
+decision-makers: asamarts
+---
+
+# 0008. `git_tracked_only` is a kind-specific option; `respect_gitignore` is common
+
+## Status
+
+Accepted. (One of: Proposed | Accepted | Rejected | Deprecated | Superseded by ADR-NNNN.)
+
+## Context
+
+`git_tracked_only` and `respect_gitignore` are the only two fields that live in a
+per-kind schema branch while also being `RuleSpec` struct fields (all other
+universal fields live in the shared `rule_common` schema def, and all other
+kind-specific options live in the kind's `Options` struct, deserialized from
+`RuleSpec.extra`). That split produces a real inconsistency:
+
+- **The schema is stricter than the loader.** The generated JSON Schema only
+  lists `git_tracked_only` on the four existence branches
+  (`file_exists`/`file_absent`/`dir_exists`/`dir_absent`), so an editor rejects
+  it elsewhere. But because it is a `RuleSpec` field, the loader *accepts* it on
+  any rule and the rule silently ignores it (`git_tracked_mode()` returns the
+  default `Off`). The `RuleSpec.git_tracked_only` doc-comment even promises that
+  "rule kinds that don't support it surface a clean config error" - that error
+  is **not implemented anywhere**. The v0.12 audit noted the divergence and
+  filed it as a not-a-bug ("schema stricter than loader is the safe direction"),
+  but the loader's silent-ignore is a latent fail-quietly gap.
+- **It blocks the type-derived schema.** Because `git_tracked_only` is not in the
+  existence kinds' `Options` structs, those kinds cannot be migrated to
+  schemars-derived schema (ADR-0001): the derivation would emit only `root_only`
+  and drop `git_tracked_only`. So the existence kinds keep a hand-authored schema
+  branch with undocumented options and a hand-edited `x-since` (ADR-0007).
+
+The two fields have *opposite* semantics, which points at opposite fixes:
+
+- `git_tracked_only` is a **hard opt-in** honored only by the existence family; it
+  changes the rule's index semantics. Setting it on any other kind is a genuine
+  mistake that should fail loudly.
+- `respect_gitignore` is a **benign, forward-compatible per-rule override** of the
+  workspace walker setting. Only `file_exists` honors it today, but by design
+  future kinds broaden coverage, and where a kind does not honor it the value
+  simply falls through to the workspace default. Setting it on a not-yet-covered
+  kind is harmless.
+
+Driver: close the divergence, deliver the fail-loud the doc-comment promises, and
+unblock the type-derived schema. Design doc:
+[git-tracked-kind-option.md](../design/v0.14/git-tracked-kind-option.md). Related:
+ADR-0001 (schema derived from Rust types), ADR-0007 (`x-since`).
+
+## Decision
+
+We will place each field where its semantics belong.
+
+1. **`git_tracked_only` becomes a kind-specific option.** Remove it from
+   `RuleSpec`; add it to the four existence `Options` structs (schemars-derived,
+   `deny_unknown_fields`); each `build()` reads `opts.git_tracked_only`; the
+   engine is unchanged (it reads the `git_tracked_mode()` trait method). Because
+   the field now flows through `RuleSpec.extra` into the kind's `Options`, every
+   non-existence kind's `deny_unknown_fields` rejects it at load with a clean
+   error - uniformly, with no ad-hoc per-kind checks - so the loader is now
+   exactly as strict as the schema, and the doc-comment's promise becomes true.
+   The four existence kinds are migrated to schemars in the same change, which
+   makes `x-since` type-derived and fills their empty Options descriptions.
+
+2. **`respect_gitignore` becomes a common field.** It stays a `RuleSpec` field
+   (the engine/walker plumbing is unchanged), but its schema representation moves
+   from the `file_exists` branch into `rule_common`, so it is universally
+   permitted and forward-compatible. Schema and loader agree: both allow it on
+   any rule, and it is honored where supported.
+
+## Consequences
+
+Easier: schema and loader agree for both fields (no divergence, no editor-vs-CLI
+surprise); a misplaced `git_tracked_only` now fails loudly at load instead of
+silently no-op'ing; the existence kinds gain type-derived schema, documented
+options, and type-derived `x-since`; and two ad-hoc concepts collapse into the
+uniform `Options`/`rule_common` mechanisms the rest of the catalog already uses.
+
+Harder / risk: this is a **validation tightening** - a config that (incorrectly)
+set `git_tracked_only` on a non-existence kind used to load and silently ignore
+it, and now errors. Such a config was already a no-op mistake, and this ships in
+the v0.14 "fail loudly" cut, so surfacing it is the intended direction; but it is
+technically a stricter load, noted for the changelog. `respect_gitignore` moving
+to `rule_common` is a slight loosening (now permitted on every kind), which is
+correct for a benign forward-compatible knob but does mean the schema no longer
+flags it on a kind that does not yet honor it.
+
+## Considered Options
+
+- **Chosen: split by semantics** (`git_tracked_only` kind-specific,
+  `respect_gitignore` common).
+- **Both into `rule_common`.** Uniform but wrong for `git_tracked_only`: it would
+  keep silently ignoring a real misconfiguration instead of failing loud.
+- **Schema-only `Options` fields** (declare the fields for schemars but keep
+  reading them from `spec.*`). Unblocks the migration without moving ownership,
+  but leaves `Options` fields nothing reads (a smell) and does not fix the
+  divergence.
+- **Keep the hand-edited schema + just fill descriptions.** Safe and in-scope for
+  the doc-drift cleanup, but leaves the wart and the aspirational doc-comment.
+
+## More Information
+
+Design, type-level detail, and the implementation/test plan:
+[git-tracked-kind-option.md](../design/v0.14/git-tracked-kind-option.md).
+Related: ADR-0001, ADR-0007, and the post-v0.12 audit's "schema stricter than
+loader" note (`docs/design/v0.12/`). Implementation PR linked on merge.

--- a/docs/adr/0008-git-tracked-only-is-a-kind-option.md
+++ b/docs/adr/0008-git-tracked-only-is-a-kind-option.md
@@ -4,7 +4,7 @@ date: 2026-07-04
 decision-makers: asamarts
 ---
 
-# 0008. `git_tracked_only` is a kind-specific option; `respect_gitignore` is common
+# 0008. `git_tracked_only` and `respect_gitignore` are kind-specific options
 
 ## Status
 
@@ -12,38 +12,46 @@ Accepted. (One of: Proposed | Accepted | Rejected | Deprecated | Superseded by A
 
 ## Context
 
-`git_tracked_only` and `respect_gitignore` are the only two fields that live in a
-per-kind schema branch while also being `RuleSpec` struct fields (all other
-universal fields live in the shared `rule_common` schema def, and all other
-kind-specific options live in the kind's `Options` struct, deserialized from
-`RuleSpec.extra`). That split produces a real inconsistency:
+`git_tracked_only` and `respect_gitignore` were the only two fields that lived in a
+per-kind schema branch while also being `RuleSpec` struct fields. Every other
+universal field lives in the shared `rule_common` schema def; every other
+kind-specific option lives in the kind's `Options` struct, deserialized from
+`RuleSpec.extra`. Housing these two on `RuleSpec` produced a real inconsistency:
 
-- **The schema is stricter than the loader.** The generated JSON Schema only
-  lists `git_tracked_only` on the four existence branches
-  (`file_exists`/`file_absent`/`dir_exists`/`dir_absent`), so an editor rejects
-  it elsewhere. But because it is a `RuleSpec` field, the loader *accepts* it on
-  any rule and the rule silently ignores it (`git_tracked_mode()` returns the
-  default `Off`). The `RuleSpec.git_tracked_only` doc-comment even promises that
-  "rule kinds that don't support it surface a clean config error" - that error
-  is **not implemented anywhere**. The v0.12 audit noted the divergence and
-  filed it as a not-a-bug ("schema stricter than loader is the safe direction"),
-  but the loader's silent-ignore is a latent fail-quietly gap.
-- **It blocks the type-derived schema.** Because `git_tracked_only` is not in the
-  existence kinds' `Options` structs, those kinds cannot be migrated to
+- **The schema was stricter than the loader.** The generated JSON Schema listed
+  `git_tracked_only` only on the four existence branches
+  (`file_exists`/`file_absent`/`dir_exists`/`dir_absent`), so an editor rejected
+  it elsewhere. But because it was a `RuleSpec` field, the loader *accepted* it on
+  any rule and the rule silently ignored it (`git_tracked_mode()` returns the
+  default `Off`). The `RuleSpec.git_tracked_only` doc-comment even promised that
+  "rule kinds that don't support it surface a clean config error" - that error was
+  **not implemented anywhere**. The v0.12 audit noted the divergence and filed it
+  as a not-a-bug ("schema stricter than loader is the safe direction"), but the
+  silent-ignore was a latent fail-quietly gap.
+- **It blocked the type-derived schema.** Because `git_tracked_only` was not in the
+  existence kinds' `Options` structs, those kinds could not be migrated to
   schemars-derived schema (ADR-0001): the derivation would emit only `root_only`
-  and drop `git_tracked_only`. So the existence kinds keep a hand-authored schema
+  and drop `git_tracked_only`. So the existence kinds kept a hand-authored schema
   branch with undocumented options and a hand-edited `x-since` (ADR-0007).
 
-The two fields have *opposite* semantics, which points at opposite fixes:
+Both fields turn out to be **kind-specific behaviors**, honored by a fixed set of
+kinds and a genuine mistake elsewhere:
 
-- `git_tracked_only` is a **hard opt-in** honored only by the existence family; it
-  changes the rule's index semantics. Setting it on any other kind is a genuine
-  mistake that should fail loudly.
-- `respect_gitignore` is a **benign, forward-compatible per-rule override** of the
-  workspace walker setting. Only `file_exists` honors it today, but by design
-  future kinds broaden coverage, and where a kind does not honor it the value
-  simply falls through to the workspace default. Setting it on a not-yet-covered
-  kind is harmless.
+- `git_tracked_only` is a **hard opt-in** honored by the existence family; it
+  changes the rule's index semantics. Every one of the four existence kinds reads
+  it (via `git_tracked_mode()`); no other kind does.
+- `respect_gitignore` is a **per-rule override** of the workspace walker setting,
+  honored **only by `file_exists`** for literal-path patterns - the bazel-style
+  "tracked AND gitignored" escape hatch (`docs/development/CONFIG-AUTHORING.md`
+  pitfall #18). No other kind - not even the sibling existence kinds
+  `file_absent`/`dir_exists`/`dir_absent` - reads the per-rule field.
+
+Setting either field on a kind that does not honor it is a mistake that today loads
+and is silently ignored. (An earlier draft of this ADR treated `respect_gitignore`
+as a "benign, forward-compatible" universal and moved it to `rule_common`; an
+adversarial review refuted that - see Considered Options. It is not universal:
+`no_bom: {respect_gitignore: false}` validated, loaded, and was silently ignored -
+the exact fail-quietly this ADR exists to close.)
 
 Driver: close the divergence, deliver the fail-loud the doc-comment promises, and
 unblock the type-derived schema. Design doc:
@@ -52,52 +60,67 @@ ADR-0001 (schema derived from Rust types), ADR-0007 (`x-since`).
 
 ## Decision
 
-We will place each field where its semantics belong.
+Both fields move off `RuleSpec` into the `Options` struct of exactly the kinds that
+honor them - the uniform mechanism the rest of the catalog already uses.
 
-1. **`git_tracked_only` becomes a kind-specific option.** Remove it from
-   `RuleSpec`; add it to the four existence `Options` structs (schemars-derived,
-   `deny_unknown_fields`); each `build()` reads `opts.git_tracked_only`; the
-   engine is unchanged (it reads the `git_tracked_mode()` trait method). Because
-   the field now flows through `RuleSpec.extra` into the kind's `Options`, every
-   non-existence kind's `deny_unknown_fields` rejects it at load with a clean
-   error - uniformly, with no ad-hoc per-kind checks - so the loader is now
-   exactly as strict as the schema, and the doc-comment's promise becomes true.
-   The four existence kinds are migrated to schemars in the same change, which
-   makes `x-since` type-derived and fills their empty Options descriptions.
+1. **`git_tracked_only` becomes a kind-specific option on the existence family.**
+   Remove it from `RuleSpec`; add it to the four existence `Options` structs
+   (schemars-derived, `deny_unknown_fields`); each `build()` reads
+   `opts.git_tracked_only`; the engine is unchanged (it reads the
+   `git_tracked_mode()` trait method). The four existence kinds are migrated to
+   schemars in the same change, which makes `x-since` type-derived and fills their
+   empty Options descriptions.
 
-2. **`respect_gitignore` becomes a common field.** It stays a `RuleSpec` field
-   (the engine/walker plumbing is unchanged), but its schema representation moves
-   from the `file_exists` branch into `rule_common`, so it is universally
-   permitted and forward-compatible. Schema and loader agree: both allow it on
-   any rule, and it is honored where supported.
+2. **`respect_gitignore` becomes a `file_exists`-only option.** Remove it from
+   `RuleSpec`; add it to `file_exists`'s `Options` struct alone (the sole kind that
+   honors it); `build()` reads `opts.respect_gitignore`. It is dropped from
+   `rule_common`. The workspace-level `Config.respect_gitignore` (the walker
+   default) is a separate field and is unchanged.
+
+Because both fields now flow through `RuleSpec.extra` into a kind's `Options`,
+every kind whose `Options` lacks the field rejects it at load via
+`deny_unknown_fields` - uniformly, with no ad-hoc per-kind checks. The loader is now
+exactly as strict as the schema for both fields, and the doc-comment's promise
+becomes true. Nested rules strip both via `PARENT_FIELDS` (unchanged).
 
 ## Consequences
 
 Easier: schema and loader agree for both fields (no divergence, no editor-vs-CLI
-surprise); a misplaced `git_tracked_only` now fails loudly at load instead of
-silently no-op'ing; the existence kinds gain type-derived schema, documented
-options, and type-derived `x-since`; and two ad-hoc concepts collapse into the
-uniform `Options`/`rule_common` mechanisms the rest of the catalog already uses.
+surprise); a misplaced `git_tracked_only` or `respect_gitignore` now fails loudly at
+load instead of silently no-op'ing; the existence kinds gain type-derived schema,
+documented options, and type-derived `x-since`; `respect_gitignore` regains its
+user-facing Options-table row on the `file_exists` rule page (moving it to
+`rule_common` had silently dropped it, since common fields are not rendered in
+per-rule tables); and two ad-hoc concepts collapse into the uniform `Options`
+mechanism.
 
-Harder / risk: this is a **validation tightening** - a config that (incorrectly)
-set `git_tracked_only` on a non-existence kind used to load and silently ignore
-it, and now errors. Such a config was already a no-op mistake, and this ships in
-the v0.14 "fail loudly" cut, so surfacing it is the intended direction; but it is
-technically a stricter load, noted for the changelog. `respect_gitignore` moving
-to `rule_common` is a slight loosening (now permitted on every kind), which is
-correct for a benign forward-compatible knob but does mean the schema no longer
-flags it on a kind that does not yet honor it.
+Harder / risk: this is a **validation tightening** - a config that (incorrectly) set
+`git_tracked_only` on a non-existence kind, or `respect_gitignore` on any kind but
+`file_exists`, used to load and silently ignore the field, and now errors. Such
+configs were already no-op mistakes, and this ships in the v0.14 "fail loudly" cut,
+so surfacing them is the intended direction; noted for the changelog. If a future
+kind gains genuine `respect_gitignore` support, add the field to that kind's
+`Options` (and implement the read) - the same pattern, per kind, rather than a
+schema-wide permit that over-promises.
 
 ## Considered Options
 
-- **Chosen: split by semantics** (`git_tracked_only` kind-specific,
-  `respect_gitignore` common).
-- **Both into `rule_common`.** Uniform but wrong for `git_tracked_only`: it would
-  keep silently ignoring a real misconfiguration instead of failing loud.
-- **Schema-only `Options` fields** (declare the fields for schemars but keep
-  reading them from `spec.*`). Unblocks the migration without moving ownership,
-  but leaves `Options` fields nothing reads (a smell) and does not fix the
-  divergence.
+- **Chosen: both kind-specific**, in the `Options` of exactly the kinds that honor
+  them (`git_tracked_only` on the four existence kinds; `respect_gitignore` on
+  `file_exists`).
+- **`respect_gitignore` into `rule_common`** (an earlier draft's choice). Rejected
+  on adversarial review: `respect_gitignore` is honored only by `file_exists`, so a
+  universal permit reintroduces the exact schema-looser-than-engine fail-quietly
+  this ADR closes - `no_bom: {respect_gitignore: false}` validates, loads, and is
+  silently ignored - and it dropped the field's documentation from the `file_exists`
+  rule page (common fields are not rendered in per-rule Options tables). "Forward
+  compatibility" does not justify it: when a kind gains real support, add the option
+  to that kind then (YAGNI).
+- **Both into `rule_common`.** Uniform but wrong for both: it keeps silently
+  ignoring real misconfigurations instead of failing loud.
+- **Schema-only `Options` fields** (declare the fields for schemars but keep reading
+  them from `spec.*`). Unblocks the migration without moving ownership, but leaves
+  `Options` fields nothing reads (a smell) and does not fix the divergence.
 - **Keep the hand-edited schema + just fill descriptions.** Safe and in-scope for
   the doc-drift cleanup, but leaves the wart and the aspirational doc-comment.
 

--- a/docs/design/v0.14/git-tracked-kind-option.md
+++ b/docs/design/v0.14/git-tracked-kind-option.md
@@ -1,0 +1,126 @@
+# Design: `git_tracked_only` as a kind-specific option
+
+Status: **Draft** (2026-07-04).
+Decisions: [ADR-0008](../../adr/0008-git-tracked-only-is-a-kind-option.md).
+
+This is the type-level design + implementation plan for ADR-0008. The ADR records
+*what* and *why*; this records *how*, precisely, so the refactor is clean at the
+type level.
+
+## 1. Problem
+
+`RuleSpec` (crates/alint-core/src/config.rs) carries `git_tracked_only: bool` and
+`respect_gitignore: Option<bool>` as explicit fields, so serde consumes them
+before the per-kind remainder lands in `RuleSpec.extra` (the `#[serde(flatten)]`
+mapping each kind's `Options` is deserialized from). Consequences (see ADR-0008):
+the loader silently accepts `git_tracked_only` on any kind (only the four
+existence kinds read it), the schema lists it only on existence branches (so
+they diverge), and the existence kinds cannot be schemars-migrated because the
+field is not in their `Options`.
+
+## 2. Type-level design
+
+The engine already has the right abstraction: it never reads
+`spec.git_tracked_only`; it reads the `Rule::git_tracked_mode()` **trait method**
+(default `GitTrackedMode::Off`; existence kinds override). So *where the flag is
+stored* is purely a loader/deserialization concern, and we can move it without
+touching the engine. The design is: store each flag where its semantics place it.
+
+### 2.1 `git_tracked_only` -> the existence `Options`
+
+Remove `pub git_tracked_only: bool` from `RuleSpec`. Add it to each existence
+kind's `Options`:
+
+```rust
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct Options {
+    /// Restrict matches to files tracked in git's index (`git ls-files`).
+    /// Entries present in the walked tree but not tracked are skipped. No
+    /// effect outside a git repo. Default `false`.
+    #[serde(default)]
+    root_only: bool,               // (file_exists: no x-since; siblings: x-since 0.14)
+    /// (doc as above)
+    #[serde(default)]
+    git_tracked_only: bool,
+}
+```
+
+`build()` reads `opts.git_tracked_only` instead of `spec.git_tracked_only`; the
+rule struct field and its `git_tracked_mode()` override are unchanged.
+
+Mechanism that makes this correct with zero new validation code: `git_tracked_only`
+now arrives in `RuleSpec.extra`, so `deserialize_options()` feeds it to the kind's
+`Options`. An existence `Options` has the field, so it deserializes. Every other
+kind's `Options` has `#[serde(deny_unknown_fields)]`, so it **rejects**
+`git_tracked_only` with a clean load error - uniformly, no per-kind checks. That
+is the fail-loud the `RuleSpec` doc-comment promised but never implemented.
+
+Note on the `x-since` asymmetry: `file_exists.root_only` is released (no
+`x-since`); the three siblings' `root_only` is v0.14 (`x-since`). So the four
+`Options` structs cannot share one type yet (a shared struct can't carry a
+per-kind `x-since`); keep them separate now. Once v0.14 releases and the `x-since`
+markers are dropped, unifying the existence `Options` into one shared struct is a
+clean follow-up. The `x-since` is expressed type-side as
+`#[schemars(extend("x-since" = "0.14"))]` on the three siblings' `root_only` field
+(the released `file_exists.root_only` carries no such attribute).
+
+### 2.2 `respect_gitignore` -> `rule_common`
+
+`respect_gitignore` stays a `RuleSpec` field (the walker/nested-inheritance
+plumbing in walker.rs / nested.rs / config.rs is unchanged, and `file_exists`
+keeps reading `spec.respect_gitignore`). Only its **schema** placement changes:
+move it out of the hand-authored `file_exists` branch and into the `rule_common`
+def, so it is universally permitted and forward-compatible. This is a base-schema
+edit only (no Rust change).
+
+### 2.3 schemars migration of the four existence kinds
+
+Add `#[derive(schemars::JsonSchema)]` + field doc-comments + `crate::
+options_schema_for!(Options);` to each existence module, and register
+`("rule_file_exists", file_exists::options_schema())` (and the three siblings) in
+`migrated_option_schemas()` (lib.rs). `compose_branch` then replaces the
+hand-authored existence branches with `{kind, paths}` + the derived `{root_only,
+git_tracked_only}`. Effects: `x-since` becomes type-derived (2.1); the empty
+Options-table descriptions fill from the Rust `///` docs; `respect_gitignore` is
+no longer needed in the `file_exists` branch (it now lives in `rule_common`, 2.2),
+so nothing is dropped.
+
+## 3. Change surface
+
+- `crates/alint-core/src/config.rs`: remove `RuleSpec.git_tracked_only` (+ its
+  doc-comment); keep `respect_gitignore`. Update the config test at ~:991.
+- `crates/alint-rules/src/{file_exists,file_absent,dir_exists,dir_absent}.rs`:
+  add `git_tracked_only` to `Options` (+ `root_only` doc), `#[derive(JsonSchema)]`,
+  `options_schema_for!`, read `opts.git_tracked_only`, keep the `x-since` attr on
+  the three siblings' `root_only`.
+- `crates/alint-rules/src/lib.rs`: register the four in `migrated_option_schemas()`.
+- `schemas/v1/config.json` (+ in-crate copy): regenerate; add `respect_gitignore`
+  to `rule_common`; the hand-edited existence `x-since` becomes derived.
+- Tests: see below.
+
+## 4. Tests
+
+- **New (the point of the refactor):** a non-existence kind with `git_tracked_only`
+  now fails to load with a clear error. Add a loader test asserting e.g. a
+  `file_content_forbidden` rule with `git_tracked_only: true` is rejected.
+- **Unchanged behavior:** the existing existence-kind `git_tracked_only` tests
+  (build + evaluate) must still pass reading it from `opts`.
+- **Schema fidelity:** `gen-schema --check` + the `generated_and_committed_agree_*`
+  tests green after regen; the four existence branches now schemars-derived.
+- **`respect_gitignore`:** a rule of any kind may carry `respect_gitignore`
+  (schema accepts via `rule_common`); `file_exists` still honors it.
+- Full gate sweep: workspace test, clippy, docs-export --check, dogfood.
+
+## 5. Compatibility
+
+A config that set `git_tracked_only` on a non-existence kind (a silent no-op
+before) now errors at load. This is the intended fail-loud for the v0.14 cut;
+record it under CHANGELOG **Changed** (a stricter load, catching a real mistake).
+No valid config changes behavior: on the existence kinds the flag is read from the
+same YAML key, just deserialized via `Options` instead of `RuleSpec`.
+
+## 6. Open questions
+
+- Unify the four existence `Options` into one shared struct post-v0.14 (once the
+  `x-since` asymmetry is gone)? Tracked as a follow-up, not done here.

--- a/docs/design/v0.14/git-tracked-kind-option.md
+++ b/docs/design/v0.14/git-tracked-kind-option.md
@@ -1,4 +1,4 @@
-# Design: `git_tracked_only` as a kind-specific option
+# Design: `git_tracked_only` and `respect_gitignore` as kind-specific options
 
 Status: **Draft** (2026-07-04).
 Decisions: [ADR-0008](../../adr/0008-git-tracked-only-is-a-kind-option.md).
@@ -65,14 +65,25 @@ clean follow-up. The `x-since` is expressed type-side as
 `#[schemars(extend("x-since" = "0.14"))]` on the three siblings' `root_only` field
 (the released `file_exists.root_only` carries no such attribute).
 
-### 2.2 `respect_gitignore` -> `rule_common`
+### 2.2 `respect_gitignore` -> `file_exists`'s `Options`
 
-`respect_gitignore` stays a `RuleSpec` field (the walker/nested-inheritance
-plumbing in walker.rs / nested.rs / config.rs is unchanged, and `file_exists`
-keeps reading `spec.respect_gitignore`). Only its **schema** placement changes:
-move it out of the hand-authored `file_exists` branch and into the `rule_common`
-def, so it is universally permitted and forward-compatible. This is a base-schema
-edit only (no Rust change).
+`respect_gitignore` is honored **only by `file_exists`** (the pitfall-#18
+literal-path escape hatch); no sibling existence kind and no other kind reads the
+per-rule field. So it is treated exactly like `git_tracked_only`, just narrower:
+remove `pub respect_gitignore: Option<bool>` from `RuleSpec`, add it to
+`file_exists`'s `Options` alone, and have `build()` read `opts.respect_gitignore`.
+It is dropped from `rule_common` and its orphaned `$def` is deleted. The
+workspace-level walker field `Config.respect_gitignore` (config.rs / walker.rs /
+nested.rs) is a *separate* field and is unchanged. Rejecting `respect_gitignore` on
+any other kind falls out of the same `deny_unknown_fields` mechanism as 2.1 - no
+extra code.
+
+An earlier draft moved `respect_gitignore` to `rule_common` instead (universal
+permit, "forward-compatible"). An adversarial review refuted it: that reintroduces
+the schema-looser-than-engine fail-quietly - `no_bom: {respect_gitignore: false}`
+validated, loaded, and was silently ignored - and it dropped the field's
+Options-table row from the `file_exists` rule page (common fields are not rendered
+per-rule). See ADR-0008 Considered Options.
 
 ### 2.3 schemars migration of the four existence kinds
 
@@ -82,21 +93,25 @@ options_schema_for!(Options);` to each existence module, and register
 `migrated_option_schemas()` (lib.rs). `compose_branch` then replaces the
 hand-authored existence branches with `{kind, paths}` + the derived `{root_only,
 git_tracked_only}`. Effects: `x-since` becomes type-derived (2.1); the empty
-Options-table descriptions fill from the Rust `///` docs; `respect_gitignore` is
-no longer needed in the `file_exists` branch (it now lives in `rule_common`, 2.2),
-so nothing is dropped.
+Options-table descriptions fill from the Rust `///` docs; `file_exists` also gains
+a derived `respect_gitignore` (2.2), which restores its Options-table row.
 
 ## 3. Change surface
 
-- `crates/alint-core/src/config.rs`: remove `RuleSpec.git_tracked_only` (+ its
-  doc-comment); keep `respect_gitignore`. Update the config test at ~:991.
+- `crates/alint-core/src/config.rs`: remove **both** `RuleSpec.git_tracked_only`
+  and `RuleSpec.respect_gitignore` (+ their doc-comments); keep the nested-strip in
+  `PARENT_FIELDS`. Update the config test at ~:991. (The workspace
+  `Config.respect_gitignore` walker field stays.)
 - `crates/alint-rules/src/{file_exists,file_absent,dir_exists,dir_absent}.rs`:
   add `git_tracked_only` to `Options` (+ `root_only` doc), `#[derive(JsonSchema)]`,
   `options_schema_for!`, read `opts.git_tracked_only`, keep the `x-since` attr on
-  the three siblings' `root_only`.
+  the three siblings' `root_only`. In `file_exists` **only**, also add
+  `respect_gitignore` to `Options` and read `opts.respect_gitignore`.
 - `crates/alint-rules/src/lib.rs`: register the four in `migrated_option_schemas()`.
-- `schemas/v1/config.json` (+ in-crate copy): regenerate; add `respect_gitignore`
-  to `rule_common`; the hand-edited existence `x-since` becomes derived.
+- `schemas/v1/config.json` (+ in-crate copy): remove `respect_gitignore` from
+  `rule_common` and delete the orphaned `per_rule_respect_gitignore` `$def`, then
+  regenerate; the existence `x-since` becomes derived and `file_exists` gains a
+  derived `respect_gitignore`.
 - Tests: see below.
 
 ## 4. Tests
@@ -108,8 +123,9 @@ so nothing is dropped.
   (build + evaluate) must still pass reading it from `opts`.
 - **Schema fidelity:** `gen-schema --check` + the `generated_and_committed_agree_*`
   tests green after regen; the four existence branches now schemars-derived.
-- **`respect_gitignore`:** a rule of any kind may carry `respect_gitignore`
-  (schema accepts via `rule_common`); `file_exists` still honors it.
+- **`respect_gitignore`:** rejected off `file_exists` - a non-existence kind
+  (`executable_bit`) and a sibling existence kind (`file_absent`) with
+  `respect_gitignore` both fail to load; `file_exists` still honors it.
 - Full gate sweep: workspace test, clippy, docs-export --check, dogfood.
 
 ## 5. Compatibility
@@ -122,5 +138,7 @@ same YAML key, just deserialized via `Options` instead of `RuleSpec`.
 
 ## 6. Open questions
 
-- Unify the four existence `Options` into one shared struct post-v0.14 (once the
-  `x-since` asymmetry is gone)? Tracked as a follow-up, not done here.
+- Unify the existence `Options` post-v0.14 (once the `x-since` asymmetry is gone)?
+  Only the three siblings (`file_absent`/`dir_exists`/`dir_absent`) can share a
+  struct: `file_exists` carries an extra `respect_gitignore` field the others do
+  not honor, so it stays distinct. Tracked as a follow-up, not done here.

--- a/examples/bazelbuild-bazel/.alint.yml
+++ b/examples/bazelbuild-bazel/.alint.yml
@@ -126,7 +126,10 @@ rules:
   - id: bazel-version-file-shape
     kind: file_content_matches
     paths: ".bazelversion"
-    respect_gitignore: false
+    # No per-rule respect_gitignore here: that override is file_exists-only
+    # (ADR-0008). Content rules read the workspace walker, which hides the
+    # gitignored .bazelversion — so this shape check fires only where the file
+    # is walker-visible.
     pattern: '^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+|-[a-zA-Z0-9.-]+)?\s*$'
     level: info
     message: >-
@@ -211,7 +214,9 @@ rules:
         extract: { regex: '(?m)^\s*bazel:\s*"?([0-9][^\s"]*)"?' }
     normalize: trim
     allow_missing_target: true
-    respect_gitignore: false      # source .bazelversion is gitignored
+    # The source .bazelversion is gitignored; the per-rule respect_gitignore
+    # override is file_exists-only (ADR-0008), so this comparison sees the
+    # source only where the walker does (allow_missing_target no-ops it otherwise).
     level: warning
     message: >-
       `.bazelversion` and the `.bazelci/presubmit.yml` `bazel:` pin should

--- a/schemas/v1/config.json
+++ b/schemas/v1/config.json
@@ -662,10 +662,6 @@
         }
       ]
     },
-    "per_rule_respect_gitignore": {
-      "description": "Per-rule override for the workspace-level `respect_gitignore:` setting. When `false`, this rule treats `.gitignore`-listed files as if they were untracked-but-on-disk: the rule sees them. The canonical use case is the bazel-style \"tracked AND gitignored\" pattern (a file like `.bazelversion` ships a default upstream and contributors override it locally without committing the override) — the workspace walker honours the gitignore, so `file_exists` reports \"no match\" against a file that's both on disk AND in `git ls-files`. This per-rule knob lets that single rule see the file without flipping the workspace-wide setting. Currently honoured by `file_exists` for literal-path patterns; other rule kinds + glob patterns fall through to the workspace setting. Default: inherit the workspace `respect_gitignore`. See `docs/development/CONFIG-AUTHORING.md` pitfall #18.",
-      "type": "boolean"
-    },
     "rule": {
       "description": "A rule entry — either a kind-driven rule (with `kind` and the kind-specific fields) or a template instance (with `extends_template` referencing a template id and optional `vars` overrides).",
       "oneOf": [
@@ -867,9 +863,6 @@
           "description": "Link to a human-readable policy justification.",
           "format": "uri",
           "type": "string"
-        },
-        "respect_gitignore": {
-          "$ref": "#/$defs/per_rule_respect_gitignore"
         },
         "scope_filter": {
           "$ref": "#/$defs/scope_filter"
@@ -1299,6 +1292,14 @@
         },
         "paths": {
           "$ref": "#/$defs/paths_spec"
+        },
+        "respect_gitignore": {
+          "default": null,
+          "description": "Per-rule override for the workspace `respect_gitignore` setting. When `false`, this rule's literal-path checks also stat the filesystem directly, so it sees files that are tracked AND `.gitignore`-masked (the bazel-style `.bazelversion` pattern — pitfall #18 in `docs/development/CONFIG-AUTHORING.md`). Honoured only by `file_exists` literal paths; glob patterns fall through to the workspace setting. Default: inherit the workspace `respect_gitignore`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "root_only": {
           "default": false,

--- a/schemas/v1/config.json
+++ b/schemas/v1/config.json
@@ -868,6 +868,9 @@
           "format": "uri",
           "type": "string"
         },
+        "respect_gitignore": {
+          "$ref": "#/$defs/per_rule_respect_gitignore"
+        },
         "scope_filter": {
           "$ref": "#/$defs/scope_filter"
         },
@@ -1010,7 +1013,9 @@
     "rule_dir_absent": {
       "properties": {
         "git_tracked_only": {
-          "$ref": "#/$defs/git_tracked_only"
+          "default": false,
+          "description": "Restrict matches to directories that contain at least one git-tracked file. No effect outside a git repo. Default `false`.",
+          "type": "boolean"
         },
         "kind": {
           "const": "dir_absent"
@@ -1020,7 +1025,7 @@
         },
         "root_only": {
           "default": false,
-          "description": "If true, only a directory directly at the repository root is forbidden.",
+          "description": "If true, only a directory directly at the repository root is forbidden; a nested match with the same name is allowed.",
           "type": "boolean",
           "x-since": "0.14"
         }
@@ -1064,7 +1069,9 @@
     "rule_dir_exists": {
       "properties": {
         "git_tracked_only": {
-          "$ref": "#/$defs/git_tracked_only"
+          "default": false,
+          "description": "Restrict matches to directories that contain at least one git-tracked file. No effect outside a git repo. Default `false`.",
+          "type": "boolean"
         },
         "kind": {
           "const": "dir_exists"
@@ -1074,7 +1081,7 @@
         },
         "root_only": {
           "default": false,
-          "description": "If true, only a directory directly at the repository root satisfies the rule.",
+          "description": "If true, only a directory directly at the repository root satisfies the rule; a nested match does not.",
           "type": "boolean",
           "x-since": "0.14"
         }
@@ -1193,7 +1200,9 @@
     "rule_file_absent": {
       "properties": {
         "git_tracked_only": {
-          "$ref": "#/$defs/git_tracked_only"
+          "default": false,
+          "description": "Restrict matches to files tracked in git's index: entries present in the walked tree but not in `git ls-files` are skipped. No effect outside a git repo. Default `false`.",
+          "type": "boolean"
         },
         "kind": {
           "const": "file_absent"
@@ -1203,7 +1212,7 @@
         },
         "root_only": {
           "default": false,
-          "description": "If true, only a file directly at the repository root is forbidden.",
+          "description": "If true, only a file matching `paths` directly at the repository root is forbidden; a nested match with the same name is allowed.",
           "type": "boolean",
           "x-since": "0.14"
         }
@@ -1281,16 +1290,15 @@
     "rule_file_exists": {
       "properties": {
         "git_tracked_only": {
-          "$ref": "#/$defs/git_tracked_only"
+          "default": false,
+          "description": "Restrict matches to files tracked in git's index: entries present in the walked tree but not in `git ls-files` are skipped. No effect outside a git repo. Default `false`.",
+          "type": "boolean"
         },
         "kind": {
           "const": "file_exists"
         },
         "paths": {
           "$ref": "#/$defs/paths_spec"
-        },
-        "respect_gitignore": {
-          "$ref": "#/$defs/per_rule_respect_gitignore"
         },
         "root_only": {
           "default": false,


### PR DESCRIPTION
## Summary

Closes the last `RuleSpec`-field-vs-schema divergence (ADR-0008). `git_tracked_only`
and `respect_gitignore` were the only two fields living in a per-kind schema branch
while also being `RuleSpec` struct fields, which made the schema stricter than the
loader (an editor rejected them off their kinds, but the loader accepted-and-ignored
them) and blocked schemars-deriving the existence kinds.

Both move off `RuleSpec` into the `Options` of exactly the kinds that honor them:

- **`git_tracked_only`** → the four existence kinds (`file_exists`/`file_absent`/
  `dir_exists`/`dir_absent`), which are migrated to schemars in the same change
  (type-derived `x-since`, filled option descriptions).
- **`respect_gitignore`** → `file_exists` alone (the only kind that reads the
  per-rule override — the pitfall #18 escape hatch).

Now schema, loader, and engine agree; a misplaced field fails loudly at load via the
uniform `deny_unknown_fields` (no ad-hoc per-kind checks), delivering the clean error
the doc-comments always promised.

## Adversarial-review fix (3rd commit)

The `respect_gitignore` half was **wrong in the first draft** — it moved to
`rule_common` ("benign universal"). Pre-merge review refuted that: `respect_gitignore`
is honored only by `file_exists`, so `rule_common` reintroduced the exact
schema-looser-than-engine fail-quietly this ADR closes. Proof: a `no_bom` rule with
`respect_gitignore: false` **validated, loaded, and was silently ignored**. It also
dropped the field's row from the `file_exists` rule page. The fix makes it
`file_exists`-only; ADR-0008 records the refuted alternative with the repro.

## Validation-tightening (v0.14 "fail loudly")

Stricter load: configs that set `git_tracked_only` on a non-existence kind, or
`respect_gitignore` on any kind but `file_exists`, used to load-and-no-op and now
error. Recorded under CHANGELOG **Changed**. The bazel example carried two such no-op
knobs (surfaced by the examples-parse test) — removed + annotated.

## Verification

Full workspace test (72 suites, 0 fail) incl. 3 new rejection tests; smoking guns
(`no_bom`/`file_absent` reject, `file_exists` honors); gen-schema/gen-facts/
docs-export `--check` green; fmt + pedantic clippy clean; dogfood 46/46; `file_exists`
Options-table row restored.