### PR TITLE
docs(v0.14): sentinel-gate root_only prose + A3 residual; pre-write baseline site docs (1b/1c/1d)

### DIFF
--- a/docs/design/v0.14/documentation-drift.md
+++ b/docs/design/v0.14/documentation-drift.md
@@ -431,9 +431,29 @@ Each fix ships with a revert-sensitive regression test (repo convention).
   (unwrap x-since options/prose, narrow walked-back claims, write feature site docs, reconcile
   pins + STATE.md, confirm gates). D-b: the `root_only` CHANGELOG entry stays correctly under
   Fixed; the checklist gives it release-time visibility.
-- `[ ]` **Remaining:** P3 (optional bench-count contract), P4.2 (deferred, above), the §6
-  release-gated v0.14 work (baseline site docs, Kani-claim narrowing), the A3 mid-sentence
-  residual, and — optional — migrating the existence kinds to schemars (type-derived `x-since`
-  + fills their empty descriptions; P1.1 used the base-schema hand-edit route).
-- **Nothing is pushed/deployed** — both branches are local; the leaks stay live until the
-  engine branch merges to `main` (triggers `docs-bundle.yml` -> the site).
+- `[x]` **Existence kinds migrated to schemars + `x-since` type-derived (#118, merged).**
+  Replaces the P1.1 base-schema hand-edit route with `#[derive(JsonSchema)]` +
+  `#[schemars(extend("x-since"="0.14"))]`. `git_tracked_only` and the `file_exists`-only
+  `respect_gitignore` become kind-specific `Options` (ADR-0008), closing the last
+  RuleSpec-vs-schema divergence and filling the four kinds' empty option descriptions. An
+  adversarial pre-merge review caught + fixed a `respect_gitignore`-in-`rule_common`
+  fail-quietly (a `no_bom: {respect_gitignore: false}` that validated, loaded, and no-op'd).
+- `[x]` **A3 residual CLOSED (1c).** `no_zero_width_chars` U+2060/U+180E split into an
+  `alint:since=0.14` block (the released U+200B/C/D sentence stays); the `no_symlinks`
+  escaping-symlink caveat wrapped whole. Both stripped at 0.13.0, shown at 0.14.0 (verified
+  both directions).
+- `[x]` **root_only prose for `file_absent`/`dir_absent` (1b) — sentinel-gated NOW** (not
+  deferred to §6): each gains an `alint:since=0.14` paragraph mirroring `dir_exists`; behaviour
+  verified honored (build + evaluate), stripped pre-release.
+- `[x]` **E1 baseline site docs PRE-WRITTEN (1d).** A `concepts/baseline.md` guide + the
+  `baseline:` configuration-reference key (both tag-pinned, safe on main) + a sentinel-wrapped
+  output-formats note (reference/** is main-overlaid, so P-REF strips it pre-release). Nav
+  wiring + un-sentineling happen at the v0.14 cut.
+- `[ ]` **Remaining:** 2a (internal `docs_url` API gate) + 2b (case-study index-card count
+  interpolation) + housekeeping (3) land this session; then only P3 (optional bench contract),
+  P4.2's EXTERNAL `source_url` probe, and the §6 release-cut tail (Kani-claim narrowing, nav +
+  un-sentinel the pre-written v0.14 prose, pin bump) remain.
+- **Deployment:** the engine drift-prevention (P1/P-C4/P-REF/P2.1/P5) and the alint.org
+  immediate fixes (§4) merged to `main` in the prior session; #118 merged this session. The
+  next `docs-bundle.yml` push carries the description/strip fixes live (the binary
+  validation-tightening ships at the v0.14 cut).

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -65,6 +65,9 @@ No file matching `paths` may exist in the walked tree. The inverse of `file_exis
 
 Fix: `file_remove` — delete every violating file.
 
+<!-- alint:since=0.14 -->
+**Optional `root_only: true`** (like `file_exists`) restricts the check to the repository root: a file forbidden at the root does not fire on nested copies of the same name.
+<!-- /alint:since -->
 **Optional `git_tracked_only: true`** restricts the check to files in git's index. With it set, the rule fires only on tracked paths regardless of `.gitignore` state — closing the gap where a `git add -f`'d file slips past the walker's gitignore filter. Outside a git repo the rule becomes a silent no-op.
 
 ```yaml
@@ -106,6 +109,9 @@ Directory counterpart of `file_absent`. The match-and-fire semantics are the sam
   level: error
 ```
 
+<!-- alint:since=0.14 -->
+**Optional `root_only: true`** (like `dir_exists`) restricts the check to the repository root: a directory forbidden at the root does not fire on nested directories of the same name.
+<!-- /alint:since -->
 **Optional `git_tracked_only: true`** restricts the check to directories that contain at least one git-tracked file. With it set, a developer's locally-built `target/` (gitignored, no tracked content) doesn't trigger; a `target/` whose contents made it into git's index does. This is the canonical "don't let `target/` be committed" semantic.
 
 ```yaml
@@ -539,7 +545,11 @@ Flag Trojan-Source bidi override characters (U+202A–202E, U+2066–2069). Defe
 
 ### `no_zero_width_chars`
 
-Flag body-internal zero-width characters (U+200B, U+200C, U+200D, U+2060, U+180E, and non-leading U+FEFF). A leading U+FEFF is `no_bom`'s concern.
+Flag body-internal zero-width characters (U+200B, U+200C, U+200D, and non-leading U+FEFF). A leading U+FEFF is `no_bom`'s concern.
+
+<!-- alint:since=0.14 -->
+As of v0.14 the detection set also covers U+2060 (word joiner) and U+180E (Mongolian vowel separator).
+<!-- /alint:since -->
 
 ```yaml
 - id: no-zwsp
@@ -650,7 +660,9 @@ All rules in this family are no-ops on Windows — the +x bit and symlinks don't
 
 Flag tracked paths that are symbolic links. Symlinks are a portability footgun: Windows NTFS needs admin rights to create them, git-for-Windows can silently flatten them, CI runners vary.
 
+<!-- alint:since=0.14 -->
 Caveat: a symlink whose target escapes the repository root (`link -> /etc`) is pruned by the walker *before* indexing, so it is **not** flagged — the rule reports in-tree symlinks (to files or directories), not escaping ones. The escaping symlink can't be read out-of-root either (path confinement blocks that), so this is a reporting gap, not a disclosure one; recording escaping symlinks safely is a tracked follow-up.
+<!-- /alint:since -->
 
 ```yaml
 - id: no-symlinks

--- a/docs/site/concepts/baseline.md
+++ b/docs/site/concepts/baseline.md
@@ -1,0 +1,92 @@
+---
+title: Baseline mode
+description: Grandfather a repo's existing violations so `alint check` gates only on new findings — the fingerprint-based baseline file, the two-command workflow, and which formats are baseline-aware.
+sidebar:
+  order: 9
+---
+
+Adopting a linter on an established repo has a chicken-and-egg problem: turn the rules on and CI goes red on thousands of pre-existing violations, none of which the current PR introduced. **Baseline mode** breaks it. You record today's violations into a committed baseline file, and from then on `alint check` reports and gates on only the findings that are *new* relative to that snapshot. The legacy debt stays visible but non-blocking; the moment someone adds a *fresh* violation, the gate catches it.
+
+This is the standard "ratchet": stop the bleeding now, pay the backlog down on your own schedule.
+
+## The two-command workflow
+
+**1. Record the baseline** — run once when you adopt alint (and again when you deliberately pay down or accept debt):
+
+```sh
+alint baseline
+```
+
+This runs the same whole-tree evaluation as `check`, then writes every current violation to `.alint-baseline.json`. Commit that file.
+
+**2. Enforce the delta** — in CI and locally:
+
+```sh
+alint check --baseline .alint-baseline.json
+```
+
+Every violation whose fingerprint is in the baseline is suppressed (up to its recorded count); only new violations are reported, and only they drive the exit code. A one-line stderr summary tells you how many were suppressed.
+
+Persist the path in `.alint.yml` so CI need not repeat the flag:
+
+```yaml
+baseline: .alint-baseline.json
+```
+
+`--baseline` on the command line overrides the config key. There is **no silent auto-detect** — a baseline suppresses findings only when you opt in explicitly (the config key or the flag), never because the file merely exists. Suppression is always a reviewable, committed decision.
+
+## The baseline file
+
+`.alint-baseline.json` is **JSON Lines** — a header line, then one sorted entry per grandfathered finding:
+
+```
+{"schema_version":1,"alint_version":"0.14.0"}
+{"rule_id":"no-todo-comments","path":"src/legacy/api.ts","fingerprint":"<64-hex>","count":3,"message":"TODO without an owner"}
+{"rule_id":"lockfiles-only-one","path":null,"fingerprint":"<64-hex>","count":1,"message":"Multiple lockfiles found"}
+```
+
+One entry per line (not a single JSON array) is a deliberate choice: it is **merge-friendly**. Two PRs that each grandfather a different finding don't collide on shared array brackets. Entries are sorted, so an unchanged tree regenerates byte-for-byte identically.
+
+The `message` and `path` fields are **advisory** — they exist so a reviewer reading the baseline diff in a PR can see *what* is being grandfathered. Only the `fingerprint` is matched.
+
+## Fingerprints, not line numbers
+
+The crux of a usable baseline is a stable identity for each violation. alint fingerprints a violation as a SHA-256 over its rule, its path, and a **content discriminator** — for a line-anchored finding, the offending line's *text*, not its line *number*. So:
+
+- Inserting or deleting unrelated lines elsewhere in the file **does not** churn the baseline (line numbers shift; fingerprints don't).
+- **Editing the offending line itself re-triggers** the rule — the fingerprint changes, so the finding is treated as new and the gate catches it. You can't silently mutate grandfathered-but-broken code into something else that's broken.
+
+This is why the baseline survives ordinary refactoring without a flood of stale-entry noise, yet never masks a genuinely new problem.
+
+## Keeping the baseline honest
+
+Re-running `alint baseline` on a repo that already has a baseline **will not silently grandfather new debt**. It prints `+N would be grandfathered / -M stale removed` and, if there is anything new (a new fingerprint, or a higher count on an existing one), refuses to write it unless you pass `--accept-new`:
+
+```sh
+alint baseline --accept-new     # deliberately accept the new debt
+```
+
+Pruning *stale* entries (findings you've since fixed) is always safe and happens without the flag. Accepting *new* debt is always explicit. This closes the footgun where a careless `baseline` re-run would rubber-stamp everything introduced since the last one.
+
+Stale entries (present in the baseline but no longer firing) warn by default; `--strict-baseline` makes them a hard failure, so a baseline can't quietly rot.
+
+## Output formats
+
+Suppression **marks** violations rather than deleting them, so each formatter does the right thing for its consumer:
+
+- **sarif** — suppressed results are emitted with `suppressions: [{ "kind": "external" }]` and `baselineState: "unchanged"`; new findings get `baselineState: "new"`. This keeps GitHub Code Scanning alerts *open-but-dismissed* instead of flapping fixed-then-reopened as findings resurface.
+- **json** — suppressed findings are omitted from `results` (the gate sees only new), but the envelope carries a `summary.baselined_suppressed` count.
+- **human** — suppressed findings are omitted; the count prints on stderr.
+
+Only **sarif** and **json** are baseline-aware; the other formats receive the already-filtered live report. The global `--show-baselined` flag lists the suppressed findings in full, in any format. The exit code is gated on the live (new) findings only, always.
+
+## What baseline mode does *not* do
+
+- **`fix` does not take `--baseline`.** Auto-fixing is orthogonal to grandfathering; run `fix` normally, then refresh the baseline.
+- **It is not `--changed`.** A baseline must be whole-tree, so `alint baseline` rejects `--changed`/`--base` — a changed-scope snapshot would capture only the diff and silently omit the rest of the legacy tree. Baseline mode and changed-file mode compose at `check` time, not at record time.
+
+## See also
+
+- [`baseline:` configuration key](/docs/configuration/#baseline)
+- [Output formats](/docs/reference/output-formats/) — the full per-format behaviour
+- [The walker and `.gitignore`](/docs/concepts/walker-and-gitignore/) — what the whole-tree evaluation sees

--- a/docs/site/configuration/index.md
+++ b/docs/site/configuration/index.md
@@ -261,6 +261,16 @@ Absent or `false` keeps the secure default (full confinement).
 
 **Security.** Like the spawning-rule trust gate, `allow_out_of_root:` is honored **only** from your own top-level config — any `extends:`'d ruleset that declares it is a load-time error, so adopting a published ruleset can never grant it out-of-tree reads. It currently applies to the read kinds `json_schema_passes` (`schema_path:`), `pair_hash` (`target:`), and `registry_paths_resolve` (`source:`); a permitted read emits an informational note so the escape is never silent. Resolve/index existence checks stay confined regardless.
 
+### `baseline`
+
+Path to a committed baseline file that grandfathers pre-existing violations, so `alint check` reports and gates on only *new* findings. Persisting it here means CI need not pass `--baseline` on every run.
+
+```yaml
+baseline: .alint-baseline.json
+```
+
+A `--baseline <path>` flag overrides this key. There is **no silent auto-detect**: a baseline suppresses findings only when it is explicitly opted in (via this key or the flag), never because a baseline file merely exists on disk. Write and refresh the file with `alint baseline`. See [Baseline mode](/docs/concepts/baseline/) for the full workflow, the fingerprinting semantics, and which output formats are baseline-aware.
+
 ## See also
 
 - [JSON Schema](https://alint.org/_alint/configuration/schema.json): authoritative source for option types.

--- a/docs/site/reference/output-formats/index.md
+++ b/docs/site/reference/output-formats/index.md
@@ -24,3 +24,14 @@ A single `Report` fans out to each format:
 | [`agent`](/docs/reference/output-formats/agent/) | `agentic`, `ai` | LLM-shaped JSON with a templated `agent_instruction` per violation. |
 
 Each format is shown by example in the [quickstart](/docs/getting-started/quickstart/). The [`agent` format](/docs/reference/output-formats/agent/) has its own reference because its shape is purpose-built for AI coding agents.
+
+<!-- alint:since=0.14 -->
+## Baseline suppression
+
+When a run is filtered through a [baseline](/docs/concepts/baseline/), suppression *marks* findings rather than deleting them, and only two formats surface those marks:
+
+- **`sarif`** carries `suppressions: [{ "kind": "external" }]` and `baselineState` (`unchanged` for suppressed, `new` for live) on each result, plus `partialFingerprints` — so GitHub Code Scanning keeps grandfathered alerts open-but-dismissed instead of flapping fixed-then-reopened.
+- **`json`** omits suppressed findings from `results` and records a `summary.baselined_suppressed` count in the envelope.
+
+The other six formats receive the already-filtered live report and are baseline-oblivious. The global `--show-baselined` flag lists the suppressed findings in full, in any format; the exit code is gated on the live (new) findings only, in every format.
+<!-- /alint:since -->


### PR DESCRIPTION
Continues the documentation-drift follow-ups (`docs/design/v0.14/documentation-drift.md` §10) after the ADR-0008 schemars migration (#118). Doc-only; no engine change.

## 1b — `root_only` prose for `file_absent`/`dir_absent`
Each existence sibling gains an `<!-- alint:since=0.14 -->` paragraph mirroring the `dir_exists` template. Verified `root_only` is genuinely honored by both (build reads `opts.root_only`; evaluate skips nested — behavioral proof included), so this documents real behaviour rather than a no-op.

## 1c — the A3 prose-leak residual (active live leaks)
- `no_zero_width_chars`: the U+2060/U+180E addition (unreleased L1 hardening) is **split** so the released U+200B/C/D sentence stays and the new chars live in a sentinel block (mid-sentence content can't be block-wrapped whole).
- `no_symlinks`: the escaping-symlink caveat (unreleased M4) is wrapped whole.

Both were **live** on the site via the rules-only bridge; the wrap strips them from the next docs-bundle push (released = 0.13.0) and restores them at v0.14.

## 1d — baseline-mode site docs, pre-written
- `concepts/baseline.md` guide + the `baseline:` configuration-reference key — both in **tag-pinned** areas (safe on main; the bundle uses the release tag, so they don't surface until v0.14 tags).
- The output-formats note lives under the **main-overlaid** `reference/**`, so it's wrapped in a **P-REF sentinel** that strips pre-release.

Every baseline claim verified against `docs/design/baseline.md`.

## Verification
Sentinel gating proven **both directions**: all five blocks + the reference note are **absent** at released 0.13.0 and **present** at 0.14.0. `docs-export --check`, dogfood 46/46, doc-examples, fmt all green.