### PR TITLE
refactor(explain): render explain/list from a retained RuleSpec (ADR-0013)

### DIFF
--- a/crates/alint-core/src/engine.rs
+++ b/crates/alint-core/src/engine.rs
@@ -73,29 +73,20 @@ type LivePerFileEntries<'a> = (Vec<(usize, &'a RuleEntry)>, Vec<(usize, RuleResu
 pub struct RuleEntry {
     pub rule: Box<dyn Rule>,
     pub when: Option<WhenExpr>,
-    /// The `when:` clause's source text, retained so `alint explain` can show
-    /// the authored expression rather than the parsed AST. `None` when the rule
-    /// is unconditional.
-    pub when_src: Option<String>,
-    /// The rule's kind (e.g. `file_exists`), retained from its `RuleSpec` so
-    /// config-scoped tooling (`alint list --category`) can map an active rule to
-    /// its categories. Empty for entries built without a spec (`Engine::new`,
-    /// nested rules). INVARIANT: category filtering treats an empty kind as "no
-    /// categories" (the rule is silently dropped), so any config-loading path
-    /// that wants `--category` to work MUST set this via [`RuleEntry::with_kind`].
-    pub kind: String,
-    /// The rule's `paths:` scope, retained from its `RuleSpec` so config-scoped
-    /// tooling (`alint explain`) can show what the rule matches without
-    /// re-reading the config. `None` for entries built without a spec.
-    pub paths: Option<crate::config::PathsSpec>,
-    /// The rule's custom `message:`, retained from its `RuleSpec` so `alint
-    /// explain` can surface the author's violation text. `None` when the rule
-    /// falls back to its kind's default message.
-    pub message: Option<String>,
-    /// The rule's kind-specific options (the flattened non-common `RuleSpec`
-    /// fields, e.g. `pattern`, `max_lines`), retained so `alint explain` can show
-    /// them. Empty for entries built without a spec.
-    pub extra: serde_yaml_ng::Mapping,
+    /// The rule's originating [`RuleSpec`](crate::config::RuleSpec), retained so
+    /// config-scoped tooling (`alint explain`, `alint list`) can render the
+    /// rule's configured detail — kind, `paths:`, `message:`, `when:` source, and
+    /// kind-specific options — from one source of truth rather than a handful of
+    /// ad-hoc per-field copies. Read only by display code, never on the check
+    /// hot path.
+    ///
+    /// `None` for entries built without a spec (`Engine::new`, nested/iterator
+    /// child rules); such entries render as if every display field were empty.
+    /// INVARIANT: `list --category` maps a `None` spec (an empty
+    /// [`kind`](RuleEntry::kind)) to "no categories" and silently drops the rule,
+    /// so any config-loading path that wants `--category` to work MUST attach the
+    /// spec via [`with_spec`](RuleEntry::with_spec).
+    pub spec: Option<Arc<crate::config::RuleSpec>>,
     /// The rule's resolved top-level `allow_out_of_root:` permission, threaded
     /// into the fixer's [`FixContext`] so a config-declared fix path can escape
     /// the root only when the user's own config opted this rule in. Defaults to
@@ -108,11 +99,7 @@ impl RuleEntry {
         Self {
             rule,
             when: None,
-            when_src: None,
-            kind: String::new(),
-            paths: None,
-            message: None,
-            extra: serde_yaml_ng::Mapping::new(),
+            spec: None,
             allow_out_of_root: false,
         }
     }
@@ -131,39 +118,48 @@ impl RuleEntry {
         self
     }
 
-    /// Record the `when:` clause's source text (see [`RuleEntry::when_src`]).
+    /// Attach the rule's originating [`RuleSpec`](crate::config::RuleSpec) (see
+    /// [`RuleEntry::spec`]) — the single source config-scoped tooling renders
+    /// the rule's kind, paths, message, `when:` source, and options from.
     #[must_use]
-    pub fn with_when_src(mut self, src: impl Into<String>) -> Self {
-        self.when_src = Some(src.into());
+    pub fn with_spec(mut self, spec: Arc<crate::config::RuleSpec>) -> Self {
+        self.spec = Some(spec);
         self
     }
 
-    /// Record the rule's kind-specific options (see [`RuleEntry::extra`]).
+    /// The rule's kind (e.g. `file_exists`), or `""` when built without a spec.
+    /// An empty kind maps to "no categories" for `list --category` (the rule is
+    /// silently dropped), matching the pre-projection behaviour.
     #[must_use]
-    pub fn with_extra(mut self, extra: serde_yaml_ng::Mapping) -> Self {
-        self.extra = extra;
-        self
+    pub fn kind(&self) -> &str {
+        self.spec.as_ref().map_or("", |s| s.kind.as_str())
     }
 
-    /// Record the rule's kind (see [`RuleEntry::kind`]).
+    /// The rule's `paths:` scope, if the spec configured one.
     #[must_use]
-    pub fn with_kind(mut self, kind: impl Into<String>) -> Self {
-        self.kind = kind.into();
-        self
+    pub fn paths(&self) -> Option<&crate::config::PathsSpec> {
+        self.spec.as_ref().and_then(|s| s.paths.as_ref())
     }
 
-    /// Record the rule's `paths:` scope (see [`RuleEntry::paths`]).
+    /// The rule's custom `message:`, if set (see [`RuleEntry::spec`]).
     #[must_use]
-    pub fn with_paths(mut self, paths: Option<crate::config::PathsSpec>) -> Self {
-        self.paths = paths;
-        self
+    pub fn message(&self) -> Option<&str> {
+        self.spec.as_ref().and_then(|s| s.message.as_deref())
     }
 
-    /// Record the rule's custom `message:` (see [`RuleEntry::message`]).
+    /// The rule's authored `when:` source text, retained so `alint explain` can
+    /// show the written expression rather than the parsed AST. `None` when the
+    /// rule is unconditional.
     #[must_use]
-    pub fn with_message(mut self, message: Option<String>) -> Self {
-        self.message = message;
-        self
+    pub fn when_src(&self) -> Option<&str> {
+        self.spec.as_ref().and_then(|s| s.when.as_deref())
+    }
+
+    /// The rule's kind-specific options (the flattened non-common `RuleSpec`
+    /// fields, e.g. `pattern`, `max_lines`), or `None` when built without a spec.
+    #[must_use]
+    pub fn extra(&self) -> Option<&serde_yaml_ng::Mapping> {
+        self.spec.as_ref().map(|s| &s.extra)
     }
 }
 

--- a/crates/alint/src/main.rs
+++ b/crates/alint/src/main.rs
@@ -1038,7 +1038,7 @@ fn cmd_list(category: Option<&str>, cli: &Cli) -> Result<ExitCode> {
     if let Some(slug) = category {
         loaded
             .entries
-            .retain(|e| rules::categories_for_kind(&e.kind).contains(&slug));
+            .retain(|e| rules::categories_for_kind(e.kind()).contains(&slug));
     }
 
     // `list` honours --format for machine consumers: `json` emits a
@@ -1089,8 +1089,8 @@ fn cmd_list(category: Option<&str>, cli: &Cli) -> Result<ExitCode> {
         // Surface the rule's kind (and a fixable marker) in the human list,
         // matching what `list --format json` already carries — otherwise the
         // human inventory can't answer "what kind is this rule?".
-        if !entry.kind.is_empty() {
-            write!(out, "  {dim}{}{dim:#}", entry.kind)?;
+        if !entry.kind().is_empty() {
+            write!(out, "  {dim}{}{dim:#}", entry.kind())?;
         }
         if entry.when.is_some() {
             write!(out, " {dim}[when]{dim:#}")?;
@@ -1122,8 +1122,8 @@ fn list_json(loaded: &LoadedConfig) -> Result<ExitCode> {
         .map(|entry| {
             serde_json::json!({
                 "id": entry.rule.id(),
-                "kind": entry.kind,
-                "categories": rules::categories_for_kind(&entry.kind),
+                "kind": entry.kind(),
+                "categories": rules::categories_for_kind(entry.kind()),
                 "level": entry.rule.level().as_str(),
                 "policy_url": entry.rule.policy_url(),
                 "conditional": entry.when.is_some(),
@@ -1301,9 +1301,9 @@ fn cmd_explain(rule_id: &str, cli: &Cli) -> Result<ExitCode> {
         Level::Off => style::DIM,
     };
     writeln!(out, "{dim}id:        {dim:#} {}", rule.id())?;
-    if !entry.kind.is_empty() {
-        writeln!(out, "{dim}kind:      {dim:#} {}", entry.kind)?;
-        let cats = rules::categories_for_kind(&entry.kind);
+    if !entry.kind().is_empty() {
+        writeln!(out, "{dim}kind:      {dim:#} {}", entry.kind())?;
+        let cats = rules::categories_for_kind(entry.kind());
         if !cats.is_empty() {
             writeln!(out, "{dim}categories:{dim:#} {}", cats.join(", "))?;
         }
@@ -1313,12 +1313,13 @@ fn cmd_explain(rule_id: &str, cli: &Cli) -> Result<ExitCode> {
         "{dim}level:     {dim:#} {level_style}{}{level_style:#}",
         rule.level().as_str(),
     )?;
-    if let Some(paths) = &entry.paths {
+    if let Some(paths) = entry.paths() {
         writeln!(out, "{dim}paths:     {dim:#} {}", paths.render_scope())?;
     }
     // Kind-specific options (pattern, max_lines, ...): the first inline after
-    // the `options:` label, the rest indented under the value column.
-    for (i, (k, v)) in entry.extra.iter().enumerate() {
+    // the `options:` label, the rest indented under the value column. A
+    // spec-less entry has no options, so the flattened iterator is empty.
+    for (i, (k, v)) in entry.extra().into_iter().flatten().enumerate() {
         let key = k.as_str().unwrap_or_default();
         let val = match serde_json::to_value(v) {
             // A single-line string renders bare; a multi-line string (and every
@@ -1338,7 +1339,7 @@ fn cmd_explain(rule_id: &str, cli: &Cli) -> Result<ExitCode> {
     // dangling `message:` label. Continuation lines indent under the value
     // column and a trailing newline (block scalars carry one) is dropped, so a
     // multi-line message stays aligned instead of wrapping back to column 0.
-    if let Some(msg) = entry.message.as_deref() {
+    if let Some(msg) = entry.message() {
         let msg = msg.trim_end_matches('\n');
         if !msg.trim().is_empty() {
             let msg = msg.replace('\n', &format!("\n{}", " ".repeat(12)));
@@ -1352,7 +1353,7 @@ fn cmd_explain(rule_id: &str, cli: &Cli) -> Result<ExitCode> {
     {
         writeln!(out, "{dim}policy_url:{dim:#} {docs}{url}{docs:#}")?;
     }
-    if let Some(when) = &entry.when_src {
+    if let Some(when) = entry.when_src() {
         writeln!(out, "{dim}when:      {dim:#} {when}")?;
     }
     if let Some(fixer) = rule.fixer() {
@@ -1378,31 +1379,33 @@ fn explain_json(entry: &alint_core::RuleEntry) -> Result<ExitCode> {
     // `paths` normalises to `{ include, exclude }` glob lists. `rule_kind`
     // carries the rule's own kind (the envelope's `kind` is the fixed `"rule"`
     // discriminator), and `categories` matches each `list --format json` entry.
-    let paths = entry.paths.as_ref().map(|p| {
+    let paths = entry.paths().map(|p| {
         let (include, exclude) = p.include_exclude();
         serde_json::json!({ "include": include, "exclude": exclude })
     });
-    let options = if entry.extra.is_empty() {
-        serde_json::Value::Null
-    } else {
-        serde_json::to_value(&entry.extra).unwrap_or(serde_json::Value::Null)
+    let options = match entry.extra() {
+        Some(extra) if !extra.is_empty() => {
+            serde_json::to_value(extra).unwrap_or(serde_json::Value::Null)
+        }
+        _ => serde_json::Value::Null,
     };
     let doc = serde_json::json!({
         "schema_version": 1,
         "kind": "rule",
         "id": entry.rule.id(),
-        "rule_kind": entry.kind,
-        "categories": rules::categories_for_kind(&entry.kind),
+        "rule_kind": entry.kind(),
+        "categories": rules::categories_for_kind(entry.kind()),
         "level": entry.rule.level().as_str(),
         "paths": paths,
         "options": options,
-        "message": entry.message.as_deref().filter(|m| !m.trim().is_empty()),
+        "message": entry.message().filter(|m| !m.trim().is_empty()),
         "policy_url": entry.rule.policy_url(),
-        "when": entry.when_src,
-        // Mirror the displayed `when` source so `conditional` and `when` can
-        // never disagree (both are set together at load; deriving from one
-        // field keeps the output self-consistent for any future caller).
-        "conditional": entry.when_src.is_some(),
+        "when": entry.when_src(),
+        // Both `when` and `conditional` project from the retained `when:` source
+        // (`spec.when`), so within this document they can never disagree - deriving
+        // both from one field keeps it self-consistent for any future caller.
+        // `list --format json`'s `conditional` reads the equivalent parsed `when`.
+        "conditional": entry.when_src().is_some(),
         "fixable": entry.rule.fixer().is_some(),
         "fix": entry.rule.fixer().map(alint_core::Fixer::describe),
     });
@@ -1681,16 +1684,17 @@ fn load_rules(cwd: &Path, cli: &Cli) -> Result<LoadedConfig> {
         // kind that doesn't honor the flag).
         let allow_out_of_root = config.allow_out_of_root.allows(&spec.id, &spec.kind);
         rule.set_allow_out_of_root(allow_out_of_root);
+        // Retain the whole spec (one `Arc`-wrapped clone) so `explain`/`list`
+        // render every configured detail from a single source of truth. The
+        // marginal cost over the old per-field copies is ~nil — `extra` was
+        // already cloned here — and nothing on the check hot path reads it.
         let mut entry = alint_core::RuleEntry::new(rule)
-            .with_kind(spec.kind.clone())
-            .with_paths(spec.paths.clone())
-            .with_message(spec.message.clone())
-            .with_extra(spec.extra.clone())
+            .with_spec(std::sync::Arc::new(spec.clone()))
             .with_allow_out_of_root(allow_out_of_root);
         if let Some(when_src) = &spec.when {
             let expr = alint_core::when::parse(when_src)
                 .with_context(|| format!("rule {:?}: parsing `when`", spec.id))?;
-            entry = entry.with_when(expr).with_when_src(when_src.clone());
+            entry = entry.with_when(expr);
         }
         entries.push(entry);
     }

--- a/crates/alint/tests/cli_format_contract.rs
+++ b/crates/alint/tests/cli_format_contract.rs
@@ -403,6 +403,54 @@ rules:
     );
 }
 
+// ─── Explain surfaces the authored `when:` source ──────────────────
+//
+// The one retired display field the other four completeness gates DON'T cover:
+// the `[when]` marker `list_human_surfaces_kind_and_markers` asserts reads the
+// retained PARSED `when` (`entry.when`), not the authored source, so it would
+// still pass if the `when:` source rendering regressed. This gate pins that
+// `explain` renders a rule's `when:` source (human AND json) and reports
+// `conditional: true`, closing the last hole in the RuleSpec -> RuleEntry
+// projection (ADR-0013).
+#[test]
+fn explain_surfaces_when_source() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join(".alint.yml"),
+        "version: 1\n\
+         rules:\n\
+        \x20 - id: gated\n\
+        \x20   kind: file_exists\n\
+        \x20   paths: rust-toolchain.toml\n\
+        \x20   level: info\n\
+        \x20   when: \"facts.has_rust\"\n",
+    )
+    .unwrap();
+
+    // JSON: `when` carries the authored source and `conditional` is true.
+    let v: serde_json::Value =
+        serde_json::from_slice(&run(dir.path(), &["explain", "gated", "--format", "json"]).stdout)
+            .expect("explain --format json must be JSON");
+    assert_eq!(
+        v["when"], "facts.has_rust",
+        "explain json dropped the authored when source: {v}"
+    );
+    assert_eq!(
+        v["conditional"], true,
+        "explain json must report a gated rule as conditional: {v}"
+    );
+
+    // Human: the `when:` line shows the source expression.
+    let human =
+        String::from_utf8_lossy(&run(dir.path(), &["explain", "gated"]).stdout).into_owned();
+    assert!(
+        human
+            .lines()
+            .any(|l| l.contains("when:") && l.contains("facts.has_rust")),
+        "explain human must show the when: source expression:\n{human}"
+    );
+}
+
 // ─── G1b — the agent format only emits commands the CLI accepts ─────
 
 /// Pull `` `alint …` `` commands out of an `agent_instruction` string:

--- a/docs/adr/0012-output-completeness-testing.md
+++ b/docs/adr/0012-output-completeness-testing.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-08-06
 decision-makers: asamarts
 ---
@@ -8,8 +8,15 @@ decision-makers: asamarts
 
 ## Status
 
-Proposed. Prompted by the `alint explain` gap fixed in the Tier 1 explain change,
-and a 2026-08-06 audit of every subcommand's output against its data model.
+Accepted (2026-08-08). Commitments 1 and 2 shipped: the positive-invariant gates
+driven by `all_kinds.yaml` (`explain_surfaces_configured_rule_detail`,
+`explain_covers_every_registered_kind`) and the `list` / `export-agents-md`
+remediations (the human `kind` + `[fix]` marker, the scope fallback, and
+kind-specific options). Commitment 3's structural-prevention choice is decided in
+ADR-0013 - retain the `RuleSpec` projection on `RuleEntry` and render from it; the
+`Rule::message()` accessor is rejected there. Originally prompted by the `alint
+explain` gap fixed in the Tier 1 explain change and a 2026-08-06 audit of every
+subcommand's output against its data model.
 
 ## Context
 

--- a/docs/adr/0013-retained-spec-projection.md
+++ b/docs/adr/0013-retained-spec-projection.md
@@ -1,0 +1,177 @@
+---
+status: accepted
+date: 2026-08-08
+decision-makers: asamarts
+---
+
+# 0013. Render explain/list from a retained RuleSpec projection
+
+## Status
+
+Accepted. This resolves the open structural-prevention choice left by ADR-0012
+(commitment 3): of the two moves ADR-0012 named, we adopt the retained-spec
+projection and reject the `Rule::message()` trait accessor. The decision below is
+settled; the implementation lands in the companion `explain-spec-projection`
+change and is guarded by gates already on `main`.
+
+## Context
+
+`alint explain <rule>` and `alint list` render a rule's *configured* detail (kind,
+scope, message, `when:`, kind-specific options) for local introspection. Since the
+output-completeness work began (ADR-0012), the data those commands read has
+accreted as **ad-hoc display-only fields on the engine's runtime `RuleEntry`**,
+one field per gap as each was closed:
+
+- `when_src` (the `when:` source string, so `explain` shows the authored clause
+  rather than the parsed AST) - `crates/alint-core/src/engine.rs:79`
+- `kind` - engine.rs:86
+- `paths` - engine.rs:90
+- `message` - engine.rs:94
+- `extra` (the flattened kind-specific options) - engine.rs:98
+
+Five display-only fields now sit on `RuleEntry`, none read on the check hot path,
+each with its own `with_*` builder and its own wiring at the load site. Every new
+"explain should also show X" gap has meant a new field, a new builder, and a new
+load-site call. ADR-0012's commitment 3 named two ways to stop this accretion and
+deliberately left the choice to a follow-up:
+
+1. a `Rule::message()` trait accessor emitted from `rule_common_impl!`, or
+2. retaining the `RuleSpec` projection so the renderers read the configured shape
+   directly.
+
+The trait accessor was investigated during the kind-options change and **does not
+hold uniformly.** 65 rule structs carry a `message: Option<String>` field, but a
+substantial set do not: the git-commit family plus two cross-file kinds - 8
+structs (`git_commit_*`, `pair_changed_together`, `changeset_requires_path`) -
+carry a `message_override` field instead (named to disambiguate from an actual
+commit message), and the iterator / cross-file kinds delegate to nested rules and
+hold no message of their own. A macro emitting `self.message` cannot compile for
+those; per-kind hand-wiring is fragile; and the accessor only ever addresses
+`message` - `paths` and the heterogeneous kind options still have no home on the
+trait. Tellingly, those same kinds already read their message from the spec -
+their builders do `message_override: spec.message.clone()`
+(`crates/alint-rules/src/git_commit_message.rs`) - so `spec.message` is the one
+uniform source that holds every kind's authored message, including the kinds the
+accessor cannot reach.
+
+The `RuleSpec` (`crates/alint-core/src/config.rs`), by contrast, already holds
+**all** of it uniformly - `kind`, `paths`, `message`, `when` (the authored source),
+`fix`, `scope_filter`, and the flattened `extra` options - because
+`RuleSpec::deserialize_options` proves `extra` is exactly the recognized
+kind-options. And there is prior art in-tree: `export_agents_md::collect_directives`
+(`crates/alint/src/export_agents_md/mod.rs`) already renders straight from
+`config.rules`, not from per-kind trait methods.
+
+## Decision
+
+We will **retain the rule's `RuleSpec` on its `RuleEntry`** and render
+`explain` / `list` from it, retiring the five ad-hoc display fields in its favour.
+Concretely:
+
+- `RuleEntry` gains `spec: Option<Arc<RuleSpec>>`, set at the CLI config load site
+  (`load_rules`) for the config-built rules `explain`/`list` render. It is `None`
+  for `Engine::new`, nested (iterator-child) entries, AND the LSP's check-only load
+  path (which builds entries for diagnostics, never renders explain/list, and so
+  skips the retained spec) - exactly the cases where the five display fields were
+  already empty. The migration MUST preserve the existing kind-empty invariant
+  (`engine.rs`): a `None` spec renders as an absent kind, which `list --category`
+  treats as "no categories" and silently drops - identical to today's empty-`kind`
+  behaviour.
+- The runtime fields stay: `rule` (the built `Box<dyn Rule>`), `when` (the parsed
+  `WhenExpr` used for gating), and `allow_out_of_root`. The five display fields
+  (`when_src`, `kind`, `paths`, `message`, `extra`) and their `with_*` builders are
+  removed.
+- `explain`, `list`, and `list --category` read `entry.spec` through small
+  accessor helpers - `spec.kind`, `spec.paths`, `spec.message`, `spec.when` (the
+  authored source, replacing `when_src`), `spec.extra` - so the next "explain
+  should also show X" is a one-line render change, not another `RuleEntry` field.
+  `explain --format json` keeps deriving both its `when` source and its
+  `conditional` flag from that one retained source, so the two cannot disagree;
+  `list --format json`'s `conditional` reads the equivalent parsed `when`.
+- **The `Rule::message()` trait accessor is rejected** for the reasons in Context.
+
+This changes no rule's runtime behaviour, no rendered output content, and none of
+the existing completeness gates. It is a data-flow refactor behind byte-identical
+output.
+
+## Consequences
+
+Easier:
+
+- One retained value replaces five accreting fields; the next display gap is a
+  render change, not an engine-struct change. The "one ad-hoc field per gap" smell
+  is gone.
+- A single source of truth for what a rule is configured as (the spec), shared by
+  `explain`, `list`, and `export-agents-md`.
+
+Harder, and accepted:
+
+- **`RuleEntry`'s public shape changes** - five `pub` fields out, one in. It is an
+  `alint-core` public type, but pre-1.0 and pre-frozen-API: RELEASING.md scopes the
+  semver contract to the observable product surface (`.alint.yml`, CLI, machine
+  output) and states the `alint-core` API "joins at v1.0", so this ships as a PATCH
+  under that document's tie-breaker (an unchanged config yields byte-identical
+  findings and output). Its only in-tree consumers are the CLI renderers, which
+  move in the same change.
+- A per-rule spec clone at load time: `spec` is borrowed while entries build, so
+  retaining it is `Arc::new(spec.clone())` - a full `RuleSpec` clone, not a
+  refcount bump. The dominant field (`extra`) was already cloned into `RuleEntry`
+  at this site; the clone newly copies a few small fields too (`id`, `level`,
+  `policy_url`, `fix`, `scope_filter`), so the marginal cost is negligible rather
+  than literally nil, and it is off the hot path - the check loop never touches
+  `spec`.
+
+Mostly guarded, with one gap this change must close. Four completeness gates
+already on `main` - `explain_surfaces_configured_rule_detail`,
+`explain_covers_every_registered_kind`, `list_human_surfaces_kind_and_markers`,
+and `explain_surfaces_kind_options` (`crates/alint/tests/cli_format_contract.rs`) -
+assert the rendered output for `kind`, `paths`, `message`, and the kind options,
+so a lossy migration of those four fails a test. The fifth retired field,
+`when_src`, is NOT covered: the only when-touching gate asserts the `list`
+`[when]` marker, which reads the retained parsed `when` (`entry.when.is_some()`),
+not the authored source, and no `explain` fixture sets a `when:`. So `explain`'s
+`when:` source line and `explain --format json`'s `when` / `conditional` fields
+would migrate unguarded. This change therefore ADDS a positive `when`-source
+completeness gate - assert `explain` (human and json) surfaces a configured
+`when:` and reports `conditional: true` - as part of the same work, closing the
+exact gap-class ADR-0012 named for the one field it had not yet reached.
+
+## Considered Options
+
+- **Retain the `RuleSpec` projection on `RuleEntry` (chosen).** Uniform across
+  message, paths, options, and `when:` in one value; matches the
+  `export_agents_md` prior art; ends the field accretion. Costs one `RuleSpec`
+  clone per rule at load (wrapped in an `Arc`), negligible over today since the
+  dominant `extra` field is already cloned here.
+- **A `Rule::message()` trait accessor.** Rejected: 8+ kinds do not hold the
+  message in a `message` field (`message_override` / delegated to nested rules), so
+  a macro-emitted `self.message` cannot be uniform, and it addresses only
+  `message` - not `paths` or the heterogeneous kind options.
+- **Keep adding ad-hoc `RuleEntry` display fields (status quo).** Rejected: every
+  future display gap keeps meaning a new engine field, builder, and load wiring -
+  the accretion this ADR exists to stop.
+- **A bespoke display-projection struct instead of `Arc<RuleSpec>`.** Slightly less
+  memory, but a second type to define and keep in sync with `RuleSpec`; the spec is
+  already exactly the configured shape, so retaining it is simpler.
+- **`Box<RuleSpec>` instead of `Arc`.** The entry is the sole owner today
+  (`RuleEntry` is not `Clone`), so `Box` would avoid the atomic refcount. `Arc` is
+  kept for the near-zero-cost option of sharing the spec later (e.g. with rendered
+  iterator children) without a field-type change; the atomic ops are off the hot
+  path.
+- **Keep the specs in `LoadedConfig` (a parallel id-keyed map) rather than on
+  `RuleEntry`.** ADR-0012 sketched this variant. Viable, but the renderers already
+  hold the `RuleEntry`; hanging the spec off it avoids a per-render id/index
+  lookup.
+
+## More Information
+
+- Resolves ADR-0012 (output-completeness as a tested contract), commitment 3, and
+  keeps the completeness gates that ADR introduced as the migration's guardrail.
+- Prior art for spec-based rendering: `export_agents_md::collect_directives`
+  (`crates/alint/src/export_agents_md/mod.rs`).
+- The fields being retired were added across the explain enrichment (kind / paths /
+  message / when_src) and the kind-options change (extra); anchors at
+  `crates/alint-core/src/engine.rs:79-98` and the load site in
+  `crates/alint/src/main.rs`.
+- Independent of ADR-0011 (per-kind explanation prose), which adds a *new* data
+  source rather than reorganising the config-instance projection this ADR covers.


### PR DESCRIPTION
Resolves ADR-0012's commitment 3 (structural prevention) via the decision recorded in **ADR-0013**: render `explain`/`list` from a retained `RuleSpec` on `RuleEntry`, rather than from ad-hoc per-field copies that accreted one-per-gap across the explain arc (#161/#163/#164).

## What

- **Retire** the five ad-hoc display fields on `RuleEntry` (`when_src`/`kind`/`paths`/`message`/`extra`) and their builders.
- **Add** `spec: Option<Arc<RuleSpec>>`, attached once at the config load site (one `Arc`-wrapped clone; `extra` was already cloned here, so the marginal cost is negligible).
- `explain`, `list`, and `list --category` read the rule's configured detail through five thin accessors that project from the spec, so the next "explain should also show X" is a render change, not another engine-struct field.
- **Reject** the `Rule::message()` trait accessor: 8 kinds carry `message_override` instead of a `message` field (the git-commit family, `pair_changed_together`, `changeset_requires_path`), and the `for_each_*` iterators have no message field at all, so a macro-emitted `self.message` would not compile. `spec.message` is the one uniform source (those kinds' builders already read it via `message_override: spec.message.clone()`).

## Why it is safe

- **Byte-identical output, proven empirically**: an old-vs-new diff of the actual pre-refactor binary across **all 99 fixture kinds × (human + json) `explain` + `list`** shows **zero mismatches** (beyond the two trycmd snapshots, which also pass unchanged). The check hot path never touches `spec`.
- **Contained** — the only consumers of the retired fields were the CLI renderers and the load site (verified across the whole workspace); every other `RuleEntry` user builds via `new`/`with_when`, and the LSP's check-only load path never rendered explain/list.
- **New guardrail** — adds `explain_surfaces_when_source`, the one completeness gate the other four lacked (the `[when]` marker they assert reads the parsed `when`, not the authored source), pinning the `when_src -> spec.when` projection in human and JSON.

## Audit

Adversarially reviewed (independent review subagent + hands-on), verified complete and consistent with ADR-0012/0013. No HIGH/MEDIUM correctness defects. Addressed before this revision:
- **Reverted an ill-advised `conditional`-source change** so `explain --format json` again derives both its `when` and `conditional` from the one retained source, restoring the prior guarantee that the two cannot disagree (and keeping output byte-identical).
- **ADR refined**: records the LSP check-only load path as a third `spec=None` case; pins the semver classification to a **patch** per RELEASING.md (the `alint-core` API is out of the pre-1.0 contract, and output is byte-identical); documents the Box-vs-Arc choice and sharpens the clone-cost wording.

No CHANGELOG entry: output is byte-identical, so there is no user-facing change to record.

## Local preflight (all green)

2039 workspace tests · clippy (`--workspace --all-targets -D warnings`) · `fmt --check` · rustdoc (`-D warnings`) · dogfood self-check · the 99-kind byte-identical diff.
