### PR TITLE
fix(docs-bundle): fetch strip-since.mjs from main before running it

### DIFF
--- a/.github/workflows/docs-bundle.yml
+++ b/.github/workflows/docs-bundle.yml
@@ -120,6 +120,13 @@ jobs:
         # P-REF. The rule-page bridge below gates separately via MAIN's xtask.)
         run: |
           set -euo pipefail
+          # strip-since.mjs is main-tracked tooling absent from the release tag
+          # checked out above (the bundle is built from the tag), so pull just the
+          # script from main before running it — the same reason the rule-page
+          # bridge below runs MAIN's xtask from a worktree. origin/main was already
+          # fetched by the overlay step; fetch again so this step is self-contained.
+          git fetch --quiet origin main
+          git checkout origin/main -- ci/scripts/strip-since.mjs
           node ci/scripts/strip-since.mjs --released-version "${BUNDLE_SOURCE#v}" \
             docs/site/reference \
             docs/site/about/architecture-diagrams.md \


### PR DESCRIPTION
Follow-up to #126. The docs bundle is built from the release **tag** (detached checkout), which does not contain `ci/scripts/strip-since.mjs` (that script only lives on main). The release-gate step died with `MODULE_NOT_FOUND` on its first real run. Pull the script from `origin/main` before invoking it, exactly as the rule-page bridge runs main's xtask from a worktree.

Validated: `origin/main` has the script, so `git checkout origin/main -- ci/scripts/strip-since.mjs` resolves. Admin-merging because this is a workflow-only change whose true validation is the docs-bundle rerun it triggers (the self-hosted CI can't exercise docs-bundle.yml, and it's mid-recovery from a 2-day outage).