### PR TITLE
feat(explain): surface kind-specific options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `alint export-agents-md` keeps a rule's scope in the generated directive when
   the rule sets no `message:` ("file_exists rule on README.md" rather than the
   bare "file_exists rule"), so a generated AGENTS.md stays actionable.
+- `alint explain <rule>` additionally surfaces a rule's kind-specific options
+  (the flattened fields such as `pattern` / `max_lines`), under an `options:`
+  block in the human output and an `options` object in `--format json`. This
+  completes the explain output: id, kind, categories, level, paths, options,
+  message, policy_url, when, and fix.
 
 ## [0.14.2] - 2026-08-06
 

--- a/crates/alint-core/src/engine.rs
+++ b/crates/alint-core/src/engine.rs
@@ -92,6 +92,10 @@ pub struct RuleEntry {
     /// explain` can surface the author's violation text. `None` when the rule
     /// falls back to its kind's default message.
     pub message: Option<String>,
+    /// The rule's kind-specific options (the flattened non-common `RuleSpec`
+    /// fields, e.g. `pattern`, `max_lines`), retained so `alint explain` can show
+    /// them. Empty for entries built without a spec.
+    pub extra: serde_yaml_ng::Mapping,
     /// The rule's resolved top-level `allow_out_of_root:` permission, threaded
     /// into the fixer's [`FixContext`] so a config-declared fix path can escape
     /// the root only when the user's own config opted this rule in. Defaults to
@@ -108,6 +112,7 @@ impl RuleEntry {
             kind: String::new(),
             paths: None,
             message: None,
+            extra: serde_yaml_ng::Mapping::new(),
             allow_out_of_root: false,
         }
     }
@@ -130,6 +135,13 @@ impl RuleEntry {
     #[must_use]
     pub fn with_when_src(mut self, src: impl Into<String>) -> Self {
         self.when_src = Some(src.into());
+        self
+    }
+
+    /// Record the rule's kind-specific options (see [`RuleEntry::extra`]).
+    #[must_use]
+    pub fn with_extra(mut self, extra: serde_yaml_ng::Mapping) -> Self {
+        self.extra = extra;
         self
     }
 

--- a/crates/alint/src/main.rs
+++ b/crates/alint/src/main.rs
@@ -1316,6 +1316,21 @@ fn cmd_explain(rule_id: &str, cli: &Cli) -> Result<ExitCode> {
     if let Some(paths) = &entry.paths {
         writeln!(out, "{dim}paths:     {dim:#} {}", paths.render_scope())?;
     }
+    // Kind-specific options (pattern, max_lines, ...): the first inline after
+    // the `options:` label, the rest indented under the value column.
+    for (i, (k, v)) in entry.extra.iter().enumerate() {
+        let key = k.as_str().unwrap_or_default();
+        let val = match serde_json::to_value(v) {
+            Ok(serde_json::Value::String(s)) => s,
+            Ok(jv) => jv.to_string(),
+            Err(_) => String::new(),
+        };
+        if i == 0 {
+            writeln!(out, "{dim}options:   {dim:#} {dim}{key}:{dim:#} {val}")?;
+        } else {
+            writeln!(out, "            {dim}{key}:{dim:#} {val}")?;
+        }
+    }
     // A blank / whitespace-only message renders as absent rather than a
     // dangling `message:` label. Continuation lines indent under the value
     // column and a trailing newline (block scalars carry one) is dropped, so a
@@ -1364,6 +1379,11 @@ fn explain_json(entry: &alint_core::RuleEntry) -> Result<ExitCode> {
         let (include, exclude) = p.include_exclude();
         serde_json::json!({ "include": include, "exclude": exclude })
     });
+    let options = if entry.extra.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::to_value(&entry.extra).unwrap_or(serde_json::Value::Null)
+    };
     let doc = serde_json::json!({
         "schema_version": 1,
         "kind": "rule",
@@ -1372,6 +1392,7 @@ fn explain_json(entry: &alint_core::RuleEntry) -> Result<ExitCode> {
         "categories": rules::categories_for_kind(&entry.kind),
         "level": entry.rule.level().as_str(),
         "paths": paths,
+        "options": options,
         "message": entry.message.as_deref().filter(|m| !m.trim().is_empty()),
         "policy_url": entry.rule.policy_url(),
         "when": entry.when_src,
@@ -1661,6 +1682,7 @@ fn load_rules(cwd: &Path, cli: &Cli) -> Result<LoadedConfig> {
             .with_kind(spec.kind.clone())
             .with_paths(spec.paths.clone())
             .with_message(spec.message.clone())
+            .with_extra(spec.extra.clone())
             .with_allow_out_of_root(allow_out_of_root);
         if let Some(when_src) = &spec.when {
             let expr = alint_core::when::parse(when_src)

--- a/crates/alint/src/main.rs
+++ b/crates/alint/src/main.rs
@@ -1321,7 +1321,10 @@ fn cmd_explain(rule_id: &str, cli: &Cli) -> Result<ExitCode> {
     for (i, (k, v)) in entry.extra.iter().enumerate() {
         let key = k.as_str().unwrap_or_default();
         let val = match serde_json::to_value(v) {
-            Ok(serde_json::Value::String(s)) => s,
+            // A single-line string renders bare; a multi-line string (and every
+            // non-string) renders as compact JSON, so an embedded newline cannot
+            // break the aligned options block.
+            Ok(serde_json::Value::String(s)) if !s.contains(['\n', '\r']) => s,
             Ok(jv) => jv.to_string(),
             Err(_) => String::new(),
         };

--- a/crates/alint/tests/cli_format_contract.rs
+++ b/crates/alint/tests/cli_format_contract.rs
@@ -343,6 +343,45 @@ rules:
     );
 }
 
+// ─── Explain surfaces kind-specific options ────────────────────────
+//
+// The last completeness gap: `explain` now shows a rule's kind options (the
+// flattened non-common `RuleSpec` fields like `pattern`/`max_lines`) in both
+// human and json, retained as `RuleEntry.extra` from the spec.
+#[test]
+fn explain_surfaces_kind_options() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join(".alint.yml"),
+        r#"version: 1
+rules:
+  - id: no-dbg
+    kind: file_content_forbidden
+    paths: "src/**/*.rs"
+    pattern: '\bdbg!\('
+    level: warning
+"#,
+    )
+    .unwrap();
+
+    // JSON: `options` carries the kind-specific fields.
+    let v: serde_json::Value =
+        serde_json::from_slice(&run(dir.path(), &["explain", "no-dbg", "--format", "json"]).stdout)
+            .expect("json");
+    assert_eq!(
+        v["options"]["pattern"], r"\bdbg!\(",
+        "explain json dropped the kind option: {v}"
+    );
+
+    // Human: the option is visible under an `options:` label.
+    let human =
+        String::from_utf8_lossy(&run(dir.path(), &["explain", "no-dbg"]).stdout).into_owned();
+    assert!(
+        human.contains("options:") && human.contains(r"pattern: \bdbg!\("),
+        "explain human dropped the kind option:\n{human}"
+    );
+}
+
 // ─── G1b — the agent format only emits commands the CLI accepts ─────
 
 /// Pull `` `alint …` `` commands out of an `agent_instruction` string:

--- a/crates/alint/tests/cli_format_contract.rs
+++ b/crates/alint/tests/cli_format_contract.rs
@@ -351,34 +351,55 @@ rules:
 #[test]
 fn explain_surfaces_kind_options() {
     let dir = tempfile::tempdir().expect("tempdir");
+    // Two options, the first a MULTI-LINE string: exercises the inline (i==0)
+    // AND indented (i>0) render branches plus multi-line handling.
     std::fs::write(
         dir.path().join(".alint.yml"),
         r#"version: 1
 rules:
-  - id: no-dbg
-    kind: file_content_forbidden
+  - id: hdr
+    kind: file_header
     paths: "src/**/*.rs"
-    pattern: '\bdbg!\('
     level: warning
+    pattern: "first\nsecond"
+    lines: 3
 "#,
     )
     .unwrap();
 
-    // JSON: `options` carries the kind-specific fields.
+    // JSON: `options` carries both kind fields, the newline preserved.
     let v: serde_json::Value =
-        serde_json::from_slice(&run(dir.path(), &["explain", "no-dbg", "--format", "json"]).stdout)
+        serde_json::from_slice(&run(dir.path(), &["explain", "hdr", "--format", "json"]).stdout)
             .expect("json");
     assert_eq!(
-        v["options"]["pattern"], r"\bdbg!\(",
-        "explain json dropped the kind option: {v}"
+        v["options"]["pattern"], "first\nsecond",
+        "explain json dropped/mangled a kind option: {v}"
+    );
+    assert_eq!(
+        v["options"]["lines"], 3,
+        "explain json dropped a kind option: {v}"
     );
 
-    // Human: the option is visible under an `options:` label.
-    let human =
-        String::from_utf8_lossy(&run(dir.path(), &["explain", "no-dbg"]).stdout).into_owned();
+    // Human: both options appear; the multi-line value stays on ONE line
+    // (escaped JSON) so it can't break the aligned block, and the second option
+    // is indented on its own line rather than run inline.
+    let human = String::from_utf8_lossy(&run(dir.path(), &["explain", "hdr"]).stdout).into_owned();
+    let opt_line = human
+        .lines()
+        .find(|l| l.contains("options:"))
+        .unwrap_or("")
+        .to_string();
     assert!(
-        human.contains("options:") && human.contains(r"pattern: \bdbg!\("),
-        "explain human dropped the kind option:\n{human}"
+        opt_line.contains("pattern:") && opt_line.contains(r"first\nsecond"),
+        "multi-line option must render inline as escaped JSON: {opt_line:?}"
+    );
+    assert!(
+        !human.lines().any(|l| l == "second"),
+        "multi-line option leaked a column-0 continuation line:\n{human}"
+    );
+    assert!(
+        human.lines().any(|l| l.trim_start() == "lines: 3"),
+        "the second option must be indented on its own line:\n{human}"
     );
 }
 


### PR DESCRIPTION
Follow-up to #161 (merged), continuing the ADR-0012 completeness work in parallel with #163. This closes the **last `explain` completeness gap: kind-specific options**.

## What

`explain` now shows a rule's kind options — the flattened non-common `RuleSpec` fields like `pattern` / `max_lines` — retained as `RuleEntry.extra` from the spec:

```
id:         no-dbg-macros-in-prod
kind:       file_content_forbidden
categories: content, security-unicode-sanity
level:      warning
paths:      crates/**/src/**/*.rs  (excluding crates/**/src/**/tests.rs)
options:    pattern: \bdbg!\s*\(
message:    `dbg!` macros should not land in committed Rust sources.
```

`--format json` gains an `options` object. The output now covers **id, kind, categories, level, paths, options, message, policy_url, when, fix** — explain is complete.

## Why the spec projection, not the `Rule::message()` trait accessor

ADR-0012 offered two structural options. I investigated the trait accessor first and found it is the wrong tool: **11 of the 70 macro-kinds do not store the message under a `message` field** — git-commit kinds use `message_override` (to disambiguate from commit messages), and the iterators delegate to nested rules. So a uniform `self.message` macro accessor cannot compile, and per-kind handling would be fragile. The **spec-based projection** (retaining config on the entry, as done here for options and in #161 for message/paths) sidesteps the per-kind field-name problem entirely. This PR is the options slice of that projection.

## Robustness

- Complex (list/map) options render as compact JSON in the human block and proper JSON under `--format json`; a rule with no options prints no `options:` line.
- Verified across **every kind in `all_kinds.yaml` (99/99 valid JSON)**.
- New gate `explain_surfaces_kind_options`.

## Relationship to #163

Independent and parallel (this touches `explain` + `RuleEntry`; #163 touches `list` / `export` + the all-kinds gate). The only overlap is a trivial CHANGELOG `[Unreleased]` bullet, resolved at merge.

## Verification

`fmt --check`, `clippy --workspace --all-targets -- -D warnings`, `rustdoc -D warnings`, `cargo test --workspace` (72 groups, 0 failures), and `alint check` all green.
