### PR TITLE
feat(explain): surface full rule detail (+ Tier 2 / testing ADRs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to alint are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `alint explain <rule>` now surfaces the rule's full configured detail. It
+  previously printed only `id`, `level`, and `policy_url`; it now also shows the
+  rule's `kind` and categories, the `paths:` scope, the author's `message:`, the
+  `when:` clause as authored (not the parsed AST), and, for a fixable rule, a
+  one-line description of the auto-fix. `explain --format json` gains matching
+  additive fields (`rule_kind`, `categories`, `paths`, `message`, `when`,
+  `fix`); the existing fields are unchanged. The detail was already in the
+  loaded config but was dropped when the rule was built, so most rules used to
+  explain to two bare lines.
+
 ## [0.14.2] - 2026-08-06
 
 A fixes-and-hardening patch on top of 0.14.1. The `hygiene-no-macos-junk`

--- a/crates/alint-core/src/config.rs
+++ b/crates/alint-core/src/config.rs
@@ -258,34 +258,56 @@ pub enum PathsSpec {
 }
 
 impl PathsSpec {
-    /// Human-readable one-line rendering of the scope, for `alint explain`.
+    /// Split a raw pattern list into `(include, exclude)` exactly as the scope
+    /// matcher does (`Scope::from_patterns`): a leading `!` marks an exclusion,
+    /// with the `!` stripped. Keeps `alint explain` honest about a rule that
+    /// uses inline negations (`paths: ["src/**", "!src/tests/**"]`).
+    fn split_patterns(patterns: &[String]) -> (Vec<String>, Vec<String>) {
+        let mut include = Vec::new();
+        let mut exclude = Vec::new();
+        for p in patterns {
+            if let Some(rest) = p.strip_prefix('!') {
+                exclude.push(rest.to_string());
+            } else {
+                include.push(p.clone());
+            }
+        }
+        (include, exclude)
+    }
+
+    /// Normalised `(include, exclude)` glob lists, for machine output. Mirrors
+    /// how `Scope::from_paths_spec` classifies each form, so inline `!`
+    /// negations report as excludes rather than includes.
     #[must_use]
-    pub fn render_scope(&self) -> String {
+    pub fn include_exclude(&self) -> (Vec<String>, Vec<String>) {
         match self {
-            PathsSpec::Single(s) => s.clone(),
-            PathsSpec::Many(v) => v.join(", "),
+            PathsSpec::Single(s) => Self::split_patterns(std::slice::from_ref(s)),
+            PathsSpec::Many(v) => Self::split_patterns(v),
             PathsSpec::IncludeExclude { include, exclude } => {
-                let inc = if include.is_empty() {
-                    "**".to_string()
-                } else {
-                    include.join(", ")
-                };
-                if exclude.is_empty() {
-                    inc
-                } else {
-                    format!("{inc}  (excluding {})", exclude.join(", "))
-                }
+                // The include list may itself carry `!` negations (the matcher
+                // folds them in); split it, then append the explicit excludes.
+                let (inc, mut exc) = Self::split_patterns(include);
+                exc.extend(exclude.iter().cloned());
+                (inc, exc)
             }
         }
     }
 
-    /// Normalised `(include, exclude)` glob lists, for machine output.
+    /// Human-readable one-line rendering of the scope, for `alint explain`.
+    /// Built from [`include_exclude`](Self::include_exclude) so it classifies
+    /// inline `!` negations the same way the matcher does.
     #[must_use]
-    pub fn include_exclude(&self) -> (Vec<String>, Vec<String>) {
-        match self {
-            PathsSpec::Single(s) => (vec![s.clone()], Vec::new()),
-            PathsSpec::Many(v) => (v.clone(), Vec::new()),
-            PathsSpec::IncludeExclude { include, exclude } => (include.clone(), exclude.clone()),
+    pub fn render_scope(&self) -> String {
+        let (include, exclude) = self.include_exclude();
+        let inc = if include.is_empty() {
+            "**".to_string()
+        } else {
+            include.join(", ")
+        };
+        if exclude.is_empty() {
+            inc
+        } else {
+            format!("{inc}  (excluding {})", exclude.join(", "))
         }
     }
 }
@@ -933,6 +955,42 @@ mod tests {
         };
         assert_eq!(include, vec!["a"]);
         assert_eq!(exclude, vec!["b", "c"]);
+    }
+
+    #[test]
+    fn paths_spec_include_exclude_classifies_negations() {
+        let inc = |s: &str| vec![s.to_string()];
+
+        // A leading `!` marks an exclusion (matching `Scope::from_patterns`),
+        // not an include — `explain` must not mislabel it.
+        let single = PathsSpec::Single("src/**".to_string());
+        assert_eq!(single.include_exclude(), (inc("src/**"), Vec::new()));
+
+        let many = PathsSpec::Many(vec!["src/**".to_string(), "!src/vendor/**".to_string()]);
+        assert_eq!(
+            many.include_exclude(),
+            (inc("src/**"), inc("src/vendor/**"))
+        );
+        assert_eq!(many.render_scope(), "src/**  (excluding src/vendor/**)");
+
+        // Explicit include/exclude, plus a `!` inside the include list: both
+        // land in the exclude bucket (mirroring `from_paths_spec`).
+        let inc_exc = PathsSpec::IncludeExclude {
+            include: vec!["a/**".to_string(), "!a/gen/**".to_string()],
+            exclude: vec!["a/test/**".to_string()],
+        };
+        assert_eq!(
+            inc_exc.include_exclude(),
+            (
+                inc("a/**"),
+                vec!["a/gen/**".to_string(), "a/test/**".to_string()],
+            )
+        );
+
+        // An exclusion-only Single renders as match-all minus the exclude.
+        let excl_only = PathsSpec::Single("!dist/**".to_string());
+        assert_eq!(excl_only.include_exclude(), (Vec::new(), inc("dist/**")));
+        assert_eq!(excl_only.render_scope(), "**  (excluding dist/**)");
     }
 
     #[test]

--- a/crates/alint-core/src/config.rs
+++ b/crates/alint-core/src/config.rs
@@ -257,6 +257,39 @@ pub enum PathsSpec {
     },
 }
 
+impl PathsSpec {
+    /// Human-readable one-line rendering of the scope, for `alint explain`.
+    #[must_use]
+    pub fn render_scope(&self) -> String {
+        match self {
+            PathsSpec::Single(s) => s.clone(),
+            PathsSpec::Many(v) => v.join(", "),
+            PathsSpec::IncludeExclude { include, exclude } => {
+                let inc = if include.is_empty() {
+                    "**".to_string()
+                } else {
+                    include.join(", ")
+                };
+                if exclude.is_empty() {
+                    inc
+                } else {
+                    format!("{inc}  (excluding {})", exclude.join(", "))
+                }
+            }
+        }
+    }
+
+    /// Normalised `(include, exclude)` glob lists, for machine output.
+    #[must_use]
+    pub fn include_exclude(&self) -> (Vec<String>, Vec<String>) {
+        match self {
+            PathsSpec::Single(s) => (vec![s.clone()], Vec::new()),
+            PathsSpec::Many(v) => (v.clone(), Vec::new()),
+            PathsSpec::IncludeExclude { include, exclude } => (include.clone(), exclude.clone()),
+        }
+    }
+}
+
 fn string_or_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
 where
     D: serde::Deserializer<'de>,

--- a/crates/alint-core/src/engine.rs
+++ b/crates/alint-core/src/engine.rs
@@ -73,6 +73,10 @@ type LivePerFileEntries<'a> = (Vec<(usize, &'a RuleEntry)>, Vec<(usize, RuleResu
 pub struct RuleEntry {
     pub rule: Box<dyn Rule>,
     pub when: Option<WhenExpr>,
+    /// The `when:` clause's source text, retained so `alint explain` can show
+    /// the authored expression rather than the parsed AST. `None` when the rule
+    /// is unconditional.
+    pub when_src: Option<String>,
     /// The rule's kind (e.g. `file_exists`), retained from its `RuleSpec` so
     /// config-scoped tooling (`alint list --category`) can map an active rule to
     /// its categories. Empty for entries built without a spec (`Engine::new`,
@@ -80,6 +84,14 @@ pub struct RuleEntry {
     /// categories" (the rule is silently dropped), so any config-loading path
     /// that wants `--category` to work MUST set this via [`RuleEntry::with_kind`].
     pub kind: String,
+    /// The rule's `paths:` scope, retained from its `RuleSpec` so config-scoped
+    /// tooling (`alint explain`) can show what the rule matches without
+    /// re-reading the config. `None` for entries built without a spec.
+    pub paths: Option<crate::config::PathsSpec>,
+    /// The rule's custom `message:`, retained from its `RuleSpec` so `alint
+    /// explain` can surface the author's violation text. `None` when the rule
+    /// falls back to its kind's default message.
+    pub message: Option<String>,
     /// The rule's resolved top-level `allow_out_of_root:` permission, threaded
     /// into the fixer's [`FixContext`] so a config-declared fix path can escape
     /// the root only when the user's own config opted this rule in. Defaults to
@@ -92,7 +104,10 @@ impl RuleEntry {
         Self {
             rule,
             when: None,
+            when_src: None,
             kind: String::new(),
+            paths: None,
+            message: None,
             allow_out_of_root: false,
         }
     }
@@ -111,10 +126,31 @@ impl RuleEntry {
         self
     }
 
+    /// Record the `when:` clause's source text (see [`RuleEntry::when_src`]).
+    #[must_use]
+    pub fn with_when_src(mut self, src: impl Into<String>) -> Self {
+        self.when_src = Some(src.into());
+        self
+    }
+
     /// Record the rule's kind (see [`RuleEntry::kind`]).
     #[must_use]
     pub fn with_kind(mut self, kind: impl Into<String>) -> Self {
         self.kind = kind.into();
+        self
+    }
+
+    /// Record the rule's `paths:` scope (see [`RuleEntry::paths`]).
+    #[must_use]
+    pub fn with_paths(mut self, paths: Option<crate::config::PathsSpec>) -> Self {
+        self.paths = paths;
+        self
+    }
+
+    /// Record the rule's custom `message:` (see [`RuleEntry::message`]).
+    #[must_use]
+    pub fn with_message(mut self, message: Option<String>) -> Self {
+        self.message = message;
         self
     }
 }

--- a/crates/alint/src/main.rs
+++ b/crates/alint/src/main.rs
@@ -1307,8 +1307,16 @@ fn cmd_explain(rule_id: &str, cli: &Cli) -> Result<ExitCode> {
     if let Some(paths) = &entry.paths {
         writeln!(out, "{dim}paths:     {dim:#} {}", paths.render_scope())?;
     }
-    if let Some(msg) = &entry.message {
-        writeln!(out, "{dim}message:   {dim:#} {msg}")?;
+    // A blank / whitespace-only message renders as absent rather than a
+    // dangling `message:` label. Continuation lines indent under the value
+    // column and a trailing newline (block scalars carry one) is dropped, so a
+    // multi-line message stays aligned instead of wrapping back to column 0.
+    if let Some(msg) = entry.message.as_deref() {
+        let msg = msg.trim_end_matches('\n');
+        if !msg.trim().is_empty() {
+            let msg = msg.replace('\n', &format!("\n{}", " ".repeat(12)));
+            writeln!(out, "{dim}message:   {dim:#} {msg}")?;
+        }
     }
     // v0.9.20: honour --no-docs by suppressing the policy_url line.
     // URLs remain in machine-readable formats regardless.
@@ -1355,10 +1363,13 @@ fn explain_json(entry: &alint_core::RuleEntry) -> Result<ExitCode> {
         "categories": rules::categories_for_kind(&entry.kind),
         "level": entry.rule.level().as_str(),
         "paths": paths,
-        "message": entry.message,
+        "message": entry.message.as_deref().filter(|m| !m.trim().is_empty()),
         "policy_url": entry.rule.policy_url(),
         "when": entry.when_src,
-        "conditional": entry.when.is_some(),
+        // Mirror the displayed `when` source so `conditional` and `when` can
+        // never disagree (both are set together at load; deriving from one
+        // field keeps the output self-consistent for any future caller).
+        "conditional": entry.when_src.is_some(),
         "fixable": entry.rule.fixer().is_some(),
         "fix": entry.rule.fixer().map(alint_core::Fixer::describe),
     });

--- a/crates/alint/src/main.rs
+++ b/crates/alint/src/main.rs
@@ -1292,11 +1292,24 @@ fn cmd_explain(rule_id: &str, cli: &Cli) -> Result<ExitCode> {
         Level::Off => style::DIM,
     };
     writeln!(out, "{dim}id:        {dim:#} {}", rule.id())?;
+    if !entry.kind.is_empty() {
+        writeln!(out, "{dim}kind:      {dim:#} {}", entry.kind)?;
+        let cats = rules::categories_for_kind(&entry.kind);
+        if !cats.is_empty() {
+            writeln!(out, "{dim}categories:{dim:#} {}", cats.join(", "))?;
+        }
+    }
     writeln!(
         out,
         "{dim}level:     {dim:#} {level_style}{}{level_style:#}",
         rule.level().as_str(),
     )?;
+    if let Some(paths) = &entry.paths {
+        writeln!(out, "{dim}paths:     {dim:#} {}", paths.render_scope())?;
+    }
+    if let Some(msg) = &entry.message {
+        writeln!(out, "{dim}message:   {dim:#} {msg}")?;
+    }
     // v0.9.20: honour --no-docs by suppressing the policy_url line.
     // URLs remain in machine-readable formats regardless.
     if opts.show_docs
@@ -1304,8 +1317,15 @@ fn cmd_explain(rule_id: &str, cli: &Cli) -> Result<ExitCode> {
     {
         writeln!(out, "{dim}policy_url:{dim:#} {docs}{url}{docs:#}")?;
     }
-    if let Some(when) = &entry.when {
-        writeln!(out, "{dim}when:      {dim:#} {when:?}")?;
+    if let Some(when) = &entry.when_src {
+        writeln!(out, "{dim}when:      {dim:#} {when}")?;
+    }
+    if let Some(fixer) = rule.fixer() {
+        writeln!(
+            out,
+            "{dim}fix:       {dim:#} {}",
+            alint_core::Fixer::describe(fixer)
+        )?;
     }
     out.flush().ok();
     // v0.9.20: dropped the `debug: {rule:?}` line. The internal Debug
@@ -1320,14 +1340,27 @@ fn cmd_explain(rule_id: &str, cli: &Cli) -> Result<ExitCode> {
 /// Machine-readable single-rule shape for `alint explain <id> --format
 /// json`. Parallels each entry of the `list --format json` inventory.
 fn explain_json(entry: &alint_core::RuleEntry) -> Result<ExitCode> {
+    // `paths` normalises to `{ include, exclude }` glob lists. `rule_kind`
+    // carries the rule's own kind (the envelope's `kind` is the fixed `"rule"`
+    // discriminator), and `categories` matches each `list --format json` entry.
+    let paths = entry.paths.as_ref().map(|p| {
+        let (include, exclude) = p.include_exclude();
+        serde_json::json!({ "include": include, "exclude": exclude })
+    });
     let doc = serde_json::json!({
         "schema_version": 1,
         "kind": "rule",
         "id": entry.rule.id(),
+        "rule_kind": entry.kind,
+        "categories": rules::categories_for_kind(&entry.kind),
         "level": entry.rule.level().as_str(),
+        "paths": paths,
+        "message": entry.message,
         "policy_url": entry.rule.policy_url(),
+        "when": entry.when_src,
         "conditional": entry.when.is_some(),
         "fixable": entry.rule.fixer().is_some(),
+        "fix": entry.rule.fixer().map(alint_core::Fixer::describe),
     });
     let mut out = std::io::stdout().lock();
     writeln!(out, "{}", serde_json::to_string_pretty(&doc)?)?;
@@ -1606,11 +1639,13 @@ fn load_rules(cwd: &Path, cli: &Cli) -> Result<LoadedConfig> {
         rule.set_allow_out_of_root(allow_out_of_root);
         let mut entry = alint_core::RuleEntry::new(rule)
             .with_kind(spec.kind.clone())
+            .with_paths(spec.paths.clone())
+            .with_message(spec.message.clone())
             .with_allow_out_of_root(allow_out_of_root);
         if let Some(when_src) = &spec.when {
             let expr = alint_core::when::parse(when_src)
                 .with_context(|| format!("rule {:?}: parsing `when`", spec.id))?;
-            entry = entry.with_when(expr);
+            entry = entry.with_when(expr).with_when_src(when_src.clone());
         }
         entries.push(entry);
     }

--- a/crates/alint/tests/cli/explain.in/.alint.yml
+++ b/crates/alint/tests/cli/explain.in/.alint.yml
@@ -4,4 +4,5 @@ rules:
     kind: file_exists
     paths: README.md
     level: error
+    message: "README.md must exist at the repository root."
     policy_url: "https://opensource.guide/starting-a-project/#writing-a-readme"

--- a/crates/alint/tests/cli/explain.stdout
+++ b/crates/alint/tests/cli/explain.stdout
@@ -1,3 +1,7 @@
 id:         has-readme
+kind:       file_exists
+categories: existence
 level:      error
+paths:      README.md
+message:    README.md must exist at the repository root.
 policy_url: https://opensource.guide/starting-a-project/#writing-a-readme

--- a/crates/alint/tests/cli_format_contract.rs
+++ b/crates/alint/tests/cli_format_contract.rs
@@ -184,6 +184,63 @@ fn explain_surfaces_configured_rule_detail() {
     }
 }
 
+// ─── Explain edge cases — negation paths + blank message ───────────
+//
+// Guards two adversarial-review findings: an inline `!` negation in a paths
+// list must report as an exclude (not a bogus include), and a blank message
+// must render as absent (no dangling `message:` label, json null).
+#[test]
+fn explain_handles_negation_paths_and_blank_message() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join(".alint.yml"),
+        r#"version: 1
+rules:
+  - id: neg
+    kind: file_content_forbidden
+    paths: ["src/**", "!src/gen/**"]
+    pattern: "TODO"
+    level: warning
+  - id: blank
+    kind: file_exists
+    paths: X
+    level: error
+    message: ""
+"#,
+    )
+    .unwrap();
+
+    // An inline `!` negation is an exclude, mirroring the scope matcher.
+    let v: serde_json::Value =
+        serde_json::from_slice(&run(dir.path(), &["explain", "neg", "--format", "json"]).stdout)
+            .expect("json");
+    assert_eq!(v["paths"]["include"][0], "src/**");
+    assert_eq!(
+        v["paths"]["exclude"][0], "src/gen/**",
+        "inline `!` negation must report as an exclude, not an include: {v}"
+    );
+    let human = String::from_utf8_lossy(&run(dir.path(), &["explain", "neg"]).stdout).into_owned();
+    assert!(
+        human.contains("(excluding src/gen/**)"),
+        "human paths must show the negation as an exclusion:\n{human}"
+    );
+
+    // A blank message renders as absent: json null, no human label.
+    let v: serde_json::Value =
+        serde_json::from_slice(&run(dir.path(), &["explain", "blank", "--format", "json"]).stdout)
+            .expect("json");
+    assert!(
+        v["message"].is_null(),
+        "blank message must be json null: {v}"
+    );
+    let human =
+        String::from_utf8_lossy(&run(dir.path(), &["explain", "blank"]).stdout).into_owned();
+    assert!(
+        !human.contains("message:"),
+        "blank message must not print a dangling label:\n{human}"
+    );
+}
+
 // ─── G1b — the agent format only emits commands the CLI accepts ─────
 
 /// Pull `` `alint …` `` commands out of an `agent_instruction` string:

--- a/crates/alint/tests/cli_format_contract.rs
+++ b/crates/alint/tests/cli_format_contract.rs
@@ -120,6 +120,70 @@ fn format_json_is_never_a_silent_human_fallthrough() {
     }
 }
 
+// ─── Explain completeness — output surfaces the rule's configured detail ─
+//
+// `explain` used to print only id/level/policy_url, silently dropping the
+// rule's kind, paths, and author `message` — all present in the loaded config,
+// and a byte-exact snapshot froze that thin output as "correct". This gate is a
+// POSITIVE completeness invariant: for a rule that sets kind/paths/message,
+// explain's human AND json output must actually contain those values, so the
+// `RuleSpec` -> `RuleEntry` projection can't quietly go lossy again. The
+// generalisation to every rule kind is tracked in ADR-0012.
+#[test]
+fn explain_surfaces_configured_rule_detail() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join(".alint.yml"),
+        "version: 1\n\
+         rules:\n\
+        \x20 - id: needs-readme\n\
+        \x20   kind: file_exists\n\
+        \x20   paths: README.md\n\
+        \x20   level: error\n\
+        \x20   message: \"README.md must exist at the repository root.\"\n",
+    )
+    .unwrap();
+
+    // JSON: the machine contract must carry the rule's kind, message, paths,
+    // and categories — not merely parse as *some* JSON (the old G1a-only gate).
+    let out = run(dir.path(), &["explain", "needs-readme", "--format", "json"]);
+    let v: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("explain --format json must be JSON");
+    assert_eq!(
+        v["rule_kind"], "file_exists",
+        "explain json dropped the rule's kind: {v}"
+    );
+    assert_eq!(
+        v["message"], "README.md must exist at the repository root.",
+        "explain json dropped the author message: {v}"
+    );
+    assert_eq!(
+        v["paths"]["include"][0], "README.md",
+        "explain json dropped the rule's paths: {v}"
+    );
+    assert!(
+        v["categories"].as_array().is_some_and(|c| !c.is_empty()),
+        "explain json dropped the kind's categories: {v}"
+    );
+
+    // Human: the same detail must be visible, not just id/level.
+    let out = run(dir.path(), &["explain", "needs-readme"]);
+    let s = String::from_utf8_lossy(&out.stdout);
+    for needle in [
+        "kind:",
+        "file_exists",
+        "paths:",
+        "README.md",
+        "message:",
+        "README.md must exist at the repository root.",
+    ] {
+        assert!(
+            s.contains(needle),
+            "explain human output is missing {needle:?}:\n{s}"
+        );
+    }
+}
+
 // ─── G1b — the agent format only emits commands the CLI accepts ─────
 
 /// Pull `` `alint …` `` commands out of an `agent_instruction` string:

--- a/docs/adr/0011-per-kind-rule-explanations.md
+++ b/docs/adr/0011-per-kind-rule-explanations.md
@@ -1,0 +1,99 @@
+---
+status: proposed
+date: 2026-08-06
+decision-makers: asamarts
+---
+
+# 0011. Per-kind rule explanations via a generated summary bridge
+
+## Status
+
+Proposed. (One of: Proposed | Accepted | Rejected | Deprecated | Superseded by ADR-NNNN.)
+
+Proposed as the Tier 2 follow-up to the `alint explain` enrichment (the Tier 1
+change that surfaces a rule's configured detail). This ADR covers the remaining
+gap: kind-level explanation.
+
+## Context
+
+`alint explain <rule>` and the `alint rules` catalog answer questions about a
+rule, but neither can answer the most basic one: **what does this KIND check, and
+why.** After the Tier 1 change, `explain` shows a rule's kind, paths, message,
+`when:`, and fix (all config-instance data). It still cannot say what
+`file_content_forbidden` *is*, because that prose exists only in `docs/rules.md`.
+
+`docs/rules.md` is the single source of truth for per-kind prose, and `xtask`'s
+`docs_export::first_sentence` already extracts a one-line summary per kind, but
+only to feed the website (family tables, the master index, the SEO meta
+description). None of it is compiled into the binary. The in-crate
+kind-to-category bridge (`crates/alint-rules/src/categories_gen.rs`) deliberately
+carries categories and **not** summaries; that omission is a documented deferral
+in `docs/design/rule-categories.md` (the "deferred-summary" note) and ADR-0009's
+Data-source section. So the terminal has no offline, config-independent way to
+describe a kind, and `alint rules show <kind>` plus `list --search` over
+summaries (both deferred in ADR-0009) have no data to read.
+
+## Decision
+
+We will compile a **per-kind one-line summary into the binary via a generated
+bridge**, extracted from the `docs/rules.md` SSOT by the existing
+`docs_export::first_sentence`, and gated by a `gen-<x> --check` so it can never
+drift from the docs. Concretely:
+
+- Extend the generated in-crate artifact (either `categories_gen.rs` or a sibling
+  `kind_docs_gen.rs`) to carry each canonical kind's summary string, keyed the
+  same way categories are. Aliases resolve to their canonical kind's summary.
+- `alint explain` prints the kind's summary under its `kind:` line, plus a deep
+  link to `https://alint.org/docs/rules/<family>/<kind>/` for the full prose.
+- `alint rules list` gains a description column and `alint rules show <kind>`
+  becomes possible; `list --search` can match summaries, closing the ADR-0009
+  catalog deferrals with one data source.
+- The generator strips the `**Categories:**` line before summarizing (the same
+  guard `rule-categories.md` already specifies for the site), and a
+  `gen-<x> --check` gate in the docs CI job fails if the committed artifact is
+  stale, exactly like `gen-facts --check` and `gen-categories --check`.
+
+## Consequences
+
+Easier:
+
+- `explain` becomes kind-aware: a user learns what a kind does without leaving the
+  terminal or reading YAML.
+- The `rules` catalog gains descriptions and summary search becomes possible — the
+  ADR-0009 catalog deferrals resolve with one data source.
+- Summaries stay honest: one SSOT (`docs/rules.md`), one extractor, one gate.
+
+Harder, and accepted:
+
+- **Doc-prose edits leave the docs-only CI fast lane.** Editing a kind's summary
+  in `docs/rules.md` now regenerates a committed in-crate artifact, so the change
+  is no longer docs-only and must ship in a release to reach CLI users (the site
+  reflects it sooner). This is the exact tradeoff ADR-0009 named and deferred; we
+  accept it now, scoped to the *first sentence* only (not the whole body) to keep
+  the churn surface minimal.
+- One more generated artifact and gate to maintain, alongside facts.json and the
+  categories bridge.
+
+## Considered Options
+
+- **Generated summary bridge from `docs/rules.md` (chosen).** One SSOT, reuses
+  `first_sentence`, drift-gated, and unlocks the catalog deferrals.
+- **Leave summaries in docs only; `explain` just deep-links out.** No new
+  artifact, but no offline/terminal kind description and no summary search — the
+  status quo this ADR exists to end.
+- **Hand-write a summary table in Rust.** Immediate, but a second source of truth
+  that silently drifts from `docs/rules.md` — the drift class alint itself exists
+  to prevent.
+- **Compile each kind's full prose body into the binary.** Real kind help in the
+  terminal, but tens of KB of doc prose in the binary and a large churn surface;
+  the one-line summary is the 90% at a fraction of the cost.
+
+## More Information
+
+- Builds on the Tier 1 `explain` enrichment (config-instance detail) and its
+  completeness gate (`explain_surfaces_configured_rule_detail`).
+- The deferral this closes: `docs/design/rule-categories.md` (the deferred-summary
+  note) and ADR-0009 (rule discovery; the `rules show` / `list --search`
+  deferrals and the CI fast-lane tradeoff).
+- Reused machinery: `xtask` `docs_export::first_sentence` (the summary extractor)
+  and `crates/alint-rules/src/categories_gen.rs` (the generated-bridge pattern).

--- a/docs/adr/0012-output-completeness-testing.md
+++ b/docs/adr/0012-output-completeness-testing.md
@@ -1,0 +1,128 @@
+---
+status: proposed
+date: 2026-08-06
+decision-makers: asamarts
+---
+
+# 0012. Output-completeness as a tested contract
+
+## Status
+
+Proposed. Prompted by the `alint explain` gap fixed in the Tier 1 explain change,
+and a 2026-08-06 audit of every subcommand's output against its data model.
+
+## Context
+
+`alint explain <rule>` shipped rendering only `id`, `level`, and `policy_url`,
+silently dropping the rule's `kind`, `paths`, and author `message:` — all present
+in the loaded config. Users saw most rules "explain" to two bare lines. The defect
+sat in released binaries and **escaped both unit and e2e tests.** Understanding
+*why the tests missed it* matters more than the one fix.
+
+Root cause of the escape (audit, 2026-08-06):
+
+1. **The one `explain` snapshot froze the thin output as correct.**
+   `crates/alint/tests/cli/explain.stdout` was a byte-exact capture of the
+   three-line output, and its fixture rule (`explain.in`) deliberately set **no
+   `message:`**, so the omission was baked in as the expected value. Worse,
+   `TRYCMD=overwrite` regenerates the snapshot from whatever the binary currently
+   prints — so a snapshot can only ever ratify current behaviour, never judge it.
+2. **The only machine-format coverage asserted nothing about content.** The
+   output-contract gate `cli_format_contract.rs::format_json_is_never_a_silent_
+   human_fallthrough` (G1a) asserted only that stdout **parses as JSON** — zero
+   fields. Thin JSON passes it perfectly.
+3. **Format tests checked exit codes only** (`cli_consistency.rs`), never output.
+4. **No unit test** covered `cmd_explain` / `explain_json` / `cmd_list` /
+   `list_json`.
+
+The missing structural property: **no test asserted a positive completeness
+invariant** — "for a rule that sets `message:`/`kind:`/`paths:`, the command's
+output actually CONTAINS them." Every existing check was either exact-equality
+against a baseline that already omitted the data, or a parse/exit-code check the
+thin output satisfied.
+
+This is not unique to `explain`. The same lossy `RuleSpec` -> `RuleEntry`
+projection (only `kind` was retained at load) means:
+
+- **`list`** — the human output hides `kind`, `categories`, and `fixable` that
+  `list --format json` emits, and both formats drop `message`/`paths`.
+- **`export-agents-md`** — falls back to `"<kind> rule"` (e.g. "file_exists rule")
+  when a rule sets no `message:`, dropping the actionable `paths:`.
+- **`explain`/`list` JSON parity** — `explain --format json` omitted the rule kind
+  and categories that `list --format json` carries (fixed for `explain` in the
+  Tier 1 change).
+
+## Decision
+
+We will treat **output completeness as an explicit, tested contract**, and close
+the class of defect at the type level where practical. Three commitments:
+
+1. **Positive-invariant gates, driven by `all_kinds.yaml`.** Beyond snapshots
+   (which guard against regression), add completeness assertions that, for a rule
+   configured with a `message:`/`kind:`/`paths:`, the rendered `explain` (and
+   `list`) output *contains* those values. The Tier 1 change seeds this with
+   `explain_surfaces_configured_rule_detail`; generalise it to iterate the
+   `crates/alint-dsl/tests/fixtures/all_kinds.yaml` fixture (which already gives
+   most kinds a `message:`; complete it so every kind does) so a newly registered
+   kind cannot render blank.
+2. **Audit and remediate the shared defect.** The `list` human gap and the
+   `export-agents-md` fallback (above) are tracked as follow-ups to this ADR and
+   fixed or explicitly deferred-with-rationale, using the same mechanism.
+3. **Prevent recurrence structurally.** Two complementary moves, to be sequenced
+   in the follow-up:
+   - **A `Rule::message()` accessor.** 60 of ~71 rule structs already store
+     `message: Option<String>`, and 70 kinds use the `rule_common_impl!` macro
+     that already stamps `id`/`level`/`policy_url` from same-named fields. Adding
+     `fn message(&self) -> Option<&str> { None }` to the `Rule` trait and emitting
+     it from the macro makes "surface the message" a near-mechanical, type-level
+     obligation wired from a field the rule already holds; the ~11 kinds without
+     the field keep the `None` default.
+   - **Retain the `RuleSpec` projection in `LoadedConfig`.** Heterogeneous data
+     (paths, kind-specific options) is a poor fit for 71 bespoke trait methods.
+     Keeping the specs (or a display projection) alongside `entries` — as
+     `export_agents_md::collect_directives` already renders straight from
+     `config.rules` — lets `explain`/`list` show everything with zero per-kind
+     code. The Tier 1 change took the narrower step of retaining `paths`/`message`
+     on `RuleEntry`; this ADR decides whether to generalise to the full projection
+     (and, if so, retire the ad-hoc `RuleEntry` display fields in its favour).
+
+## Consequences
+
+Easier:
+
+- The whole class of "a command silently drops data it has" becomes catchable, not
+  just the one instance we tripped over.
+- New rule kinds and new commands inherit the completeness gate for free (the
+  `all_kinds.yaml` driver already enumerates every kind).
+
+Harder, and accepted:
+
+- Completeness invariants are more code than a snapshot, and the `all_kinds.yaml`
+  driver is one more thing to keep green. We accept it: a snapshot proves output
+  is *stable*, never that it is *adequate*, and adequacy is exactly what failed.
+- The `Rule::message()` and projection changes touch many kinds and the load path.
+  Mechanical, but not free; sequenced behind the gate so the gate proves the fix.
+
+## Considered Options
+
+- **Snapshot-only (status quo).** Rejected: snapshots ratify current behaviour and
+  `TRYCMD=overwrite` re-bakes it; this is precisely what froze the bug.
+- **Positive completeness invariants + structural prevention (chosen).** Catches
+  the class, and the type-level accessor makes the common case a compile-time
+  obligation.
+- **Trait accessors only.** Clean for `message`, but a poor fit for heterogeneous
+  `paths`/options — would need 71 bespoke methods.
+- **Spec-projection only.** Renders everything with no per-kind code, but gives no
+  compile-time guarantee a *new* kind is surfaced; pairs best with the chosen
+  option's gate.
+
+## More Information
+
+- The triggering fix and its seed gate: the Tier 1 `explain` change
+  (`explain_surfaces_configured_rule_detail` in
+  `crates/alint/tests/cli_format_contract.rs`).
+- Related: ADR-0011 (per-kind explanations — the *other* explain gap) and ADR-0009
+  (the `list` / `rules` surfaces these findings touch).
+- Anchors: the lossy projection at load (`crates/alint/src/main.rs`, the
+  `RuleEntry::with_kind` site), the `Rule` trait + `rule_common_impl!`
+  (`crates/alint-core/src/rule.rs`), and the `all_kinds.yaml` fixture.


### PR DESCRIPTION
## What

`alint explain <rule>` printed only `id`, `level`, and `policy_url`, so most rules "explained" to two bare lines, even though the rule's kind, scope, and author message were all sitting in the loaded config. This surfaces them.

**Before**

```
id:         no-dbg-macros-in-prod
level:      warning
```

**After**

```
id:         no-dbg-macros-in-prod
kind:       file_content_forbidden
categories: content, security-unicode-sanity
level:      warning
paths:      crates/**/src/**/*.rs  (excluding crates/**/src/**/tests.rs)
message:    `dbg!` macros should not land in committed Rust sources.
```

`explain --format json` gains matching additive fields (`rule_kind`, `categories`, `paths`, `message`, `when`, `fix`), reaching parity with each `list --format json` entry. `when:` now shows the authored expression (`facts.has_rust`) instead of the parsed AST, and a fixable rule shows a one-line fix description.

## Root cause

`load_rules` projected each `RuleSpec` down to a `RuleEntry` retaining only `kind`; `message`/`paths`/`when`-source were dropped at build time, and the `Rule` trait exposes no accessor for them. This retains `paths`/`message`/`when`-source on `RuleEntry` (mirroring the existing `kind` retention) and gives `PathsSpec` its own render helpers.

## Test

The gap escaped tests because the one `explain` snapshot was a byte-exact capture of the thin output (its fixture rule set no `message:`), and the only JSON gate asserted merely "stdout parses as JSON". This adds `explain_surfaces_configured_rule_detail`: a positive-completeness invariant. For a rule that sets `message`/`kind`/`paths`, both human and JSON output must *contain* them. The snapshot fixture now sets a message so it exercises that path.

## ADRs

- **ADR-0011** is the Tier 2 follow-up: compile a per-kind one-line summary into the binary (generated from the `docs/rules.md` SSOT) so `explain` can describe what a *kind* checks, closing the ADR-0009 `rules show` / `list --search` deferrals.
- **ADR-0012** captures why the gap escaped unit and e2e tests, and the prevention: `all_kinds.yaml`-driven completeness invariants plus a type-level `Rule::message()` accessor or a retained spec projection.

## Out of scope (tracked in ADR-0012)

An audit found the same lossy projection degrades two other commands: `list`'s human output hides kind/categories/fixable, and `export-agents-md` falls back to `"<kind> rule"` (dropping paths) for message-less rules. Left for the ADR-0012 follow-up to keep this PR focused on the reported `explain` issue.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace`, `cargo test --workspace` (72 groups, 0 failures), and `alint check` (self-lint, rc 0) all green.
