### PR TITLE
docs: use alint.org/install.sh in the install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Working `.alint.yml` configs for 30 OSS repos (single-language workspaces, polyg
 
 ```sh
 # Install (Linux + macOS + Windows tarballs):
-curl -sSL https://raw.githubusercontent.com/asamarts/alint/main/install.sh | bash
+curl -sSL https://alint.org/install.sh | bash
 
 # Initialise a config in the current repo (uses bundled oss-baseline + auto-detected ecosystem rulesets):
 cat > .alint.yml <<'YAML'
@@ -97,7 +97,7 @@ Scope is the filesystem shape and contents of a repository, not the semantics of
 ### install.sh (Linux + macOS + Windows tarballs)
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/asamarts/alint/main/install.sh | bash
+curl -sSL https://alint.org/install.sh | bash
 ```
 
 Detects platform (Linux / macOS, x86_64 / aarch64), downloads the matching tarball, verifies the SHA-256, and installs to `$INSTALL_DIR` (default `~/.local/bin`). Windows users download the Windows tarball from the [Releases page](https://github.com/asamarts/alint/releases).

--- a/docs/site/getting-started/installation.md
+++ b/docs/site/getting-started/installation.md
@@ -21,12 +21,12 @@ The recommended path on macOS and Linux. The [asamarts/homebrew-alint](https://g
 ## install.sh (Linux + macOS + Windows tarballs)
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/asamarts/alint/main/install.sh | bash
+curl -sSL https://alint.org/install.sh | bash
 ```
 
 Detects platform (Linux / macOS, x86_64 / aarch64), downloads the matching tarball from GitHub Releases, verifies its SHA-256, and installs to `$INSTALL_DIR` (default `~/.local/bin`). Windows users download the Windows tarball from the [Releases page](https://github.com/asamarts/alint/releases) directly.
 
-Supply-chain note: the installer verifies the SHA-256 of the release tarball it downloads, but the script itself is fetched from the `main` branch. To pin the installer too, point `curl` at a release tag instead of `main` (for example `https://raw.githubusercontent.com/asamarts/alint/v0.14.1/install.sh`), or download it from the [Releases page](https://github.com/asamarts/alint/releases) and review it before running.
+Supply-chain note: the installer verifies the SHA-256 of the release tarball it downloads, but the script itself is fetched from the `main` branch (`alint.org/install.sh` redirects there). To pin the installer too, point `curl` at a release tag instead of `main` (for example `https://raw.githubusercontent.com/asamarts/alint/v0.14.1/install.sh`), or download it from the [Releases page](https://github.com/asamarts/alint/releases) and review it before running.
 
 ## Docker
 

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 # $HOME/.local/bin).
 #
 # Usage:
-#   curl -sSL https://raw.githubusercontent.com/asamarts/alint/main/install.sh | bash
+#   curl -sSL https://alint.org/install.sh | bash
 #
 # Environment variables:
 #   ALINT_VERSION   Tag to install (e.g. v0.1.0). Defaults to the latest release.


### PR DESCRIPTION
Switches the curl install command in the README (x2), the install guide (docs/site), and install.sh own usage comment from the raw githubusercontent URL to the branded alint.org/install.sh (302-redirects to the same canonical main installer). Clarifies the supply-chain note that alint.org/install.sh redirects to main; keeps the pinned v0.14.1 example. Matches the alint.org authored surfaces (asamarts/alint.org#52); the docs/site copy re-syncs to alint.org on the next release. Verified locally: no main-URL left in the repo, README em-dash-clean, v0.14.1 pin intact.