### PR TITLE
ci: SHA-pin third-party GitHub Actions and enforce it

### DIFF
--- a/.alint.yml
+++ b/.alint.yml
@@ -419,3 +419,25 @@ rules:
     message: >-
       Smart / curly quotes on top-level user-facing docs are a
       "pasted from a chat window" tell. Use straight quotes.
+
+  # --- Supply-chain: pin GitHub Actions to full commit SHAs ----------------
+  # OpenSSF Scorecard Pinned-Dependencies. Mirrors gha-pin-actions-to-sha in
+  # alint://bundled/ci/github-actions@v1, enforced at error here (the ruleset
+  # default is warning). Every third-party action `uses:` must be a full 40-hex
+  # commit SHA so a moved or compromised tag cannot silently change what CI
+  # runs. Local `./` composite-action references (the action-selftest jobs that
+  # load this repo's own action.yml from the checked-out commit) are allowed.
+  # Dependabot (.github/dependabot.yml) keeps the pins current.
+  - id: gha-pin-actions-to-sha
+    kind: yaml_path_matches
+    paths:
+      - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"
+    path: "$.jobs.*.steps[*].uses"
+    matches: '^(\./.*|[a-zA-Z0-9._/-]+@[a-f0-9]{40})$'
+    if_present: true
+    level: error
+    message: >-
+      Third-party GitHub Action is not pinned to a full commit SHA. Pin with
+      `@<40-char-sha>  # v4.1.1` so a moved or compromised tag cannot silently
+      change what runs. (Local `./` action references are allowed.)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,12 +50,12 @@ updates:
         update-types:
           - patch
           - minor
-    # dtolnay/rust-toolchain@X.Y.Z's tag IS the rustc version it installs, and
-    # bench-record.yml pins it to the canonical bench fingerprint (rustc 1.97.0;
-    # the whole macro corpus is measured on it). Dependabot treats it as an action
-    # version and bumps it (did: 1.97.0 -> 1.100.0 in #132), silently breaking
-    # fingerprint reproducibility. That pin is bumped MANUALLY in lock-step with a
-    # re-baseline (see the comment at its `uses:`), so hold it here.
+    # dtolnay/rust-toolchain is now SHA-pinned with an explicit `toolchain:`
+    # input (bench-record.yml uses `toolchain: 1.97.0`, the canonical bench
+    # fingerprint the whole macro corpus is measured on). Holding it here keeps
+    # both the action SHA and that pinned rustc stable: the rustc bump is done
+    # MANUALLY in lock-step with a re-baseline, not by Dependabot (which once
+    # bumped 1.97.0 -> 1.100.0 in #132, silently breaking fingerprint repro).
     ignore:
       - dependency-name: "dtolnay/rust-toolchain"
     commit-message:

--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -36,7 +36,7 @@ jobs:
     name: default (github annotations)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: alint check (annotations)
         uses: ./
         # Default format is `github` — inline annotations on
@@ -47,7 +47,7 @@ jobs:
     name: sarif output
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: alint check (sarif)
         id: alint
         uses: ./
@@ -70,7 +70,7 @@ jobs:
     name: json output
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: alint check (json)
         uses: ./
         with:
@@ -80,7 +80,7 @@ jobs:
     name: pinned version input
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: alint check with explicit version input
         uses: ./
         with:
@@ -97,7 +97,7 @@ jobs:
     name: config input (single path)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: alint check with an explicit config path
         uses: ./
         with:
@@ -111,7 +111,7 @@ jobs:
     name: config input (multiple paths rejected)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: alint rejects two config paths
         id: multi
         continue-on-error: true

--- a/.github/workflows/bench-docker.yml
+++ b/.github/workflows/bench-docker.yml
@@ -48,7 +48,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # SHA-pinned per supply-chain hardening (matches release.yml).
       # Dependabot raises a PR on any docker/* major-version bump; keep

--- a/.github/workflows/bench-record.yml
+++ b/.github/workflows/bench-record.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: [self-hosted, linux, bench]
     timeout-minutes: 360   # 6h cap; ~3.5h expected at publish-grade flags
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
           fetch-depth: 0
@@ -83,8 +83,10 @@ jobs:
       # being cross-version comparable. 1.97.0 matches the v0.10-v0.13 backfill
       # that re-based the series onto kbench. Bump deliberately (and re-baseline)
       # when the fleet moves, never implicitly via `stable` drift.
-      - uses: dtolnay/rust-toolchain@1.97.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@35a842e360814583e976785eeda0bd0655cb8e83 # 1.97.0
+        with:
+          toolchain: 1.97.0
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: bench-record
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       runner: ${{ steps.route.outputs.runner }}
       untrusted: ${{ steps.route.outputs.untrusted }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
       # Routing runs FIRST and writes to its OWN step output, which the
@@ -81,9 +81,11 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ci-fmt
       - run: ci/scripts/fmt.sh
@@ -96,9 +98,11 @@ jobs:
       && needs.changes.outputs.rust == 'true'
     runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ci-clippy
       - run: ci/scripts/clippy.sh
@@ -111,9 +115,11 @@ jobs:
       && needs.changes.outputs.rust == 'true'
     runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ci-test
       - run: ci/scripts/test.sh
@@ -126,9 +132,11 @@ jobs:
       && needs.changes.outputs.rust == 'true'
     runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ci-audit
       - run: ci/scripts/audit.sh
@@ -141,9 +149,11 @@ jobs:
       && needs.changes.outputs.rust == 'true'
     runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ci-deny
       - run: ci/scripts/deny.sh
@@ -156,9 +166,11 @@ jobs:
       && needs.changes.outputs.rust == 'true'
     runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ci-build
       - run: ci/scripts/build.sh
@@ -178,9 +190,11 @@ jobs:
       && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.docs == 'true')
     runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ci-docs
       # Ephemeral fork-PR path only: the box's runner image already ships
@@ -188,7 +202,7 @@ jobs:
       # `likec4 validate` + `gen-mermaid --check` gates run (they fetch
       # likec4 via `npx -y likec4@<pin>`). Skipped on the box.
       - if: needs.changes.outputs.untrusted == 'true'
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
       # Load-bearing for schema/parser/contract correctness; must catch drift
@@ -203,9 +217,11 @@ jobs:
       && needs.changes.outputs.rust == 'true'
     runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ci-dogfood
       - run: ci/scripts/dogfood.sh
@@ -227,9 +243,11 @@ jobs:
       && needs.changes.outputs.untrusted != 'true'
     runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ci-bench-smoke
       - run: ci/scripts/bench-smoke.sh
@@ -257,11 +275,13 @@ jobs:
       # job's `needs:` so a failed gate is reflected in the aggregate Summary.
       DET_PERF_ADVISORY: "1"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ci-perf-gate
       - env:
@@ -281,9 +301,11 @@ jobs:
       && needs.changes.outputs.examples == 'true'
     runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ci-examples
       - run: ci/scripts/examples-validate.sh
@@ -300,7 +322,7 @@ jobs:
       && needs.changes.outputs.rust == 'true'
     runs-on: ${{ fromJSON(needs.changes.outputs.runner) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - run: ci/scripts/shell-tests.sh
 
   # ── Editor extensions ─────────────────────────────────────────────
@@ -317,8 +339,8 @@ jobs:
       && needs.changes.outputs.editors == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "20"
       - name: VS Code — install, typecheck, bundle
@@ -327,17 +349,18 @@ jobs:
           npm ci
           npm run check-types
           npm run build
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           targets: wasm32-wasip1
       - name: Zed — wasm build
         working-directory: editors/zed
         run: cargo build --release --target wasm32-wasip1
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
           java-version: "17"
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
       - name: JetBrains — build + verify plugin
         working-directory: editors/jetbrains
         run: ./gradlew buildPlugin verifyPlugin --no-daemon
@@ -365,7 +388,7 @@ jobs:
     # fall back to ubuntu-latest so a clean cancel can't fail on fromJSON('').
     runs-on: ${{ needs.changes.outputs.runner && fromJSON(needs.changes.outputs.runner) || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - env:
           RUST_CHANGED: ${{ needs.changes.outputs.rust }}
           DOCS_CHANGED: ${{ needs.changes.outputs.docs }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,28 +39,29 @@ jobs:
     # recurring — this is the belt-and-suspenders net.
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: coverage
 
       - run: ci/scripts/coverage.sh
 
       - name: Upload LCOV artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-lcov
           path: target/coverage/coverage.lcov
           retention-days: 30
 
       - name: Upload HTML artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-html
           path: target/coverage/html/
@@ -82,7 +83,7 @@ jobs:
           fi
       - name: Upload to Codecov
         if: steps.codecov_token.outputs.present == 'true'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/coverage/coverage.lcov

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -39,13 +39,13 @@ jobs:
             target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install stable toolchain
         run: rustup toolchain install stable --profile minimal
 
       - name: Cache cargo registry & build
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/docs-bundle.yml
+++ b/.github/workflows/docs-bundle.yml
@@ -49,7 +49,7 @@ jobs:
     name: Build + push docs bundle
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Full history + tags: the bundle is built from the latest
           # *release* tag (next step), not the ref that triggered the
@@ -74,8 +74,10 @@ jobs:
           git checkout --detach "${LATEST_TAG}"
           echo "BUNDLE_SOURCE=${LATEST_TAG}" >> "$GITHUB_ENV"
 
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: docs-bundle
 

--- a/.github/workflows/editors-e2e.yml
+++ b/.github/workflows/editors-e2e.yml
@@ -31,13 +31,15 @@ jobs:
     name: VS Code extension (headless)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
       - name: Build alint from this branch
         run: cargo build --release -p alint
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "20"
 
@@ -55,9 +57,11 @@ jobs:
     name: Neovim LSP smoke (headless)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
       - name: Build alint from this branch
         run: cargo build --release -p alint
 
@@ -76,7 +80,7 @@ jobs:
     name: Tier-2 editor configs (static)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # python3 (tomllib) is preinstalled; emacs is needed to byte-compile
       # the elisp config.
       - name: Install Emacs
@@ -88,17 +92,19 @@ jobs:
     name: JetBrains LSP e2e (headless)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
       - name: Build alint from this branch
         run: cargo build --release -p alint
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
           java-version: "17"
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
 
       - name: JetBrains LSP integration test
         working-directory: editors/jetbrains

--- a/.github/workflows/issue-26-e2e.yml
+++ b/.github/workflows/issue-26-e2e.yml
@@ -33,7 +33,7 @@ jobs:
     name: range mode (synthetic fixture)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -185,7 +185,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -231,6 +231,6 @@ jobs:
     name: rust test suites
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: cargo test (workspace)
         run: cargo test --workspace --quiet

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -24,8 +24,8 @@ jobs:
   kani:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Run Kani proofs
-        uses: model-checking/kani-github-action@v1
+        uses: model-checking/kani-github-action@2534b7aeb3c6b4b0a5ecc3981bb3e63d47b5b126 # v1
         with:
           args: "-p alint-rules"

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -31,10 +31,12 @@ jobs:
     runs-on: [self-hosted, linux, alint]
     timeout-minutes: 240
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: mutants
 
@@ -95,7 +97,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mutants-${{ steps.pick.outputs.target }}-${{ github.run_id }}
           path: target/mutants/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       CARGO_INCREMENTAL: "0"
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: verify tag matches workspace version
         # release.yml triggers only on `push: tags: ["v*"]`, so
         # GITHUB_REF_NAME is the tag. Fail fast if the tag doesn't match the
@@ -71,10 +71,11 @@ jobs:
             exit 1
           fi
           echo "tag ${GITHUB_REF_NAME} matches Cargo.toml version ${CARGO_VER}."
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           components: rustfmt,clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: release-preflight
       - name: fmt
@@ -120,9 +121,11 @@ jobs:
             use_cross: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: release-${{ matrix.target }}
 
@@ -139,7 +142,7 @@ jobs:
         run: ci/scripts/release-binary.sh
 
       - name: upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: alint-${{ matrix.target }}
           path: |
@@ -155,10 +158,10 @@ jobs:
       contents: write   # create the GitHub Release
       actions: write    # dispatch docs-bundle.yml (workflow_dispatch) below
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: release-artifacts
           merge-multiple: true
@@ -230,10 +233,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: download linux artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: release-artifacts
           pattern: alint-*-unknown-linux-musl
@@ -332,13 +335,15 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: publish-crates
       - name: mint a short-lived crates.io token via OIDC
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1
         id: crates-auth
       - name: publish all 6 crates in dependency order
         env:
@@ -356,8 +361,8 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
@@ -393,7 +398,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: download SHA256SUMS from this release
         env:
@@ -410,7 +415,7 @@ jobs:
         # Dedicated ed25519 deploy key registered on
         # asamarts/homebrew-alint with write access; private half
         # stored as the HOMEBREW_TAP_DEPLOY_KEY secret.
-        uses: webfactory/ssh-agent@v0.10.0
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
 
@@ -454,8 +459,8 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "20"
       - name: stamp version from tag + publish to both registries
@@ -501,12 +506,12 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
           java-version: "17"
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
       - name: stamp version from tag + publish
         env:
           # Repo secrets (Settings → Secrets → Actions):


### PR DESCRIPTION
## What

SHA-pins every third-party GitHub Action across the 12 workflows to a full commit SHA and enforces it via alint's own Dogfood self-lint. Completes Batch 2 of the launch fix plan (the alint.org half landed in asamarts/alint.org#49). Backs the r/devops launch hook: alint's own repos now SHA-pin their third-party actions.

## Changes

- **~92 refs pinned**: `checkout`, `rust-cache`, `setup-node`/`setup-java`, `upload`/`download-artifact`, `setup-gradle`, `ssh-agent`, `codecov`, `cache`, `kani`, `crates-io-auth` to full SHAs (each with a `# vX` comment). The `docker/*` actions were already pinned.
- **`dtolnay/rust-toolchain` (22 uses)**: pinned to a SHA AND given an explicit `toolchain:` input (`stable`, or `1.97.0` for the bench fingerprint). The `@stable` / `@X.Y.Z` ref previously carried the toolchain selection, which a bare SHA cannot, so the input is required.
- **Enforce**: `gha-pin-actions-to-sha` at `error` in `.alint.yml` (allowing local `./` composite refs), so a future unpinned action fails the Dogfood job.
- **Dependabot**: already covers `github-actions`; refreshed the `dtolnay/rust-toolchain` ignore comment for the new SHA + toolchain-input reality.

## Verification (local)

- All 12 workflows parse (`yaml.safe_load`).
- The pin rule loads and passes (`alint check` exit 0, no `gha-pin-actions-to-sha` violations); **114 refs SHA-pinned; zero unpinned third-party refs remain**.
- SHAs are `gh api`-resolved (valid existing commits).
- Spot-checked the rust-toolchain transformation: `toolchain:` lands as the first `with:` param, existing `components:`/`targets:` preserved, no duplicate `with:`.

Note: release/bench/kani/mutants workflows do not run on PRs, so CI here exercises the common actions (`checkout`, `rust-toolchain`, `rust-cache`); the rarer refs are API-resolved SHAs used identically elsewhere.
