### PR TITLE
ci: scope remaining v* tag triggers to v*.*.* (major-tag safety; follow-up to #148)

### DIFF
--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -22,7 +22,7 @@ name: Action self-test
 on:
   push:
     branches: [main]
-    tags: ["v*"]
+    tags: ["v*.*.*"]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/bench-docker.yml
+++ b/.github/workflows/bench-docker.yml
@@ -18,7 +18,7 @@ name: bench-docker
 on:
   push:
     tags:
-      - "v*"
+      - "v*.*.*"
     branches:
       - main
     paths:

--- a/.github/workflows/bench-record.yml
+++ b/.github/workflows/bench-record.yml
@@ -40,7 +40,7 @@ name: bench-record
 on:
   push:
     tags:
-      - "v*"
+      - "v*.*.*"
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches: [main, master]
-    tags: ["v*"]
+    tags: ["v*.*.*"]
   pull_request:
     branches: [main, master]
 

--- a/.github/workflows/docs-bundle.yml
+++ b/.github/workflows/docs-bundle.yml
@@ -13,7 +13,7 @@ on:
     #   Treats docs as a sixth distribution channel alongside
     #   crates.io / npm / Docker / Homebrew / GH Release.
     branches: [main]
-    tags: ["v*"]
+    tags: ["v*.*.*"]
   workflow_dispatch:
     # Lets the alint.org repo (or a maintainer) re-trigger a
     # rebuild without a code change — useful when only a brand-


### PR DESCRIPTION
Follow-up to #148 (which scoped release.yml). Scopes ci, action-selftest, docs-bundle, bench-docker, and bench-record from tags:[v*] to [v*.*.*] so a bare major tag (v0) never fires the release-oriented workflows. Otherwise, creating/moving the v0 pointer for asamarts/alint@v0 consumers would spuriously run full CI, the action self-test, a docs-bundle rebuild+deploy, and record a bogus v0 benchmark datapoint. Every real release tag is three-part (vX.Y.Z), so real releases are unaffected. YAML validated; diff is 5 one-line trigger changes.