### PR TITLE
fix(docs): audit remediation — description gate, docker/release/action fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ alint suggest                       # human-readable proposal table
 alint suggest --format yaml         # paste-ready config snippet
 alint suggest --format json         # stable shape for agent consumption
 alint suggest --explain             # show file-level evidence per proposal
+alint suggest --confidence high     # raise the proposal threshold (low|medium|high; default medium)
+alint suggest --include-bundled     # also propose bundled rulesets you already extend
 ```
 
 For agent-driven workflows where `AGENTS.md` / `CLAUDE.md` / `.cursorrules` carries the directives the agent reads at session start, `alint export-agents-md` renders the active rule set as a markdown directive block. alint becomes the single source of truth, and the agent reads what alint enforces:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -94,13 +94,23 @@ Release-aware documentation is enforced mechanically (ADR-0007; see
 checklist so the release-gated pieces land and nothing drifts:
 
 1. **Newly-released options and prose.** Any option gated with an `x-since` for
-   this version now ships. Drop its `x-since` keyword from
-   `schemas/v1/config.json` (then `gen-schema`), and unwrap its
-   `<!-- alint:since=X -->` prose in `docs/rules.md` / `docs/site/reference/**`.
-   The gates strip these pre-release and `--released-version` catches up at the
-   tag, so unwrapping is cosmetic, but it keeps the source honest. For v0.14:
-   `root_only` on `file_absent` / `dir_exists` / `dir_absent` (add its prose to
-   `file_absent` / `dir_absent`, which currently only carry it in the table).
+   this version now ships; unwrap it at the source. This is cosmetic (the gates
+   strip these pre-release and `--released-version` catches up at the tag), but
+   it keeps the source honest.
+   - **Schema `x-since`.** For a schemars-migrated kind the keyword is
+     type-derived, so remove the `#[schemars(extend("x-since" = "<ver>"))]`
+     attribute from the option's Rust struct, then run `gen-schema`. Editing
+     `schemas/v1/config.json` directly is silently reverted by `gen-schema` and
+     fails `--check`. For a hand-authored branch, drop the keyword from
+     `config.json`, then `gen-schema`.
+   - **Prose sentinels.** Unwrap every `<!-- alint:since=<ver> -->` block; grep
+     `alint:since` across `docs/rules.md` and `docs/site/reference/**` to find all.
+   For v0.14: remove `#[schemars(extend("x-since" = "0.14"))]` from
+   `crates/alint-rules/src/{file_absent,dir_absent,dir_exists}.rs` (`root_only`),
+   and unwrap the six `alint:since=0.14` blocks: five in `docs/rules.md`
+   (`root_only` on `file_absent`/`dir_absent`/`dir_exists`, plus
+   `no_zero_width_chars` and `no_symlinks`) and one in
+   `docs/site/reference/output-formats/index.md`.
 2. **Claims whose scope changed.** Narrow any published claim the cut walked
    back. The Kani proof is scoped to the *lexical* path-confinement policy since
    the post-v0.13 H1 fix, so `roadmap.json` / CHANGELOG wording must not imply

--- a/ci/scripts/bump-version.sh
+++ b/ci/scripts/bump-version.sh
@@ -98,6 +98,18 @@ for f in "${SNIPPET_FILES[@]}"; do
   fi
 done
 
+# 2a-bis. Docker `<major>.<minor>` channel tag (docker.md). The loop above only
+#   rewrites full-version pins (`:0.13.0`); the bare minor-channel tag (`:0.13`)
+#   has no patch component, so it never matched and silently rotted for several
+#   releases (shipped `:0.10` at v0.13.0). Rewrite it here. Ordering matters: the
+#   full-version pass already bumped `:0.13.0`, and the trailing `[^0-9.]|$`
+#   guard keeps this pass from re-matching a full pin.
+CUR_MINOR="${CUR%.*}"
+NEW_MINOR="${NEW%.*}"
+if [[ -f docs/site/integrations/docker.md ]]; then
+  sed -i -E "s#:${CUR_MINOR//./\\.}([^0-9.]|\$)#:${NEW_MINOR}\1#g" docs/site/integrations/docker.md
+fi
+
 # 2b. npm shim version. The package itself ships zero JS behaviour
 #     — it downloads the matching binary at install time — but
 #     `npm view @asamarts/alint version` reports whatever is in

--- a/crates/alint-dsl/schemas/v1/config.json
+++ b/crates/alint-dsl/schemas/v1/config.json
@@ -883,6 +883,7 @@
       "description": "A `source` file must hold a `relation` to one or more `targets` (or the filesystem). Value relations extract values: `equals` (default — every target value equals the single source value; the released `cross_file_value_equals`), `subset` / `superset` / `set_equals` (the source's extracted set vs each target's set). `identical` compares whole files byte-for-byte (no `extract`; optional `skip_header_lines`). `resolves` checks that each path the source extracts exists on disk (`source.extract`, no `targets` — the forward half of `registry_paths_resolve`). `targets` is a `{ files: <glob>, extract }` map or a `[{ file, extract }]` list. `normalize` relaxes value comparison. Non-literal values are skipped, not failed. `cross_file_value_equals` is a byte-compatible alias (relation defaults to equals). The per-relation shape (which of `source.extract` / `targets` is present) is validated at load.",
       "properties": {
         "allow_missing_target": {
+          "description": "When true, an absent target file or a missing extracted target value is tolerated instead of reported as drift.",
           "type": "boolean"
         },
         "kind": {
@@ -918,6 +919,7 @@
           ]
         },
         "relation": {
+          "description": "The assertion checked between the source and each target: `equals` (default), `subset`, `superset`, `set_equals`, `identical` (whole file byte-for-byte), or `resolves` (each path the source extracts exists on disk).",
           "enum": [
             "equals",
             "subset",
@@ -928,11 +930,13 @@
           ]
         },
         "skip_header_lines": {
+          "description": "For the `identical` relation only: drop this many leading lines from both files before comparison, to ignore a differing license or generated header.",
           "minimum": 0,
           "type": "integer"
         },
         "source": {
           "additionalProperties": false,
+          "description": "The file whose extracted value(s) form the reference side of the relation — a single `{ file, extract }`, or (set relations only) `{ files: <glob>, extract }` whose matches are unioned into one set.",
           "oneOf": [
             {
               "required": [
@@ -961,6 +965,7 @@
           "type": "object"
         },
         "targets": {
+          "description": "The file(s) compared against the source, one relation check per target — a `{ files: <glob>, extract }` map or a list of `{ file, extract }` pins; omitted for the `resolves` relation (whose target is the filesystem).",
           "oneOf": [
             {
               "additionalProperties": false,
@@ -1050,6 +1055,7 @@
           ]
         },
         "select": {
+          "description": "Glob selecting the directories to check.",
           "type": "string"
         }
       },
@@ -1123,6 +1129,7 @@
           "const": "every_matching_has"
         },
         "require": {
+          "description": "One or more nested rules that every file or directory matching `select` must satisfy.",
           "items": {
             "$ref": "#/$defs/nested_rule"
           },
@@ -1954,6 +1961,7 @@
           "const": "generated_file_fresh"
         },
         "normalize": {
+          "description": "Normalization applied before comparison to absorb trailing-newline churn: `none`, `trim`, or `final-newline`.",
           "enum": [
             "none",
             "trim",
@@ -3091,12 +3099,15 @@
           "type": "string"
         },
         "entries_are_globs": {
+          "description": "Expand each extracted entry as a glob rather than treating it as a single literal path; a glob that matches nothing is a violation.",
           "type": "boolean"
         },
         "exclude_query": {
+          "description": "A structured query selecting entries to subtract from the extracted list before resolution is checked.",
           "type": "string"
         },
         "expect": {
+          "description": "Constrain the kind each entry must resolve to on disk: `any` (default), `file`, or `dir`.",
           "enum": [
             "any",
             "file",
@@ -3137,10 +3148,12 @@
           "const": "registry_paths_resolve"
         },
         "must_contain": {
+          "description": "When an entry resolves to a directory, that directory must contain this named child (e.g. `Cargo.toml`), else the entry is a violation.",
           "type": "string"
         },
         "orphans": {
           "additionalProperties": false,
+          "description": "Enable the reverse-completeness check: on-disk artefacts under the `space` glob that no entry references (the \"new crate not wired into the workspace\" detector).",
           "properties": {
             "space": {
               "type": "string"
@@ -3198,9 +3211,11 @@
           "$ref": "#/$defs/level"
         },
         "message": {
+          "description": "Override the default failure message. Supports `{{vars.*}}` and `{{ctx.*}}` substitution.",
           "type": "string"
         },
         "policy_url": {
+          "description": "Link to a human-readable policy justification.",
           "format": "uri",
           "type": "string"
         },
@@ -3216,6 +3231,7 @@
           "type": "object"
         },
         "when": {
+          "description": "Gate the rule on a fact-based expression (available from v0.2).",
           "type": "string"
         }
       },

--- a/crates/alint-dsl/tests/schema.rs
+++ b/crates/alint-dsl/tests/schema.rs
@@ -43,6 +43,61 @@ fn schema_is_well_formed_json() {
     let _: serde_json::Value = serde_json::from_str(CONFIG_SCHEMA_V1).expect("valid JSON");
 }
 
+/// Every kind-specific rule option must render a non-blank Options-table cell on
+/// alint.org (that table is generated from this schema). An option with no
+/// `description` — inline, or on the `$ref` target it points to — ships as a
+/// blank cell: the class of bug that once left 16 fields empty. This gate fails
+/// the build if any rule-branch option would render blank, whether the schema is
+/// hand-authored (`"description"` in the branch) or schemars-derived (a `///`
+/// doc-comment on the `Options` field). The `kind` discriminator is exempt.
+#[test]
+fn every_rule_option_has_a_description() {
+    let schema: serde_json::Value = serde_json::from_str(CONFIG_SCHEMA_V1).expect("valid JSON");
+    let defs = schema["$defs"].as_object().expect("schema has $defs");
+
+    let has_desc = |node: &serde_json::Value| {
+        node.get("description")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|s| !s.trim().is_empty())
+    };
+
+    let mut gaps: Vec<String> = Vec::new();
+    for (branch_name, branch) in defs {
+        if !branch_name.starts_with("rule_") {
+            continue;
+        }
+        let Some(props) = branch
+            .get("properties")
+            .and_then(serde_json::Value::as_object)
+        else {
+            continue;
+        };
+        for (prop_name, prop) in props {
+            if prop_name == "kind" || has_desc(prop) {
+                continue; // the discriminator, or an inline description is present
+            }
+            // No inline description — a `$ref` is acceptable only if its target is described.
+            let ref_ok = prop
+                .get("$ref")
+                .and_then(serde_json::Value::as_str)
+                .and_then(|r| r.rsplit('/').next())
+                .and_then(|target| defs.get(target))
+                .is_some_and(has_desc);
+            if !ref_ok {
+                gaps.push(format!("{branch_name}.{prop_name}"));
+            }
+        }
+    }
+
+    assert!(
+        gaps.is_empty(),
+        "these rule options have no description and would render as blank cells in \
+         alint.org's Options tables — add one (a `///` doc-comment on the schemars \
+         `Options` field, or a `\"description\"` in the hand-authored schema branch):\n  {}",
+        gaps.join("\n  "),
+    );
+}
+
 #[test]
 fn schema_compiles_as_draft_2020_12() {
     let _ = compile_schema();

--- a/docs/site/integrations/docker.md
+++ b/docs/site/integrations/docker.md
@@ -21,7 +21,7 @@ The image's `WORKDIR` is `/repo`, so the bind-mount lets alint see your repo as 
 docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.13.0 check
 ```
 
-Tags published per release: the exact git tag (`:v0.13.0`), the bare semver (`:0.13.0`), the `<major>.<minor>` channel (`:0.10`), and `:latest`.
+Tags published per release: the exact git tag (`:v0.13.0`), the bare semver (`:0.13.0`), the `<major>.<minor>` channel (`:0.13`), and `:latest`.
 
 ## Apply auto-fixes
 

--- a/docs/site/integrations/github-actions.md
+++ b/docs/site/integrations/github-actions.md
@@ -24,6 +24,7 @@ This runs `alint check --format github` against `.` and emits findings as `::err
   with:
     version: v0.13.0        # release tag; omit to follow the pinned action ref
     path: .                # directory to lint (default: .)
+    working-directory: .   # dir the action runs in (default: the runner workspace)
     format: github         # human | json | sarif | github (default)
     config: |              # extra config path(s), one per line
       .alint.yml

--- a/schemas/v1/config.json
+++ b/schemas/v1/config.json
@@ -883,6 +883,7 @@
       "description": "A `source` file must hold a `relation` to one or more `targets` (or the filesystem). Value relations extract values: `equals` (default — every target value equals the single source value; the released `cross_file_value_equals`), `subset` / `superset` / `set_equals` (the source's extracted set vs each target's set). `identical` compares whole files byte-for-byte (no `extract`; optional `skip_header_lines`). `resolves` checks that each path the source extracts exists on disk (`source.extract`, no `targets` — the forward half of `registry_paths_resolve`). `targets` is a `{ files: <glob>, extract }` map or a `[{ file, extract }]` list. `normalize` relaxes value comparison. Non-literal values are skipped, not failed. `cross_file_value_equals` is a byte-compatible alias (relation defaults to equals). The per-relation shape (which of `source.extract` / `targets` is present) is validated at load.",
       "properties": {
         "allow_missing_target": {
+          "description": "When true, an absent target file or a missing extracted target value is tolerated instead of reported as drift.",
           "type": "boolean"
         },
         "kind": {
@@ -918,6 +919,7 @@
           ]
         },
         "relation": {
+          "description": "The assertion checked between the source and each target: `equals` (default), `subset`, `superset`, `set_equals`, `identical` (whole file byte-for-byte), or `resolves` (each path the source extracts exists on disk).",
           "enum": [
             "equals",
             "subset",
@@ -928,11 +930,13 @@
           ]
         },
         "skip_header_lines": {
+          "description": "For the `identical` relation only: drop this many leading lines from both files before comparison, to ignore a differing license or generated header.",
           "minimum": 0,
           "type": "integer"
         },
         "source": {
           "additionalProperties": false,
+          "description": "The file whose extracted value(s) form the reference side of the relation — a single `{ file, extract }`, or (set relations only) `{ files: <glob>, extract }` whose matches are unioned into one set.",
           "oneOf": [
             {
               "required": [
@@ -961,6 +965,7 @@
           "type": "object"
         },
         "targets": {
+          "description": "The file(s) compared against the source, one relation check per target — a `{ files: <glob>, extract }` map or a list of `{ file, extract }` pins; omitted for the `resolves` relation (whose target is the filesystem).",
           "oneOf": [
             {
               "additionalProperties": false,
@@ -1050,6 +1055,7 @@
           ]
         },
         "select": {
+          "description": "Glob selecting the directories to check.",
           "type": "string"
         }
       },
@@ -1123,6 +1129,7 @@
           "const": "every_matching_has"
         },
         "require": {
+          "description": "One or more nested rules that every file or directory matching `select` must satisfy.",
           "items": {
             "$ref": "#/$defs/nested_rule"
           },
@@ -1954,6 +1961,7 @@
           "const": "generated_file_fresh"
         },
         "normalize": {
+          "description": "Normalization applied before comparison to absorb trailing-newline churn: `none`, `trim`, or `final-newline`.",
           "enum": [
             "none",
             "trim",
@@ -3091,12 +3099,15 @@
           "type": "string"
         },
         "entries_are_globs": {
+          "description": "Expand each extracted entry as a glob rather than treating it as a single literal path; a glob that matches nothing is a violation.",
           "type": "boolean"
         },
         "exclude_query": {
+          "description": "A structured query selecting entries to subtract from the extracted list before resolution is checked.",
           "type": "string"
         },
         "expect": {
+          "description": "Constrain the kind each entry must resolve to on disk: `any` (default), `file`, or `dir`.",
           "enum": [
             "any",
             "file",
@@ -3137,10 +3148,12 @@
           "const": "registry_paths_resolve"
         },
         "must_contain": {
+          "description": "When an entry resolves to a directory, that directory must contain this named child (e.g. `Cargo.toml`), else the entry is a violation.",
           "type": "string"
         },
         "orphans": {
           "additionalProperties": false,
+          "description": "Enable the reverse-completeness check: on-disk artefacts under the `space` glob that no entry references (the \"new crate not wired into the workspace\" detector).",
           "properties": {
             "space": {
               "type": "string"
@@ -3198,9 +3211,11 @@
           "$ref": "#/$defs/level"
         },
         "message": {
+          "description": "Override the default failure message. Supports `{{vars.*}}` and `{{ctx.*}}` substitution.",
           "type": "string"
         },
         "policy_url": {
+          "description": "Link to a human-readable policy justification.",
           "format": "uri",
           "type": "string"
         },
@@ -3216,6 +3231,7 @@
           "type": "object"
         },
         "when": {
+          "description": "Gate the rule on a fact-based expression (available from v0.2).",
           "type": "string"
         }
       },


### PR DESCRIPTION
Remediates the alint-repo findings from the two-repo audit (the alint.org sidebar finding shipped separately in alint.org#16). Each fix ships with prevention.

## F4 — 16 blank Options-table cells + a coverage gate
16 rule-option fields had no schema `description`, so alint.org's generated Options tables rendered blank (`cross_file`, `registry_paths_resolve`, `every_matching_has`, `dir_contains`, `generated_file_fresh`, `template_instance`). Filled each faithfully to `docs/rules.md`.
**Prevention:** a new `every_rule_option_has_a_description` schema test fails the build if any rule option would render blank — inline description *or* a described `$ref` target; `kind` exempt — hand-authored or schemars-derived alike. (Verified positive + negative.)

## F2 — stale docker minor-channel tag + bumper fix
`docker.md` advertised `:0.10` as the `<major>.<minor>` channel (should be `:0.13`); pulling it got a 3-release-old image. Fixed to `:0.13`.
**Prevention:** `bump-version.sh` now rewrites the bare `<major>.<minor>` channel (it only matched full-version pins before — why it rotted for 3 releases). Dry-run confirmed `:0.13`→`:0.14` without touching full pins.

## F3 — RELEASING.md checklist accuracy
Item 1 said to drop `x-since` from `config.json`, but post-#118 it's type-derived from `#[schemars(extend(...))]` and editing the JSON is reverted by `gen-schema`. Rewrote it correctly and enumerated all six `alint:since=0.14` sentinel blocks.

## F5 / F6 — missing flag/input docs
README `suggest` block now documents `--confidence` / `--include-bundled`; `github-actions.md` Inputs now lists `working-directory` (both were code-only).

## Verified
gen-schema/gen-facts `--check` green; workspace tests incl. the new gate (positive + negative); dogfood 46/46; clippy + fmt clean.