### PR TITLE
feat(cli): close list/export output gaps + generalize the completeness gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `fix`); the existing fields are unchanged. The detail was already in the
   loaded config but was dropped when the rule was built, so most rules used to
   explain to two bare lines.
+- `alint list` now shows each rule's `kind` and a `[fix]` marker in its human
+  output, matching what `list --format json` already carried (the human
+  inventory previously showed only level, id, `[when]`, and the policy URL).
+- `alint export-agents-md` keeps a rule's scope in the generated directive when
+  the rule sets no `message:` ("file_exists rule on README.md" rather than the
+  bare "file_exists rule"), so a generated AGENTS.md stays actionable.
 
 ## [0.14.2] - 2026-08-06
 

--- a/crates/alint/src/export_agents_md/mod.rs
+++ b/crates/alint/src/export_agents_md/mod.rs
@@ -111,10 +111,14 @@ fn collect_directives(config: &alint_core::Config, include_info: bool) -> Vec<Di
         .map(|spec| Directive {
             rule_id: spec.id.clone(),
             severity: spec.level,
-            directive: spec
-                .message
-                .clone()
-                .unwrap_or_else(|| format!("{} rule", spec.kind)),
+            directive: spec.message.clone().unwrap_or_else(|| match &spec.paths {
+                // No author message: fall back to the kind AND the scope it
+                // applies to, so a generated AGENTS.md directive stays
+                // actionable ("file_exists rule on README.md", not just the
+                // bare "file_exists rule").
+                Some(p) => format!("{} rule on {}", spec.kind, p.render_scope()),
+                None => format!("{} rule", spec.kind),
+            }),
             policy_url: spec.policy_url.clone(),
         })
         .collect();
@@ -319,6 +323,17 @@ mod tests {
         let dirs = collect_directives(&cfg, false);
         assert_eq!(dirs.len(), 1);
         assert_eq!(dirs[0].directive, "file_exists rule");
+    }
+
+    #[test]
+    fn missing_message_with_paths_keeps_the_scope() {
+        // A message-less rule WITH a paths scope keeps the scope in the
+        // directive, so a generated AGENTS.md stays actionable (ADR-0012).
+        let mut s = spec("no-msg-scoped", Level::Warning, None);
+        s.paths = Some(alint_core::PathsSpec::Single("README.md".into()));
+        let dirs = collect_directives(&config_with(vec![s]), false);
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].directive, "file_exists rule on README.md");
     }
 
     #[test]

--- a/crates/alint/src/main.rs
+++ b/crates/alint/src/main.rs
@@ -1086,8 +1086,17 @@ fn cmd_list(category: Option<&str>, cli: &Cli) -> Result<ExitCode> {
             "{level_style}{label}{level_style:#}{pad} {}",
             rule.id()
         )?;
+        // Surface the rule's kind (and a fixable marker) in the human list,
+        // matching what `list --format json` already carries — otherwise the
+        // human inventory can't answer "what kind is this rule?".
+        if !entry.kind.is_empty() {
+            write!(out, "  {dim}{}{dim:#}", entry.kind)?;
+        }
         if entry.when.is_some() {
             write!(out, " {dim}[when]{dim:#}")?;
+        }
+        if rule.fixer().is_some() {
+            write!(out, " {dim}[fix]{dim:#}")?;
         }
         if opts.show_docs
             && let Some(url) = rule.policy_url()

--- a/crates/alint/tests/cli/list.stdout
+++ b/crates/alint/tests/cli/list.stdout
@@ -1,2 +1,2 @@
-error    has-readme
-warning  no-bak-files
+error    has-readme  file_exists
+warning  no-bak-files  file_absent

--- a/crates/alint/tests/cli_format_contract.rs
+++ b/crates/alint/tests/cli_format_contract.rs
@@ -241,6 +241,51 @@ rules:
     );
 }
 
+// ─── Explain covers every registered kind (all_kinds.yaml) ─────────
+//
+// ADR-0012's generalisation of the per-rule completeness gate: drive the
+// `all_kinds.yaml` fixture (a rule for ~every registered kind) through
+// `explain --format json` and assert each renders valid JSON with its id and
+// kind round-tripping and categories present. A newly registered kind that
+// rendered blank, mis-reported its kind, or crashed `explain` fails here.
+#[test]
+fn explain_covers_every_registered_kind() {
+    let fixture = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../alint-dsl/tests/fixtures/all_kinds.yaml"
+    ))
+    .expect("read all_kinds.yaml");
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join(".alint.yml"), &fixture).unwrap();
+
+    let list: serde_json::Value =
+        serde_json::from_slice(&run(dir.path(), &["list", "--format", "json"]).stdout)
+            .expect("list --format json must be JSON");
+    let rules = list["rules"].as_array().expect("rules array");
+    assert!(
+        rules.len() > 60,
+        "all_kinds fixture should exercise many kinds (got {})",
+        rules.len()
+    );
+
+    for r in rules {
+        let id = r["id"].as_str().expect("rule id");
+        let kind = r["kind"].as_str().expect("rule kind");
+        let out = run(dir.path(), &["explain", id, "--format", "json"]);
+        let ev: serde_json::Value = serde_json::from_slice(&out.stdout)
+            .unwrap_or_else(|_| panic!("explain {id} --format json must be valid JSON"));
+        assert_eq!(ev["id"], id, "explain mis-reported the id for {id}: {ev}");
+        assert_eq!(
+            ev["rule_kind"], kind,
+            "explain mis-reported the kind for {id}: {ev}"
+        );
+        assert!(
+            ev["categories"].as_array().is_some(),
+            "explain dropped categories for {id}: {ev}"
+        );
+    }
+}
+
 // ─── G1b — the agent format only emits commands the CLI accepts ─────
 
 /// Pull `` `alint …` `` commands out of an `agent_instruction` string:


### PR DESCRIPTION
Stacked on #161 (base: `explain-surface-rule-details`); GitHub will retarget this to `main` when #161 merges. This is the **ADR-0012 follow-up**: the same lossy `RuleSpec` → `RuleEntry` projection that hid detail in `explain` also degraded two sibling commands, and no gate covered every kind. All three are addressed.

## `list` human output (parity with its JSON)

The human inventory showed only level / id / `[when]` / policy_url — you could not tell a rule's *kind* from it, though `list --format json` already carried it. Now:

```
warning  adr-filename-pattern  filename_regex  (https://adr.github.io/madr/)
error    architecture-doc-exists  file_exists
error    no-committed-cargo-lock-bak  file_absent [fix]
```

kind (dimmed) plus a `[fix]` marker for fixable rules. Categories stay in `--format json` + the `--category` filter, to keep the human list scannable.

## `export-agents-md` fallback stays actionable

A message-less rule fell back to `"<kind> rule"` (e.g. `file_exists rule`), dropping the scope. It now reuses `PathsSpec::render_scope`:

```
- **`needs-x`**: file_exists rule on X.md
```

Added a test for the paths branch — the existing fallback test used a no-paths spec, so the new branch was uncovered.

## Generalized completeness gate

`explain_covers_every_registered_kind` drives the `all_kinds.yaml` fixture (~99 kinds) through `explain --format json` and asserts each renders valid JSON with its id + kind round-tripping and categories present. A newly registered kind that renders blank, mis-reports its kind, or crashes `explain` now fails a test.

## Deferred (noted in the commit + ADR-0012)

The type-level `Rule::message()` accessor — making "surface the message" a compile-time obligation across ~70 kinds — is a mechanical follow-up, left out to keep this PR reviewable.

## Verification

`fmt --check`, `clippy --workspace --all-targets -- -D warnings`, `rustdoc -D warnings`, `cargo test --workspace` (72 groups, 0 failures), and `alint check` all green.
