### PR TITLE
fix(docs-bundle): strip unreleased since-blocks from the main-overlaid docs

### DIFF
--- a/.github/workflows/docs-bundle.yml
+++ b/.github/workflows/docs-bundle.yml
@@ -103,16 +103,37 @@ jobs:
             docs/site/about/architecture-diagrams.md docs/site/concepts/how-it-works.md
           echo "Overlaid reference + design docs from origin/main ($(git rev-parse --short origin/main))."
 
+      - name: Release-gate the overlaid docs (strip unreleased since-blocks)
+        # The overlay above brings main's reference + design prose into the
+        # tag-built tree, and that prose may carry `<!-- alint:since=X -->` blocks
+        # staged for a FUTURE release (e.g. a v0.14 baseline note). The release
+        # TAG's docs-export (next step) predates the P-REF stripper, so it cannot
+        # gate them — without this step an unreleased block reaches the bundle
+        # AND the live site, and a link inside it to a not-yet-shipped page (a
+        # since-gated whole page the tag correctly omits) dangles the check-links
+        # gate. Strip here with a standalone port of strip_unreleased_prose, keyed
+        # to the release tag, so nothing newer than the released version ships.
+        # This lifts the former "reference overlay stays within released
+        # behaviour by convention" limitation: since-gated prose may now live in
+        # the overlaid docs and is gated mechanically. Idempotent once the tag's
+        # own docs-export gains the stripper. (ADR-0007; documentation-drift.md
+        # P-REF. The rule-page bridge below gates separately via MAIN's xtask.)
+        run: |
+          set -euo pipefail
+          node ci/scripts/strip-since.mjs --released-version "${BUNDLE_SOURCE#v}" \
+            docs/site/reference \
+            docs/site/about/architecture-diagrams.md \
+            docs/site/concepts/how-it-works.md \
+            docs/design/ARCHITECTURE.md \
+            docs/design/ROADMAP.md
+
       - name: Generate docs-bundle/
         # This runs the RELEASE TAG's docs-export, so it must NOT pass a flag the
-        # tag's xtask lacks. P-REF's `--released-version` (stripping unreleased
-        # `<!-- alint:since=X -->` blocks from the main-overlaid
-        # docs/site/reference) only exists from v0.14 on — and the tag's
-        # copy_site_tree has no stripper anyway — so reference-overlay
-        # release-gating activates once v0.14 is the release tag. Until then the
-        # reference overlay stays within released behaviour by convention. (The
-        # rule-page bridge below DOES gate, because it runs MAIN's docs-export
-        # from a worktree, where the flag exists.)
+        # tag's xtask lacks — the main-overlaid reference/design docs were already
+        # release-gated by the standalone stripper step above (the tag's
+        # copy_site_tree has no stripper of its own). The rule-page bridge below
+        # gates separately, because it runs MAIN's docs-export from a worktree
+        # where `--released-version` exists.
         run: cargo run -q -p xtask -- docs-export
         # Output lives at target/docs-bundle/.
 

--- a/ci/scripts/docs.sh
+++ b/ci/scripts/docs.sh
@@ -76,3 +76,12 @@ bash ci/scripts/likec4.sh
 # Run `cargo run -p xtask -- gen-mermaid` to refresh after a model change.
 echo "==> Running xtask gen-mermaid --check"
 cargo run -q -p xtask -- gen-mermaid --check
+
+# `strip-since.mjs` release-gates the main-overlaid reference docs in
+# docs-bundle.yml, stripping `<!-- alint:since=X -->` blocks newer than the
+# release tag so unreleased prose can't reach the bundle (or the live site). It
+# is a standalone port of strip_unreleased_prose (xtask/src/docs_export.rs);
+# these tests pin it byte-for-byte to the Rust semantics so the two can't drift.
+# Needs Node (set up by the Docs job).
+echo "==> Running node --test ci/scripts/strip-since.test.mjs"
+node --test ci/scripts/strip-since.test.mjs

--- a/ci/scripts/strip-since.mjs
+++ b/ci/scripts/strip-since.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// Strip release-gated prose blocks from Markdown, in place.
+//
+// A block delimited by `<!-- alint:since=X -->` ... `<!-- /alint:since -->` is
+// DROPPED when its version X is newer than the released version passed on the
+// command line (the prose describes an unreleased capability); otherwise the
+// block content is KEPT. The marker comments themselves are ALWAYS removed, so
+// they never reach a published page. Markers inside a fenced code example stay
+// literal.
+//
+// WHY THIS EXISTS (docs-bundle.yml): the docs bundle is built by the latest
+// RELEASE TAG's docs-export, which predates the P-REF stripper, so it cannot
+// gate the `docs/site/reference` (+ design) docs that docs-bundle.yml overlays
+// from main. This script runs right after that overlay and before the tag's
+// docs-export, keeping unreleased since-blocks out of the bundle (and off the
+// live site). Once the stripper ships in a release tag the tag's own
+// docs-export does this and the step is idempotent.
+//
+// MIRROR: this is a line-for-line port of `strip_unreleased_prose`
+// (xtask/src/docs_export.rs) + `parse_version` (xtask/src/rule_options_table.rs).
+// Keep the two in sync; ci/scripts/strip-since.test.mjs pins the same cases the
+// Rust unit tests cover. ADR-0007; docs/design/v0.14/documentation-drift.md P-REF.
+
+import { readdirSync, readFileSync, writeFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SINCE_OPEN = '<!-- alint:since=';
+const SINCE_CLOSE = '<!-- /alint:since -->';
+
+/**
+ * Parse a dotted version string (`"0.14"`, `"v0.13.0"`) into a
+ * `[major, minor, patch]` tuple, treating a missing or unparsable component as
+ * 0. Lenient by design, exactly like the Rust `parse_version`.
+ */
+export function parseVersion(s) {
+  const parts = s.trim().replace(/^v/, '').split('.');
+  const at = (i) => {
+    const n = Number.parseInt((parts[i] ?? '').trim(), 10);
+    return Number.isNaN(n) ? 0 : n;
+  };
+  return [at(0), at(1), at(2)];
+}
+
+/** `a > b` for `[major, minor, patch]` tuples (lexicographic). */
+function versionGt(a, b) {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] > b[i];
+  }
+  return false;
+}
+
+/**
+ * Strip unreleased since-blocks from a markdown body. `released` is a
+ * `[major, minor, patch]` tuple or `null` (null keeps every block, only
+ * unwrapping the markers). Returns the transformed body.
+ */
+export function stripUnreleasedProse(body, released) {
+  // Fast path: almost every file carries no marker, so leave it byte-for-byte
+  // untouched (no line-ending normalisation), matching the Rust fast path.
+  if (!body.includes('alint:since')) return body;
+
+  // Rust's `str::lines()` splits on `\n`/`\r\n`, drops the `\r`, and does NOT
+  // yield a trailing empty element for a final newline. Replicate that so the
+  // output is byte-identical.
+  const lines = body.split('\n');
+  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+
+  const out = [];
+  let inCodeFence = false;
+  let dropping = false;
+  for (const raw of lines) {
+    const line = raw.endsWith('\r') ? raw.slice(0, -1) : raw;
+    const trimmed = line.trim();
+    if (trimmed.startsWith('```')) {
+      inCodeFence = !inCodeFence;
+      if (!dropping) out.push(line);
+      continue;
+    }
+    if (!inCodeFence) {
+      if (trimmed.startsWith(SINCE_OPEN)) {
+        const ver = trimmed.slice(SINCE_OPEN.length).trim().replace(/(?:-->)+$/, '').trim();
+        dropping = released !== null && versionGt(parseVersion(ver), released);
+        continue; // never emit the marker line itself
+      }
+      if (trimmed === SINCE_CLOSE) {
+        dropping = false;
+        continue;
+      }
+    }
+    if (!dropping) out.push(line);
+  }
+  return out.map((l) => `${l}\n`).join('');
+}
+
+/** Recursively collect `.md` files under `path` (or `path` itself if a file). */
+function collectMarkdown(path) {
+  const st = statSync(path);
+  if (st.isFile()) return path.endsWith('.md') ? [path] : [];
+  const found = [];
+  for (const entry of readdirSync(path, { withFileTypes: true })) {
+    const child = join(path, entry.name);
+    if (entry.isDirectory()) found.push(...collectMarkdown(child));
+    else if (entry.isFile() && entry.name.endsWith('.md')) found.push(child);
+  }
+  return found;
+}
+
+function main(argv) {
+  let released = null;
+  const paths = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--released-version') {
+      const v = argv[++i];
+      if (v === undefined) {
+        console.error('strip-since: --released-version needs a value');
+        process.exit(2);
+      }
+      released = parseVersion(v);
+    } else {
+      paths.push(argv[i]);
+    }
+  }
+  if (paths.length === 0) {
+    console.error('usage: strip-since.mjs [--released-version X] <path>...');
+    process.exit(2);
+  }
+
+  let changed = 0;
+  let scanned = 0;
+  for (const path of paths) {
+    for (const file of collectMarkdown(path)) {
+      scanned++;
+      const before = readFileSync(file, 'utf8');
+      const after = stripUnreleasedProse(before, released);
+      if (after !== before) {
+        writeFileSync(file, after);
+        changed++;
+        console.log(`  stripped since-block(s): ${file}`);
+      }
+    }
+  }
+  const rel = released ? released.join('.') : '(none)';
+  console.log(`strip-since: released=${rel}, scanned ${scanned} .md file(s), rewrote ${changed}.`);
+}
+
+// Run only as a CLI, not when imported by the test.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2));
+}

--- a/ci/scripts/strip-since.test.mjs
+++ b/ci/scripts/strip-since.test.mjs
@@ -1,0 +1,89 @@
+// Parity tests for strip-since.mjs. These mirror the Rust unit tests for
+// `strip_unreleased_prose` (xtask/src/docs_export/tests.rs) so the standalone
+// port cannot drift from the source semantics, and add byte-exact output
+// assertions (stronger than the Rust `contains` checks) plus code-fence and
+// parseVersion coverage. Run: `node --test ci/scripts/strip-since.test.mjs`.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { stripUnreleasedProse, parseVersion } from './strip-since.mjs';
+
+const BODY = [
+  'Intro line, always shown.',
+  '',
+  '<!-- alint:since=0.14 -->',
+  '**Optional `root_only`** requires the match to be at the repo root.',
+  '<!-- /alint:since -->',
+  '',
+  'Trailer line, always shown.',
+  '',
+].join('\n');
+
+test('released 0.13.0: since=0.14 block dropped, markers gone, surrounds kept (byte-exact)', () => {
+  const out = stripUnreleasedProse(BODY, [0, 13, 0]);
+  assert.equal(out, 'Intro line, always shown.\n\n\nTrailer line, always shown.\n');
+  assert.ok(!out.includes('root_only') && !out.includes('alint:since'));
+});
+
+test('released 0.14.0: block content kept, markers still stripped (byte-exact)', () => {
+  const out = stripUnreleasedProse(BODY, [0, 14, 0]);
+  assert.equal(
+    out,
+    'Intro line, always shown.\n\n**Optional `root_only`** requires the match to be at the repo root.\n\nTrailer line, always shown.\n',
+  );
+  assert.ok(out.includes('root_only') && !out.includes('alint:since'));
+});
+
+test('released null (local/dev): content kept, markers stripped', () => {
+  const out = stripUnreleasedProse(BODY, null);
+  assert.ok(out.includes('root_only') && !out.includes('alint:since'));
+});
+
+test('a body with no markers is returned byte-for-byte (fast path)', () => {
+  const plain = 'no markers here\n';
+  assert.equal(stripUnreleasedProse(plain, [0, 13, 0]), plain);
+  // No trailing newline is likewise preserved untouched by the fast path.
+  assert.equal(stripUnreleasedProse('abc', [0, 13, 0]), 'abc');
+});
+
+test('markers inside a fenced code block stay literal (not treated as gates)', () => {
+  const fenced = [
+    'Before.',
+    '```md',
+    '<!-- alint:since=99.0 -->',
+    'inside fence',
+    '<!-- /alint:since -->',
+    '```',
+    'After.',
+    '',
+  ].join('\n');
+  const out = stripUnreleasedProse(fenced, [0, 13, 0]);
+  // The example survives verbatim even though 99.0 > 0.13 — it is inside a fence.
+  assert.equal(out, fenced);
+  assert.ok(out.includes('<!-- alint:since=99.0 -->') && out.includes('inside fence'));
+});
+
+test('multiple blocks: each gated independently', () => {
+  const body = [
+    'A',
+    '<!-- alint:since=0.14 -->',
+    'future',
+    '<!-- /alint:since -->',
+    'B',
+    '<!-- alint:since=0.13 -->',
+    'released',
+    '<!-- /alint:since -->',
+    'C',
+    '',
+  ].join('\n');
+  const out = stripUnreleasedProse(body, [0, 13, 0]);
+  assert.equal(out, 'A\nB\nreleased\nC\n');
+});
+
+test('parseVersion: lenient dotted parse matching the Rust tuple', () => {
+  assert.deepEqual(parseVersion('0.14'), [0, 14, 0]);
+  assert.deepEqual(parseVersion('v0.13.0'), [0, 13, 0]);
+  assert.deepEqual(parseVersion('1'), [1, 0, 0]);
+  assert.deepEqual(parseVersion('2.5.9'), [2, 5, 9]);
+  assert.deepEqual(parseVersion('garbage'), [0, 0, 0]);
+  assert.deepEqual(parseVersion(' v1.2 '), [1, 2, 0]);
+});


### PR DESCRIPTION
## Problem

`check-links` has been red on `main` (and the live site has been leaking unreleased content). Root cause: `docs-bundle.yml` overlays `docs/site/reference` (+ design docs) from main onto the release-tag tree, and that prose can carry `<!-- alint:since=X -->` blocks staged for a future release. The release TAG's docs-export predates the P-REF stripper, so it could not gate them.

Concretely: the v0.14 baseline note in `output-formats/index.md` shipped onto the live site early, and its link to `/docs/concepts/baseline/` (a since-gated whole page the tag correctly omits) dangled the internal-link gate.

## Fix

A standalone `ci/scripts/strip-since.mjs` (a faithful port of `strip_unreleased_prose`) runs right after the overlay and before the tag's docs-export, keyed to the release tag:

- **drops** since-blocks newer than the release,
- **unwraps** the markers on already-released ones,
- markerless files pass through byte-for-byte.

Proven on the real `output-formats/index.md`: at 0.13.0 the block + baseline link are gone; at 0.14.0 the content is kept, markers unwrapped.

This **lifts** the former "reference overlay stays within released behaviour by convention" limitation, which the 1b/1c/1d v0.14 doc pre-write had outgrown.

## Anti-drift

`strip-since.test.mjs` pins the port **byte-for-byte** to the Rust unit-test cases (dropped-when-future, unwrapped-when-released, markerless fast path, code-fence literals, multi-block, `parseVersion`), so the JS and Rust implementations cannot silently diverge. `docs.sh` runs it in the node-equipped Docs job.