### PR TITLE
ci(release): maintain a moving v0 major tag (unblocks alint.org auto-bump)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,10 @@ name: Release
 
 on:
   push:
-    tags: ["v*"]
+    # Three-part version tags only. A bare major tag (v0, v1) is a moving
+    # pointer the `release` job maintains for `asamarts/alint@v0` consumers;
+    # it must NOT re-run this release pipeline.
+    tags: ["v*.*.*"]
 
 permissions:
   contents: write   # required to create GitHub Releases
@@ -205,6 +208,22 @@ jobs:
           # *published* Release (now this one), rebuilds the bundle at the new
           # version, and pings the deploy hook -- so the guard clears on its own.
           gh workflow run docs-bundle.yml --ref main
+
+      - name: move the major tag (e.g. v0) to this release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Consumers pin `asamarts/alint@v<major>` (e.g. @v0) to always track the
+          # latest release: the action resolves a non-vX.Y.Z ref to `latest`
+          # (see action.yml), and alint.org's CI pins @v0. Keep the major tag on
+          # the newest release so its action.yml + install.sh stay current. Pushed
+          # with GITHUB_TOKEN, so it does NOT re-trigger this workflow
+          # (anti-recursion); the `v*.*.*` filter above also excludes bare major tags.
+          MAJOR="${GITHUB_REF_NAME%%.*}"   # v0.14.1 -> v0
+          echo "Moving major tag ${MAJOR} -> ${GITHUB_SHA} (from ${GITHUB_REF_NAME})"
+          git tag -f "$MAJOR" "$GITHUB_SHA"
+          git push -f origin "refs/tags/${MAJOR}"
 
   docker:
     name: push Docker image to ghcr.io


### PR DESCRIPTION
## What

Maintain a moving `v0` major tag so alint.org's CI (and any consumer) can pin `asamarts/alint@v0` instead of an exact `@vX.Y.Z`. The action already resolves a non-`vX.Y.Z` ref to the latest release (`action.yml`), so `@v0` always installs the newest alint.

## Why

alint.org's `bump-on-release` auto-bumper edits `lint.yml`'s pinned `asamarts/alint@vX.Y.Z` on every release, but `GITHUB_TOKEN` cannot push workflow-file changes, so the auto-PR never opens and the bump is done manually. Pinning `@v0` removes that per-release action-ref edit entirely, so the token-based bumper can push and open its PR.

## Changes

- **Trigger** `tags: ["v*"]` to `["v*.*.*"]`: a bare major tag (`v0`) must not re-run the release pipeline (the preflight `tag == Cargo.toml version` check would fail on `v0`). Every real release tag is three-part, so all still match.
- **`release` job**: after creating the Release, force-move `v<major>` (e.g. `v0`) to the released commit via `GITHUB_TOKEN`. GitHub's anti-recursion rule means this push does not re-trigger the workflow, and the `v*.*.*` filter excludes bare major tags anyway.

## Follow-up (after this merges)

1. Create the `v0` tag once (pointing at v0.14.1) so `@v0` resolves before the next release.
2. alint.org: repin `lint.yml` to `@v0`, and drop the action-ref from `bump-version-pins.sh` + `check-version-pins.sh`.

The move step can only be exercised on the next real release, but it is a plain `git tag -f` + `git push` under the already-declared `contents: write`.
