### PR TITLE
docs(rule-authoring): rewrite for accuracy, completeness, and house style

### DIFF
--- a/docs/development/rule-authoring.md
+++ b/docs/development/rule-authoring.md
@@ -1,106 +1,130 @@
 # Rule-authoring workflow
 
-Lands in v0.9.9. Codifies the four-step process every new rule
-kind, bundled ruleset, or rule-kind alias goes through so the
-coverage audits stay green and CI doesn't surprise anyone.
+This page is the checklist for adding a new rule kind, bundled ruleset, or
+rule-kind alias. Follow it and the coverage audits stay green, so CI passes on
+the first push.
 
-This doc supplements (does not replace)
-`docs/design/v0.9/coverage-and-dogfood.md`, which captures
-the *why*. This doc captures the *what to do*.
-
-The four-step workflow every new rule kind, ruleset, or alias goes through:
+The path every new rule kind, ruleset, or alias takes:
 
 <likec4-view view-id="addRuleKindFlow"></likec4-view>
 
 ## Two-layer enforcement
 
+Two independent layers keep the rule surface honest, and both run in CI.
+
 | Layer | Tool | Catches |
 |---|---|---|
-| **1 — File presence** | `alint check .` (the `.alint.yml` at the repo root, run via the `action-selftest.yml` workflow on every push) | Missing source files, missing scenario YAMLs, missing bundled-ruleset coverage. Fast feedback during local development. |
-| **2 — Semantic** | `cargo test -p alint-e2e` (`coverage_audit_*.rs` integration tests) | Pass/fail symmetry, alias-aware kind coverage, bundled-ruleset symmetry, git-mode symmetry, registry consistency. |
+| 1. File presence | `alint check .` (the root `.alint.yml`, run by the `action-selftest.yml` workflow on every push) | Missing source files, missing scenario YAMLs, missing bundled-ruleset coverage. Fast feedback while you develop locally. |
+| 2. Semantic | `cargo test -p alint-e2e` (the `coverage_audit_*.rs` integration tests) | Pass/fail symmetry, alias-aware kind coverage, bundled-ruleset symmetry, git-mode symmetry, and registry-to-schema-to-docs consistency. |
 
-Both layers run in CI. A PR that lands a new rule without an
-e2e scenario fails layer 1 at lint time; a PR that lands only
-a passing scenario (no fires/silent counterpart) fails layer 2
-at test time.
+A PR that adds a rule kind with no e2e scenario fails layer 1 at lint time. A PR
+that adds only a passing scenario, with no firing counterpart, fails layer 2 at
+test time.
 
 ## Adding a new rule kind
 
-```text
-1. Implement under `crates/alint-rules/src/<kind>.rs`.
-2. Register in `alint-rules/src/lib.rs::builtin_registry()`.
-3. Add e2e scenarios:
-     crates/alint-e2e/scenarios/check/<family>/<kind>_pass.yml
-     crates/alint-e2e/scenarios/check/<family>/<kind>_fires.yml
-4. If `wants_git_tracked()` / `wants_git_blame()` is opt-in or
-   mode-dependent, add:
-     <family>/<kind>_in_repo.yml         (given.git.init: true)
-     <family>/<kind>_no_op_outside_git.yml  (no given.git block)
-5. Run `cargo test -p alint-e2e -- --no-fail-fast`. Every
-   `coverage_audit_*` should pass.
-```
+1. Implement the rule in `crates/alint-rules/src/<kind>.rs` as a `Rule` or
+   `PerFileRule` impl.
+2. Register it in `register_builtin()` in `crates/alint-rules/src/lib.rs`.
+3. Add a minimal entry for the kind to
+   `crates/alint-dsl/tests/fixtures/all_kinds.yaml`. This fixture is the
+   canonical enumeration of every kind; the config schema, `facts.json`, the
+   LikeC4 model, and the headline counts are all derived from it. The registry
+   guard in `crates/alint-dsl/tests/schema.rs` fails and prints the missing kind
+   name until the entry exists.
+4. Document the kind in `docs/rules.md`, under its family (an `##` heading) as an
+   `###` section that contains at least one fenced ` ```yaml ` usage example.
+   The reference page at `alint.org/docs/rules/<family>/<kind>/` is sliced from
+   this section, and the docs build fails if the example is missing.
+5. Add e2e scenarios:
+   - `crates/alint-e2e/scenarios/check/<family>/<kind>_pass.yml`
+   - `crates/alint-e2e/scenarios/check/<family>/<kind>_fires.yml`
+6. If the rule reads git state (`git_tracked_mode()` returns a non-`Off`
+   `GitTrackedMode`, or `wants_git_blame()` returns `true`), add scenarios that
+   cover both modes:
+   - `<family>/<kind>_in_repo.yml` (with `given.git.init: true`)
+   - `<family>/<kind>_no_op_outside_git.yml` (no `given.git` block)
+7. Regenerate the derived contracts and run the audits:
+   ```text
+   cargo run -p xtask -- gen-facts     # headline counts + catalogues
+   cargo run -p xtask -- gen-schema    # config JSON Schema (kinds with options)
+   cargo run -p xtask -- gen-model     # LikeC4 model fragments
+   cargo test -p alint-e2e -- --no-fail-fast
+   ```
+   Every `coverage_audit_*` test should pass. The `gen-* --check` gates in CI and
+   the local preflight fail if any committed contract has drifted from the code.
+
+### Options and the config schema
 
 If the kind carries options, derive its schema branch from the Rust `Options`
-struct rather than hand-editing `schemas/v1/config.json`: add
-`#[derive(schemars::JsonSchema)]` to the struct (with `///` field docs and any
-`#[schemars(range/length/regex)]` constraints), register it in
-`alint-rules/src/lib.rs::migrated_option_schemas()`, then run
-`cargo run -p xtask -- gen-schema` to regenerate the schema (root + the in-crate
-copy). CI and preflight run `gen-schema --check`, which fails if the committed
-schema drifts from the Rust types. See ADR-0001 and
-`docs/design/spec-driven-development.md`. Kinds with deeply nested option shapes
-stay hand-written in the schema (omit them from `migrated_option_schemas`).
+struct rather than hand-editing `schemas/v1/config.json`:
 
-Your `///` field docs and constraints are not just for the schema: `xtask
-docs-export` reads the type-derived `$defs/rule_<kind>` branch and renders a
-`## Options` table (name / type / required / default / description) into the
-rule's alint.org page automatically. Write the field doc once on the Rust struct
-and it surfaces in the published reference - no separate options list to
-maintain. The `committed_schema_every_branch_renders_a_clean_table` test in
-`xtask` fails if a new option shape can't be classified into a clean table cell.
+1. Add `#[derive(schemars::JsonSchema)]` to the struct, with `///` docs on each
+   field and any `#[schemars(range/length/regex)]` constraints.
+2. Register the struct in `migrated_option_schemas()` in
+   `crates/alint-rules/src/lib.rs`.
+3. Run `cargo run -p xtask -- gen-schema` to regenerate the schema (both the root
+   copy and the in-crate copy).
 
-Adding a new rule kind also moves a surface-area count, so regenerate the
-contract: `cargo run -p xtask -- gen-facts` refreshes the committed `facts.json`
-(version + the six headline counts + catalogue lists that the README, docs, and
-alint.org render from). CI + the docs script run `gen-facts --check` and fail if
-`facts.json` drifts. The same applies when you add a family, bundled ruleset,
-fixer, output format, or subcommand. See `docs/design/facts-json.md`.
+CI and preflight run `gen-schema --check`, which fails when the committed schema
+drifts from the Rust types. Kinds with deeply nested option shapes stay
+hand-written in the schema; leave those out of `migrated_option_schemas()`.
 
-If you add or remove a *crate* (or an intra-workspace dependency), run
-`cargo run -p xtask -- gen-arch` to refresh the committed crate dependency graph
-(`docs/design/architecture/crate-graph.md`) and update the C4 model
-(`docs/design/architecture/workspace.dsl`); `gen-arch --check` gates both. See
-`docs/design/architecture-as-code.md`.
+The `///` field docs do double duty. `xtask docs-export` reads the type-derived
+`$defs/rule_<kind>` branch and renders an `## Options` table (name, type,
+required, default, description) onto the rule's page automatically, so you write
+each field's doc once. The `committed_schema_every_branch_renders_a_clean_table`
+test in `xtask/src/rule_options_table.rs` fails if an option shape cannot be
+placed into a clean table cell.
 
-### Family-directory conventions
+### Regenerating the surface-area contracts
 
-The family directory is chosen by what the rule *does*:
+Adding a rule kind moves a surface-area count, so `facts.json` has to be
+regenerated with `cargo run -p xtask -- gen-facts`. That file holds the version,
+the six headline counts, and the catalogue lists that the README, the docs, and
+alint.org render from. CI and the docs script run `gen-facts --check` and fail on
+drift. The same applies when you add a family, bundled ruleset, fix operation,
+output format, or subcommand.
 
-- `content/` — content scanning rules (file_content_matches /
-  no_trailing_whitespace / final_newline / line_endings / …)
-- `existence/` — presence/absence (file_exists / file_absent /
-  dir_exists / dir_absent)
-- `cross_file/` — fan-out / relational (for_each_dir /
-  for_each_file / pair / unique_by / every_matching_has /
-  dir_only_contains / dir_contains)
-- `encoding/` — Unicode + bytes (no_bom / no_bidi_controls /
-  no_zero_width_chars / file_is_text / file_is_ascii)
-- `metadata/` — file-property (file_min_size / file_max_size /
-  file_min_lines / file_max_lines / file_hash)
-- `naming/` — filename-shape (filename_case / filename_regex)
-- `structure/` — layout (max_directory_depth /
-  max_files_per_directory / no_empty_files)
-- `structured/` — JSONPath / JSON-Schema / YAML / TOML
-- `security/` — Trojan-source defense, denylists
-- `git/` — git-aware rules (git_blame_age / git_commit_message
-  / git_no_denied_paths / git_tracked_only behaviour)
-- `unix_metadata/` — chmod / symlink shapes
-- `when_iter/` / `when_facts/` — `when:` expression coverage
-- `interactions/` — multi-rule scenarios
+`cargo run -p xtask -- gen-model` refreshes the LikeC4 model fragment that
+carries the rule-kind taxonomy (`docs/design/architecture/model/rule-families.gen.c4`),
+which it derives from the `docs/rules.md` heading structure. Run it after step 4.
 
-If your rule doesn't fit, add a new family. The audits walk
-`scenarios/check/**/*.yml` recursively, so directory layout is
-purely organisational.
+Run `cargo run -p xtask -- gen-arch` only when you add or remove a crate or an
+intra-workspace dependency. It refreshes the crate dependency graph
+(`docs/design/architecture/crate-graph.md`) and its model fragment;
+`gen-arch --check` gates them.
+
+### Scenario directory conventions
+
+Scenarios live under `crates/alint-e2e/scenarios/check/<family>/`. The audits
+walk this tree recursively, so the split is purely organisational. Pick the
+family that matches what the rule does:
+
+- `content/` content scanning (`file_content_matches`, `file_content_forbidden`,
+  `file_header`, `file_footer`, `no_trailing_whitespace`, `final_newline`,
+  `line_endings`)
+- `cross_file/` relational and fan-out rules (`for_each_dir`, `for_each_file`,
+  `pair`, `unique_by`, `every_matching_has`, `dir_contains`)
+- `encoding/` Unicode and byte checks (`no_bom`, `no_bidi_controls`,
+  `no_zero_width_chars`, `file_is_text`, `file_is_ascii`)
+- `existence/` presence and absence (`file_exists`, `file_absent`, `dir_exists`,
+  `dir_absent`)
+- `git/` git-aware rules (`git_blame_age`, `git_commit_message`,
+  `git_no_denied_paths`)
+- `metadata/` file-property checks (`file_min_size`, `file_max_size`,
+  `file_min_lines`, `file_max_lines`, `file_hash`)
+- `naming/` filename shape (`filename_case`, `filename_regex`)
+- `scope_filter/` per-file scope-narrowing behaviour
+- `security/` Trojan-source defence and denylists
+- `structure/` repository layout (`max_directory_depth`,
+  `max_files_per_directory`, `no_empty_files`)
+- `structured/` JSONPath, JSON-Schema, YAML, and TOML queries
+- `unix_metadata/` permission and symlink shapes
+- `when_facts/` and `when_iter/` `when:` expression coverage
+- `interactions/` multi-rule scenarios
+
+If your rule does not fit an existing family, add a new directory.
 
 ### Scenario shape
 
@@ -114,176 +138,167 @@ given:
   tree:
     <path>: <content>            # files
     <path>:                      # directories
-      <child>: …
+      <child>: <content>
   config: |
     version: 1
     rules:
       - id: <test-rule-id>
         kind: <kind>
-        paths: …
-        level: …
+        paths: <glob>
+        level: <level>
 
 when: [check]                    # or [fix]
 
 expect:
-  - violations: []               # pass
-  - violations:                  # fires
+  - violations: []               # a passing case
+  - violations:                  # a firing case
       - {rule: <test-rule-id>, level: <level>, path: <where>}
 ```
 
-For git-aware rules, add `given.git: { init: true, add: […], commit: true }`.
+For git-aware rules, add `given.git: { init: true, add: [<paths>], commit: true }`.
 
 ### Native-test allowlist
 
-Some rule kinds can't have firing YAML scenarios because the
-testkit doesn't yet materialise the required filesystem
-primitive (chmod, symlinks, backdated commits, custom commit
-messages). For these, add a Rust integration test under
-`crates/alint-rules/tests/` or `crates/alint-e2e/tests/` that
-covers the firing path directly, then add the kind to
-`coverage_audit_pass_fail.rs::NATIVE_FIRES_ALLOWLIST` with a
-pointer to the native test.
+A few rule kinds cannot have firing YAML scenarios, because the testkit does not
+yet materialise the filesystem primitive they need (chmod bits, symlinks,
+backdated commits, custom commit messages). For these, add a Rust integration
+test under `crates/alint-rules/tests/` or `crates/alint-e2e/tests/` that
+exercises the firing path directly, then list the kind in
+`NATIVE_FIRES_ALLOWLIST` in `coverage_audit_pass_fail.rs`, with a pointer to that
+test.
 
-The allowlist is meant to shrink, not grow. As the testkit
-acquires `mode: 0o755`, `symlink_to: <path>`, custom commit
-messages, and `GIT_AUTHOR_DATE` overrides, allowlist entries
-move into native YAML coverage.
+The allowlist is meant to shrink, not grow. As the testkit gains `mode: 0o755`,
+`symlink_to: <path>`, custom commit messages, and `GIT_AUTHOR_DATE` overrides,
+allowlist entries move back into native YAML coverage.
 
 ## Adding a new bundled ruleset
 
-```text
-1. Add `crates/alint-dsl/rulesets/v1/<...>.yml`. The first
-   three lines must be:
-     # alint://bundled/<name>@v<rev>
-     #
-     # <prose description>
-   (enforced by the `bundled-ruleset-has-uri-header` rule in
-    .alint.yml — caught by `alint check .`)
-2. Add e2e scenarios:
-     crates/alint-e2e/scenarios/check/bundled-<name>/
-       <name>_well_formed_passes.yml      (every expect.violations: [])
-       <name>_*_flagged.yml               (≥1 non-empty violations entry)
-3. Run `cargo test -p alint-e2e --test coverage_audit_bundled_rulesets`.
-```
+1. Add `crates/alint-dsl/rulesets/v1/<name>.yml`. Its first three lines must be:
+   ```text
+   # alint://bundled/<name>@v<rev>
+   #
+   # <prose description>
+   ```
+   The `bundled-ruleset-has-uri-header` rule in the root `.alint.yml` enforces
+   this shape, so `alint check .` catches a malformed header.
+2. Add e2e scenarios under `crates/alint-e2e/scenarios/check/bundled-<name>/`:
+   - `<name>_well_formed_passes.yml` (every `expect.violations: []`)
+   - `<name>_*_flagged.yml` (at least one non-empty `violations` entry)
+3. Document the ruleset in `docs/rules.md`. The rule IDs in its markdown table
+   and the "N rules" count in the section header must match the YAML exactly;
+   `coverage_audit_rules_md_drift` gates this.
+4. Run `cargo test -p alint-e2e --test coverage_audit_bundled_rulesets`.
 
-### `scope_filter:` for ecosystem rulesets (v0.9.6+)
+### scope_filter for ecosystem rulesets
 
-Bundled rulesets that target one ecosystem (`rust@v1`,
-`node@v1`, etc.) should pair their tree-level `when:
-facts.has_<ecosystem>` gate with a per-rule
-`scope_filter: { has_ancestor: <manifest> }` on per-file
-content rules so the rule fires only on files inside that
-ecosystem's package subtree. The two gates compose:
-`when:` is a cheap tree-level short-circuit (no facts → no
-rule iteration); `scope_filter:` narrows per-file scope when
-the rule does run, useful in polyglot monorepos where one
-language's package sits next to another's.
+A bundled ruleset that targets one ecosystem (`rust`, `node`, and so on) should
+pair its tree-level `when: facts.has_<ecosystem>` gate with a per-rule
+`scope_filter: { has_ancestor: <manifest> }` on its per-file content rules, so a
+rule fires only on files inside that ecosystem's package subtree. The two gates
+compose. `when:` is a cheap tree-level short-circuit (no facts means no rule
+iteration), while `scope_filter:` narrows per-file scope when the rule does run.
+That distinction matters in polyglot monorepos, where one language's package
+sits next to another's.
 
 ```yaml
-# In a ruleset YAML:
 facts:
   - id: has_rust
-    any_file_exists: [Cargo.toml, "**/Cargo.toml"]    # broadened: catch nested manifests
+    any_file_exists: [Cargo.toml, "**/Cargo.toml"]   # catch nested manifests too
 
 rules:
   - id: rust-sources-no-bidi
-    when: facts.has_rust                              # tree gate
+    when: facts.has_rust                             # tree gate
     kind: no_bidi_controls
-    paths: "**/*.rs"                                  # path glob
-    scope_filter:                                     # ancestor walk
-      has_ancestor: Cargo.toml                        # canonical per-package manifest
+    paths: "**/*.rs"                                 # path glob
+    scope_filter:                                    # ancestor walk
+      has_ancestor: Cargo.toml                       # per-package manifest
     level: error
 ```
 
 Constraints:
 
-- **Per-file rules only.** `scope_filter:` is supported on
-  `PerFileRule`-trait rules (engine consults it in the file-
-  major dispatch loop). Cross-file rules (`pair`,
-  `for_each_dir`, `file_exists`, etc.) reject `scope_filter:`
-  at build time with a pointer to the `for_each_dir +
-  when_iter:` pattern. Rule-major rules like `filename_case`
-  silently ignore `scope_filter:` today — gate them via the
-  rule's `paths:` glob or skip the filter.
-- **Literal filenames, not globs.** Each `has_ancestor:` entry
-  is a filename like `Cargo.toml` or `package.json`; no `**/`
-  prefix, no path separators. The walk handles "anywhere up
-  the tree" by traversing `Path::parent()` upward.
-- **File's own dir counts as ancestor.** A `pyproject.toml`
-  matched by `paths: pyproject.toml` and gated by
-  `scope_filter: { has_ancestor: pyproject.toml }` always
-  passes its own ancestor walk — don't add the filter when the
-  rule's `paths:` is already a literal manifest filename.
-- **`has_ancestor` accepts a single string or a list.**
-  `has_ancestor: pom.xml` and `has_ancestor: [pom.xml,
-  build.gradle, build.gradle.kts]` are both valid; first-match-
-  wins on the upward walk.
+- **Per-file rules only.** `scope_filter:` is honoured by `PerFileRule` rules,
+  which consult it in the file-major dispatch loop. Cross-file rules (`pair`,
+  `for_each_dir`, `file_exists`, and the like) reject `scope_filter:` at build
+  time with a pointer to the `for_each_dir` plus `when_iter:` pattern. Rule-major
+  rules such as `filename_case` ignore `scope_filter:`, so gate those with the
+  rule's `paths:` glob instead.
+- **Literal filenames, not globs.** Each `has_ancestor:` entry is a filename such
+  as `Cargo.toml` or `package.json`, with no `**/` prefix and no path
+  separators. The walk reaches "anywhere up the tree" by traversing parent
+  directories upward.
+- **A file's own directory counts as an ancestor.** A `pyproject.toml` matched by
+  `paths: pyproject.toml` and gated by
+  `scope_filter: { has_ancestor: pyproject.toml }` always passes its own ancestor
+  walk, so do not add the filter when the rule's `paths:` is already a literal
+  manifest filename.
+- **`has_ancestor` accepts a single string or a list.** Both
+  `has_ancestor: pom.xml` and
+  `has_ancestor: [pom.xml, build.gradle, build.gradle.kts]` are valid; the upward
+  walk stops at the first match.
 
-Design + semantics:
-[`docs/design/v0.9/scope-filter.md`](../design/v0.9/scope-filter.md).
-
-The audit treats nested rulesets like
-`monorepo/cargo-workspace.yml` as a single unit — its scenarios
-live alongside `monorepo`'s under `bundled-monorepo/`. The
-audit doesn't require a separate family directory per nested
-ruleset; the URI match (`extends: alint://bundled/monorepo/cargo-workspace@v1`)
-is what counts.
+The audit treats a nested ruleset such as `monorepo/cargo-workspace.yml` as a
+single unit, with its scenarios alongside `monorepo`'s under `bundled-monorepo/`.
+No separate family directory is required per nested ruleset; the URI match
+(`extends: alint://bundled/monorepo/cargo-workspace@v1`) is what counts.
 
 ## Adding a rule-kind alias
 
-Aliases register the same builder under multiple names (e.g.
-`max_size` ↔ `file_max_size`). They don't need new scenarios;
-add the alias to `coverage_audit.rs::aliased` AND
-`coverage_audit_pass_fail.rs::ALIASES` so the audits treat
-both spellings as one canonical kind.
+An alias registers the same builder under a second name (for example, `max_size`
+for `file_max_size`). Aliases need no new scenarios. Add the pair to every alias
+table in the coverage audits, so each audit treats both spellings as one
+canonical kind:
+
+- the inline `aliased` table in `coverage_audit.rs`
+- `ALIASES` in `coverage_audit_pass_fail.rs`
+- `ALIASES` in `coverage_audit_bench_listing.rs`
+- `ALIASES` in `coverage_audit_baseline_safety.rs`
+
+These tables are kept identical. A missing entry in any one of them fails that
+audit.
 
 ## Bench-scale coverage (soft)
 
-Bench coverage isn't a correctness requirement; the
-`coverage_audit_bench_listing.rs` test always passes and
-just emits an `eprintln!` summary of rule kinds absent from
-any `xtask/src/bench/scenarios/*.yml`. Run with
-`cargo test -p alint-e2e -- --nocapture` to see the listing.
+Bench coverage is not a correctness requirement. The `coverage_audit_bench_listing`
+test always passes and only prints a summary of the rule kinds absent from every
+`xtask/src/bench/scenarios/*.yml`. Run `cargo test -p alint-e2e -- --nocapture`
+to see the listing.
 
-If your new rule's dispatch shape is novel (e.g. a new
-cross-file aggregation that today's S6 / S7 / S8 don't
-exercise), consider extending one of those scenarios so
-`xtask bench-compare` gates regressions of its perf shape.
-This is opt-in — most rule additions don't need it.
+If your rule's dispatch shape is genuinely new (for example, a cross-file
+aggregation that the existing S6, S7, and S8 scenarios do not exercise), consider
+extending one of those scenarios so `xtask bench-compare` gates regressions of
+its performance shape. This is opt-in; most rule additions do not need it.
 
-## Failure modes you'll hit
+## Common failures
 
-- **`coverage_audit_pass_fail` fails with "missing FIRING"** —
-  add a `<kind>_fires.yml` scenario whose `expect.violations:`
-  lists a rule with that kind. Or, if the firing case can't be
-  expressed in YAML, add to `NATIVE_FIRES_ALLOWLIST`.
-- **`coverage_audit_pass_fail` fails with "missing SILENT"** —
-  add a `<kind>_pass.yml` (or similar) with
-  `expect: - violations: []`.
-- **`coverage_audit_bundled_rulesets` fails** — the new
-  ruleset hasn't been referenced from any scenario via
-  `extends:`. Add at least a well-formed scenario.
-- **`coverage_audit.rs` fails with "missing kinds"** — the
-  audit doesn't see your new kind in any scenario at all. The
-  earlier failures usually surface first; this is the
-  catch-all backstop.
-- **`alint check .` fires `bundled-ruleset-has-uri-header`** —
-  the ruleset's first three lines don't match the docs-export
-  parser's expected header shape. See the rule's `message:` in
-  `.alint.yml` for the exact pattern.
+- `coverage_audit_pass_fail` reports "missing FIRING": add a `<kind>_fires.yml`
+  scenario whose `expect.violations:` lists a rule of that kind. If the firing
+  case cannot be expressed in YAML, add the kind to `NATIVE_FIRES_ALLOWLIST`.
+- `coverage_audit_pass_fail` reports "missing SILENT": add a `<kind>_pass.yml`
+  with `expect: - violations: []`.
+- `coverage_audit_bundled_rulesets` fails: the new ruleset is not referenced from
+  any scenario via `extends:`. Add at least a well-formed scenario.
+- `coverage_audit` reports "missing kinds": the audit sees no scenario for the
+  kind at all. The more specific failures above usually surface first; this is
+  the catch-all backstop.
+- The `schema.rs` registry guard reports a missing kind: add the kind's entry to
+  `all_kinds.yaml`.
+- `alint check .` fires `bundled-ruleset-has-uri-header`: the ruleset's first
+  three lines do not match the required header shape. See the rule's `message:`
+  in `.alint.yml` for the exact pattern.
 
 ## Keeping docs in lockstep
 
 The generated contracts (facts, schema, rules, the architecture model) flow to
-alint.org and are gated against drift, so a new rule kind's docs can't silently
+alint.org and are gated against drift, so a new rule kind's docs cannot silently
 fall out of sync:
 
 <likec4-view view-id="docsAsCodeFlow"></likec4-view>
 
 ## Related docs
 
-- `docs/design/v0.9/coverage-and-dogfood.md` — design rationale
-- `docs/design/ARCHITECTURE.md` — engine + rule layer overview
-- `crates/alint-e2e/tests/coverage_audit_*.rs` — the audits
-  themselves; each is a single integration test with a clear
-  panic message
+- `docs/design/spec-driven-development.md`: the spec-driven model and the audit
+  matrix.
+- `docs/design/facts-json.md`: the facts contract and how the counts are derived.
+- `crates/alint-e2e/tests/coverage_audit_*.rs`: the audits themselves, each a
+  single integration test with a clear panic message.


### PR DESCRIPTION
## Why

The rule-authoring page (`alint.org/docs/development/rule-authoring/`) opened with **\"Lands in v0.9.9.\"** and carried other version-stamped framing (`(v0.9.6+)`), plus heavy em-dash / ellipsis prose. A review against the current code also surfaced real **accuracy and completeness** gaps, not just cosmetics.

## Accuracy / completeness fixes

- **Missing checklist steps.** The "add a rule kind" list omitted three required steps the LikeC4 `addRuleKindFlow` diagram already showed:
  - add the kind to `crates/alint-dsl/tests/fixtures/all_kinds.yaml` (the `schema.rs` registry guard fails without it);
  - document it in `docs/rules.md` (the reference page is sliced from that H3 section; the docs build fails without a fenced ` ```yaml ` example);
  - run `gen-model`.
- **`wants_git_tracked()` does not exist** — the method is `git_tracked_mode()` returning `GitTrackedMode`.
- **Registration** is `register_builtin()`, not `builtin_registry()` (the latter just calls the former).
- **Alias tables**: the doc named two; there are now **four** (`coverage_audit.rs` inline `aliased`, plus `ALIASES` in `coverage_audit_pass_fail` / `coverage_audit_bench_listing` / `coverage_audit_baseline_safety`), kept identical.
- **Scenario-family list** was stale (missing `scope_filter/`); per-family kind examples refreshed against the real kinds.

## Style

No em-dashes, en-dashes, ellipses, or curly punctuation. Version-free repo-path references as inline code (no markdown file links, so nothing dangles on GitHub or the site). Added a "Common failures" section and reconciled the prose with both embedded LikeC4 flows.

## Verification

- `cargo test -p alint-e2e --test coverage_audit_doc_links` passes.
- `xtask docs-export` bundles the page cleanly, both `<likec4-view>` embeds intact.

## Propagation note

`docs/development/rule-authoring.md` is **not** in the docs-bundle main-overlay list, so the live alint.org page rebuilds from the release tag. This lands on the site at the **next release (v0.14.0)** — correct, since the rewrite references `coverage_audit_baseline_safety.rs` (baseline mode is still `[Unreleased]`), so the drift gate intentionally holds it back from the live v0.13.0 site.