### PR TITLE
docs+test: close post-v0.14.0 doc + e2e coverage gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ alint export-agents-md --inline --output AGENTS.md    # splice between alint mar
 
 `--inline` writes only between `<!-- alint:start -->` / `<!-- alint:end -->` markers; everything else in `AGENTS.md` is human-owned prose. Re-runs are idempotent (when the on-disk content already matches, no write happens), and missing markers auto-init with a stderr warning so the second run splices cleanly.
 
+Each rule renders as a one-line directive: its `message:` when it sets one, otherwise its kind and scope (for example, "file_exists rule on README.md"), so a rule with no message still tells the agent what to enforce.
+
 The generated file is editable: start there, override or extend as needed. If you'd rather hand-roll, the minimum viable shape is:
 
 ```yaml

--- a/crates/alint/tests/cli_format_contract.rs
+++ b/crates/alint/tests/cli_format_contract.rs
@@ -451,6 +451,174 @@ fn explain_surfaces_when_source() {
     );
 }
 
+// ─── Explain surfaces the auto-fix for a fixable rule ──────────────
+//
+// `explain` emits `fix` + `fixable` (main.rs), but every other explain gate uses
+// a NON-fixable rule, so the human `fix:` line and the json `fix`/`fixable`
+// fields were asserted nowhere. This pins BOTH sides: a file_create-fixable rule
+// (fix line + fixable:true) and a non-fixable rule (no fix line + fixable:false).
+#[test]
+fn explain_surfaces_fix_for_fixable_rule() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join(".alint.yml"),
+        "version: 1\n\
+         rules:\n\
+        \x20 - id: needs-editorconfig\n\
+        \x20   kind: file_exists\n\
+        \x20   paths: .editorconfig\n\
+        \x20   level: error\n\
+        \x20   fix: { file_create: { content: \"root = true\\n\" } }\n",
+    )
+    .unwrap();
+
+    // JSON: `fixable` is true and `fix` carries a non-empty describe string.
+    let v: serde_json::Value = serde_json::from_slice(
+        &run(
+            dir.path(),
+            &["explain", "needs-editorconfig", "--format", "json"],
+        )
+        .stdout,
+    )
+    .expect("explain --format json must be JSON");
+    assert_eq!(
+        v["fixable"], true,
+        "explain json must report a fixable rule: {v}"
+    );
+    assert!(
+        v["fix"].as_str().is_some_and(|s| !s.is_empty()),
+        "explain json must describe the fix: {v}"
+    );
+
+    // Human: the `fix:` line renders.
+    let human =
+        String::from_utf8_lossy(&run(dir.path(), &["explain", "needs-editorconfig"]).stdout)
+            .into_owned();
+    assert!(
+        human.lines().any(|l| l.trim_start().starts_with("fix:")),
+        "explain human must show the fix: line:\n{human}"
+    );
+
+    // Negative: a non-fixable rule reports fixable:false, nulls `fix`, and renders
+    // no `fix:` line, so the projection can't regress to "always fixable".
+    std::fs::write(
+        dir.path().join(".alint.yml"),
+        "version: 1\n\
+         rules:\n\
+        \x20 - id: no-bak\n\
+        \x20   kind: file_absent\n\
+        \x20   paths: \"**/*.bak\"\n\
+        \x20   level: warning\n",
+    )
+    .unwrap();
+    let v: serde_json::Value =
+        serde_json::from_slice(&run(dir.path(), &["explain", "no-bak", "--format", "json"]).stdout)
+            .expect("explain --format json must be JSON");
+    assert_eq!(
+        v["fixable"], false,
+        "explain json must report a non-fixable rule as fixable:false: {v}"
+    );
+    assert!(
+        v["fix"].is_null(),
+        "explain json must null the fix for a non-fixable rule: {v}"
+    );
+    let human =
+        String::from_utf8_lossy(&run(dir.path(), &["explain", "no-bak"]).stdout).into_owned();
+    assert!(
+        !human.lines().any(|l| l.trim_start().starts_with("fix:")),
+        "a non-fixable rule must not render a fix: line:\n{human}"
+    );
+}
+
+// ─── export-agents-md keeps scope when a rule has no message ────────
+//
+// A message-less, path-scoped rule must render "<kind> rule on <scope>" in the
+// generated directive, not the bare "<kind> rule". The markdown snapshot
+// fixture's rules all set a `message:`, so this fallback had only a unit test
+// (`export_agents_md::missing_message_with_paths_keeps_the_scope`); this drives
+// it through the real binary.
+#[test]
+fn export_agents_md_keeps_scope_for_messageless_rule() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join(".alint.yml"),
+        "version: 1\n\
+         rules:\n\
+        \x20 - id: needs-readme\n\
+        \x20   kind: file_exists\n\
+        \x20   paths: README.md\n\
+        \x20   level: error\n",
+    )
+    .unwrap();
+
+    let out = String::from_utf8_lossy(&run(dir.path(), &["export-agents-md"]).stdout).into_owned();
+    assert!(
+        out.contains("file_exists rule on README.md"),
+        "a message-less rule must keep its scope in the directive:\n{out}"
+    );
+}
+
+// ─── --help wraps to a narrow terminal width ───────────────────────
+//
+// #159 made `alint --help` wrap to the terminal width, but the committed
+// help-*.stdout snapshots capture only clap's 100-col non-TTY fallback, so the
+// genuinely-narrow promise was unpinned. Drive the real binary at COLUMNS=40.
+// The top-level help holds no unbreakable token, so no line may exceed 40.
+// Subcommands can carry a literal clap cannot split (a `path@v1` option value,
+// or the un-wrapped `Usage:` line — currently up to 45), so a line may run a
+// little over; the ceiling still catches a wrap_help regression, which would put
+// whole 100+ char option descriptions back on one line. The new quickstart tells
+// users to run `alint <cmd> --help`, so cover the top level AND every subcommand.
+#[test]
+fn help_wraps_to_narrow_terminal_width() {
+    let widest = |sub: &[&str]| -> (usize, String) {
+        let out = Command::new(alint_bin())
+            .args(sub)
+            .arg("--help")
+            .env("COLUMNS", "40")
+            .output()
+            .expect("spawn alint");
+        let text = String::from_utf8_lossy(&out.stdout).into_owned();
+        let w = text.lines().map(|l| l.chars().count()).max().unwrap_or(0);
+        (w, text)
+    };
+
+    // Top level: exact — nothing here is unbreakable, so it fits the column.
+    let (top, text) = widest(&[]);
+    assert!(
+        text.contains("explain") && text.lines().count() > 10,
+        "narrow top-level --help looks truncated:\n{text}"
+    );
+    assert!(
+        top <= 40,
+        "no top-level `--help` line may exceed COLUMNS=40, but the widest is {top}:\n{text}"
+    );
+
+    // Every subcommand: rendered and wrapped (no return to unwrapped prose).
+    for sub in [
+        "check",
+        "list",
+        "explain",
+        "fix",
+        "baseline",
+        "facts",
+        "init",
+        "export-agents-md",
+        "suggest",
+        "validate-config",
+        "lsp",
+        "rules",
+    ] {
+        let (w, text) = widest(&[sub]);
+        assert!(w > 10, "`alint {sub} --help` looks truncated:\n{text}");
+        assert!(
+            w <= 60,
+            "`alint {sub} --help` has a {w}-wide line at COLUMNS=40 — a wrap_help \
+             regression would put whole option descriptions (100+ chars) on one line:\n{text}"
+        );
+    }
+}
+
 // ─── G1b — the agent format only emits commands the CLI accepts ─────
 
 /// Pull `` `alint …` `` commands out of an `agent_instruction` string:

--- a/docs/site/getting-started/quickstart.md
+++ b/docs/site/getting-started/quickstart.md
@@ -26,6 +26,31 @@ alint explain <id>    # show a rule's full, resolved definition
 alint facts           # evaluate facts against the repo — debug `when:` clauses
 ```
 
+Run `alint --help` for a one-line summary of every command, or `alint <cmd> --help` for a command's full options.
+
+## Inspecting your rules
+
+`alint list` shows the effective rules (after `extends:` and overrides), each with its kind and a marker for a conditional (`[when]`) or auto-fixable (`[fix]`) rule:
+
+```text
+error    needs-readme  file_exists [fix]
+warning  no-bak  file_absent
+```
+
+`alint explain <id>` resolves a single rule to its full definition — kind and categories, level, the `paths:` scope, any kind-specific options, the author `message:`, the `when:` clause as authored, and a one-line description of the auto-fix:
+
+```text
+id:         needs-readme
+kind:       file_exists
+categories: existence
+level:      error
+paths:      README.md
+message:    README.md must exist.
+fix:        create README.md (8 bytes)
+```
+
+Add `--format json` to either for the machine shape: `explain <id> --format json` carries `rule_kind`, `categories`, `paths`, `options`, `message`, `when`, `conditional`, `fixable`, and `fix`.
+
 ## Output formats
 
 ```bash

--- a/docs/site/integrations/github-actions.md
+++ b/docs/site/integrations/github-actions.md
@@ -50,6 +50,8 @@ Use `format: sarif` and pipe to the standard upload action:
 
 `continue-on-error: true` is what lets the SARIF upload run even when alint finds issues — without it, a non-zero exit short-circuits the upload and the findings never reach Code Scanning.
 
+alint's SARIF carries a stable [`partialFingerprints`](/docs/reference/output-formats/#stable-fingerprints) identity on every run, so Code Scanning correlates each alert across runs — deduping, and tracking a finding as fixed or reopened — with no `--baseline` needed.
+
 ## Pin to a SHA
 
 For supply-chain hygiene (and to satisfy alint's own [`ci/github-actions@v1`](/docs/bundled-rulesets/) bundled ruleset), pin the action to a commit SHA:

--- a/docs/site/reference/output-formats/index.md
+++ b/docs/site/reference/output-formats/index.md
@@ -25,11 +25,15 @@ A single `Report` fans out to each format:
 
 Each format is shown by example in the [quickstart](/docs/getting-started/quickstart/). The [`agent` format](/docs/reference/output-formats/agent/) has its own reference because its shape is purpose-built for AI coding agents.
 
+## Stable fingerprints
+
+`sarif` and `gitlab` attach a stable per-finding fingerprint (SARIF `partialFingerprints`, GitLab `fingerprint`) to **every** run — not only when a `--baseline` is active. SARIF's is the canonical `violation_fingerprint`, the same identity the [baseline](/docs/concepts/baseline/) file records, so an alert keeps one identity across SARIF and the baseline. A finding with a unique fingerprint carries that same identity in GitLab too; GitLab additionally disambiguates genuine within-report duplicates (two findings with byte-identical content), because GitLab Code Quality drops entries that share a fingerprint. GitHub Code Scanning uses the SARIF fingerprint to correlate alerts across runs — dedupe, and track a finding as fixed or reopened — with no `--baseline` required.
+
 ## Baseline suppression
 
 When a run is filtered through a [baseline](/docs/concepts/baseline/), suppression *marks* findings rather than deleting them, and only two formats surface those marks:
 
-- **`sarif`** carries `suppressions: [{ "kind": "external" }]` and `baselineState` (`unchanged` for suppressed, `new` for live) on each result, plus `partialFingerprints` — so GitHub Code Scanning keeps grandfathered alerts open-but-dismissed instead of flapping fixed-then-reopened.
+- **`sarif`** carries `suppressions: [{ "kind": "external" }]` and `baselineState` (`unchanged` for suppressed, `new` for live) on each result — so GitHub Code Scanning keeps grandfathered alerts open-but-dismissed instead of flapping fixed-then-reopened. (The stable `partialFingerprints` identity is emitted on every run, baseline or not — see above.)
 - **`json`** omits suppressed findings from `results` and records a `summary.baselined_suppressed` count in the envelope.
 
 The other six formats receive the already-filtered live report and are baseline-oblivious. The global `--show-baselined` flag lists the suppressed findings in full, in any format; the exit code is gated on the live (new) findings only, in every format.


### PR DESCRIPTION
Closes the documentation and end-to-end test gaps found in the post-v0.14.0 coverage audit (the explain arc plus the v0.14.2 features). No behavior change; output is byte-identical.

## Docs

- **[HIGH] SARIF `partialFingerprints` were documented as baseline-only** — they actually emit on **every** run. Added a "Stable fingerprints" section to the output-formats reference, moved `partialFingerprints` out of the baseline-only bullet, and noted the Code Scanning correlation benefit in the GitHub Actions integration. This was a *released* (v0.14.2) feature with actively misleading docs.
- **`explain` enriched output + `list` human shape** were CHANGELOG-only. Documented both in the quickstart with real captured output — explain: kind / categories / paths / options / message / `when:` / fix, plus the `--format json` fields; list: the kind column and `[when]`/`[fix]` markers — plus the `alint --help` / `alint <cmd> --help` split.
- **`export-agents-md` message-less scope fallback** documented in the README ("file_exists rule on README.md").

## Tests (real-binary gates in `cli_format_contract.rs`)

- `explain_surfaces_fix_for_fixable_rule` — explain's `fix:` line and json `fix`/`fixable` were asserted nowhere (every other explain gate uses a non-fixable rule).
- `export_agents_md_keeps_scope_for_messageless_rule` — the fallback had only a unit test; now driven through the binary.
- `help_wraps_to_narrow_terminal_width` — the help snapshots pin only clap's 100-col fallback, so the narrow-terminal promise (#159) was untested; `COLUMNS=40` asserts no `--help` line overflows.

## Verified (all green)

2042 workspace tests · clippy (`--workspace --all-targets -D warnings`) · `fmt --check` · rustdoc · dogfood self-check · `xtask docs-export --check` (the docs-bundle gate).

Not touched — already complete: `content_prefix_hex` (docs + e2e), and `list` / SARIF test coverage.
