### PR TITLE
ADR-0014 Phase 2: native-fires harness + migrate the 7 exec/symlink/git kinds

### DIFF
--- a/crates/alint-e2e/scenarios/check/git/changeset_requires_path_missing_fail.yml
+++ b/crates/alint-e2e/scenarios/check/git/changeset_requires_path_missing_fail.yml
@@ -1,0 +1,30 @@
+name: changeset_requires_path fires when a change ships no changeset entry
+tags: [check, changeset_requires_path]
+
+docs:
+  title: A code change with no changeset entry
+  case: fail
+  kind: changeset_requires_path
+
+given:
+  tree:
+    src:
+      lib.rs: "pub fn feature() {}\n"
+  config: |
+    version: 1
+    rules:
+      - id: needs-changeset
+        kind: changeset_requires_path
+        add_glob: ".changeset/*.md"
+        since: HEAD~1
+        level: error
+  git:
+    commits:
+      - "chore: base"
+      - { message: "feat: add feature", add: [src/lib.rs] }
+
+when: [check]
+
+expect:
+  - violations:
+      - {rule: needs-changeset, level: error}

--- a/crates/alint-e2e/scenarios/check/git/changeset_requires_path_present_pass.yml
+++ b/crates/alint-e2e/scenarios/check/git/changeset_requires_path_present_pass.yml
@@ -1,0 +1,31 @@
+name: changeset_requires_path is silent when the change includes a changeset
+tags: [check, changeset_requires_path, passing]
+
+docs:
+  title: A code change with its changeset entry
+  case: pass
+  kind: changeset_requires_path
+
+given:
+  tree:
+    src:
+      lib.rs: "pub fn feature() {}\n"
+    .changeset:
+      add-feature.md: "Added the feature.\n"
+  config: |
+    version: 1
+    rules:
+      - id: needs-changeset
+        kind: changeset_requires_path
+        add_glob: ".changeset/*.md"
+        since: HEAD~1
+        level: error
+  git:
+    commits:
+      - "chore: base"
+      - { message: "feat: add feature", add: [src/lib.rs, ".changeset/add-feature.md"] }
+
+when: [check]
+
+expect:
+  - violations: []

--- a/crates/alint-e2e/scenarios/check/git/git_blame_age_fresh_todo_pass.yml
+++ b/crates/alint-e2e/scenarios/check/git/git_blame_age_fresh_todo_pass.yml
@@ -1,0 +1,30 @@
+name: git_blame_age is silent on a freshly-committed TODO
+tags: [check, git_blame_age, passing]
+
+docs:
+  title: A freshly-added TODO
+  case: pass
+  kind: git_blame_age
+
+given:
+  tree:
+    src:
+      main.rs: "fn main() {\n    // TODO: refactor this\n}\n"
+  config: |
+    version: 1
+    rules:
+      - id: stale-todos
+        kind: git_blame_age
+        paths: "**/*.rs"
+        pattern: '\bTODO\b'
+        max_age_days: 30
+        message: "This TODO is older than 30 days; address it or remove the marker."
+        level: warning
+  git:
+    commits:
+      - { message: "add a todo", add: [src/main.rs] }
+
+when: [check]
+
+expect:
+  - violations: []

--- a/crates/alint-e2e/scenarios/check/git/git_blame_age_stale_todo_fail.yml
+++ b/crates/alint-e2e/scenarios/check/git/git_blame_age_stale_todo_fail.yml
@@ -1,0 +1,31 @@
+name: git_blame_age fires on a long-stale TODO
+tags: [check, git_blame_age]
+
+docs:
+  title: A TODO comment that has gone stale
+  case: fail
+  kind: git_blame_age
+
+given:
+  tree:
+    src:
+      main.rs: "fn main() {\n    // TODO: refactor this\n}\n"
+  config: |
+    version: 1
+    rules:
+      - id: stale-todos
+        kind: git_blame_age
+        paths: "**/*.rs"
+        pattern: '\bTODO\b'
+        max_age_days: 30
+        message: "This TODO is older than 30 days; address it or remove the marker."
+        level: warning
+  git:
+    commits:
+      - { message: "add a todo", add: [src/main.rs], date: "2000-01-01T00:00:00" }
+
+when: [check]
+
+expect:
+  - violations:
+      - {rule: stale-todos, level: warning}

--- a/crates/alint-e2e/scenarios/check/git/git_commit_message_convention_fail.yml
+++ b/crates/alint-e2e/scenarios/check/git/git_commit_message_convention_fail.yml
@@ -1,0 +1,27 @@
+name: git_commit_message fires when HEAD's subject breaks the convention
+tags: [check, git_commit_message]
+
+docs:
+  title: A commit with a non-conventional subject
+  case: fail
+  kind: git_commit_message
+
+given:
+  tree:
+    README.md: "# demo\n"
+  config: |
+    version: 1
+    rules:
+      - id: conventional-commits
+        kind: git_commit_message
+        pattern: '^(feat|fix|chore): '
+        level: error
+  git:
+    commits:
+      - { message: "wip nonsense", add: [README.md] }
+
+when: [check]
+
+expect:
+  - violations:
+      - {rule: conventional-commits, level: error}

--- a/crates/alint-e2e/scenarios/check/git/git_commit_message_convention_pass.yml
+++ b/crates/alint-e2e/scenarios/check/git/git_commit_message_convention_pass.yml
@@ -1,0 +1,26 @@
+name: git_commit_message is silent when HEAD follows the convention
+tags: [check, git_commit_message, passing]
+
+docs:
+  title: A commit that follows the convention
+  case: pass
+  kind: git_commit_message
+
+given:
+  tree:
+    README.md: "# demo\n"
+  config: |
+    version: 1
+    rules:
+      - id: conventional-commits
+        kind: git_commit_message
+        pattern: '^(feat|fix|chore): '
+        level: error
+  git:
+    commits:
+      - { message: "feat: add the readme", add: [README.md] }
+
+when: [check]
+
+expect:
+  - violations: []

--- a/crates/alint-e2e/scenarios/check/git/pair_changed_together_missing_fail.yml
+++ b/crates/alint-e2e/scenarios/check/git/pair_changed_together_missing_fail.yml
@@ -1,0 +1,31 @@
+name: pair_changed_together fires when the paired file is not updated
+tags: [check, pair_changed_together]
+
+docs:
+  title: A format change without the version bump
+  case: fail
+  kind: pair_changed_together
+
+given:
+  tree:
+    src:
+      format.rs: "pub struct Format;\n"
+  config: |
+    version: 1
+    rules:
+      - id: format-version
+        kind: pair_changed_together
+        if_changed: "src/format.rs"
+        then_changed: "FORMAT_VERSION"
+        since: HEAD~1
+        level: error
+  git:
+    commits:
+      - "chore: base"
+      - { message: "change the format struct", add: [src/format.rs] }
+
+when: [check]
+
+expect:
+  - violations:
+      - {rule: format-version, level: error}

--- a/crates/alint-e2e/scenarios/check/git/pair_changed_together_present_pass.yml
+++ b/crates/alint-e2e/scenarios/check/git/pair_changed_together_present_pass.yml
@@ -1,0 +1,31 @@
+name: pair_changed_together is silent when both files change together
+tags: [check, pair_changed_together, passing]
+
+docs:
+  title: A format change with the version bump
+  case: pass
+  kind: pair_changed_together
+
+given:
+  tree:
+    src:
+      format.rs: "pub struct Format;\n"
+    FORMAT_VERSION: "2\n"
+  config: |
+    version: 1
+    rules:
+      - id: format-version
+        kind: pair_changed_together
+        if_changed: "src/format.rs"
+        then_changed: "FORMAT_VERSION"
+        since: HEAD~1
+        level: error
+  git:
+    commits:
+      - "chore: base"
+      - { message: "change the format struct and bump the version", add: [src/format.rs, FORMAT_VERSION] }
+
+when: [check]
+
+expect:
+  - violations: []

--- a/crates/alint-e2e/scenarios/check/unix_metadata/executable_bit_fail.yml
+++ b/crates/alint-e2e/scenarios/check/unix_metadata/executable_bit_fail.yml
@@ -1,0 +1,27 @@
+name: executable_bit fires on a committed +x file that should not be
+tags: [check, executable_bit, unix_metadata, unix-only]
+
+docs:
+  title: A docs file that is unexpectedly executable
+  case: fail
+  kind: executable_bit
+
+given:
+  tree:
+    README.md: "# demo"
+    docs:
+      generate.sh: { "$exec": "echo generated\n" }
+  config: |
+    version: 1
+    rules:
+      - id: docs-not-exec
+        kind: executable_bit
+        paths: "docs/**"
+        level: error
+        require: false
+
+when: [check]
+
+expect:
+  - violations:
+      - {rule: docs-not-exec, level: error, path: docs/generate.sh}

--- a/crates/alint-e2e/scenarios/check/unix_metadata/executable_bit_pass.yml
+++ b/crates/alint-e2e/scenarios/check/unix_metadata/executable_bit_pass.yml
@@ -1,6 +1,11 @@
 name: executable_bit is silent when require=false matches the default mode
 tags: [check, executable_bit, unix_metadata, passing]
 
+docs:
+  title: Docs files that are not executable
+  case: pass
+  kind: executable_bit
+
 # Tree-spec files are created with umask defaults (no +x), so
 # require=false passes trivially on Unix and is a no-op elsewhere.
 # The require=true fail case lives in tests/unix_metadata.rs.

--- a/crates/alint-e2e/scenarios/check/unix_metadata/executable_has_shebang_fail.yml
+++ b/crates/alint-e2e/scenarios/check/unix_metadata/executable_has_shebang_fail.yml
@@ -1,0 +1,26 @@
+name: executable_has_shebang fires on an executable file with no shebang
+tags: [check, executable_has_shebang, unix_metadata, unix-only]
+
+docs:
+  title: An executable script missing its shebang
+  case: fail
+  kind: executable_has_shebang
+
+given:
+  tree:
+    README.md: "# demo"
+    scripts:
+      run: { "$exec": "echo hi\n" }
+  config: |
+    version: 1
+    rules:
+      - id: exec-shebang
+        kind: executable_has_shebang
+        paths: "scripts/**"
+        level: error
+
+when: [check]
+
+expect:
+  - violations:
+      - {rule: exec-shebang, level: error, path: scripts/run}

--- a/crates/alint-e2e/scenarios/check/unix_metadata/executable_has_shebang_pass.yml
+++ b/crates/alint-e2e/scenarios/check/unix_metadata/executable_has_shebang_pass.yml
@@ -1,21 +1,16 @@
-name: executable_has_shebang is silent when no file carries the +x bit
-tags: [check, executable_has_shebang, unix_metadata, passing]
+name: executable_has_shebang is silent when the executable carries a shebang
+tags: [check, executable_has_shebang, unix_metadata, unix-only, passing]
 
 docs:
-  title: No executable scripts, so nothing to require a shebang
+  title: An executable script that has its shebang
   case: pass
   kind: executable_has_shebang
 
-# The testkit writes tree files via std::fs::write, which never sets
-# the +x bit. `executable_has_shebang` only checks +x files, so this
-# scenario is vacuously passing — the +x-ing-matters paths live in
-# the native Rust integration tests under tests/unix_metadata.rs.
 given:
   tree:
     README.md: "# demo"
     scripts:
-      hello.sh: "echo hi\n"
-      broken.sh: "no shebang here\n"
+      hello.sh: { "$exec": "#!/bin/sh\necho hi\n" }
   config: |
     version: 1
     rules:

--- a/crates/alint-e2e/scenarios/check/unix_metadata/executable_has_shebang_pass.yml
+++ b/crates/alint-e2e/scenarios/check/unix_metadata/executable_has_shebang_pass.yml
@@ -1,6 +1,11 @@
 name: executable_has_shebang is silent when no file carries the +x bit
 tags: [check, executable_has_shebang, unix_metadata, passing]
 
+docs:
+  title: No executable scripts, so nothing to require a shebang
+  case: pass
+  kind: executable_has_shebang
+
 # The testkit writes tree files via std::fs::write, which never sets
 # the +x bit. `executable_has_shebang` only checks +x files, so this
 # scenario is vacuously passing — the +x-ing-matters paths live in

--- a/crates/alint-e2e/scenarios/check/unix_metadata/no_symlinks_fail.yml
+++ b/crates/alint-e2e/scenarios/check/unix_metadata/no_symlinks_fail.yml
@@ -1,0 +1,27 @@
+name: no_symlinks fires on a committed symbolic link
+tags: [check, no_symlinks, unix_metadata, unix-only]
+
+docs:
+  title: A repository containing a symlink
+  case: fail
+  kind: no_symlinks
+
+given:
+  tree:
+    README.md: "# demo"
+    src:
+      main.rs: "fn main() {}\n"
+    latest.rs: { "$symlink": "src/main.rs" }
+  config: |
+    version: 1
+    rules:
+      - id: no-links
+        kind: no_symlinks
+        paths: "**"
+        level: error
+
+when: [check]
+
+expect:
+  - violations:
+      - {rule: no-links, level: error, path: latest.rs}

--- a/crates/alint-e2e/scenarios/check/unix_metadata/no_symlinks_pass.yml
+++ b/crates/alint-e2e/scenarios/check/unix_metadata/no_symlinks_pass.yml
@@ -1,6 +1,11 @@
 name: no_symlinks is silent on regular files
 tags: [check, no_symlinks, unix_metadata, passing]
 
+docs:
+  title: A repository with no symlinks
+  case: pass
+  kind: no_symlinks
+
 given:
   tree:
     README.md: "# demo"

--- a/crates/alint-e2e/tests/coverage_audit_pass_fail.rs
+++ b/crates/alint-e2e/tests/coverage_audit_pass_fail.rs
@@ -121,35 +121,22 @@ fn walkdir(root: &Path) -> Vec<std::path::PathBuf> {
     out
 }
 
-/// Rule kinds whose firing case can't be expressed in the
-/// scenario YAML format because the testkit doesn't yet
-/// materialise the required filesystem primitive. Each entry
-/// must point at a native Rust integration test that DOES
-/// cover the firing case.
-///
-/// These should shrink to zero as the testkit grows
-/// `mode: 0o755`, `symlink_to: <path>`, custom commit
-/// messages, and `GIT_AUTHOR_DATE` overrides — at which point
-/// the YAML coverage becomes feasible and the entry is
-/// removed.
-const NATIVE_FIRES_ALLOWLIST: &[(&str, &str)] = &[
-    (
-        "git_blame_age",
-        "crates/alint-rules/tests/git_blame_age.rs (testkit runner doesn't backdate commits via GIT_AUTHOR_DATE)",
-    ),
-    (
-        "git_commit_message",
-        "crates/alint-rules/tests/shell_out_rules.rs (testkit runner uses a fixed commit message)",
-    ),
-    (
-        "changeset_requires_path",
-        "crates/alint-rules/tests/shell_out_rules.rs (testkit `git: {commits}` makes empty commits; an added-file diff can't be expressed)",
-    ),
-    (
-        "pair_changed_together",
-        "crates/alint-rules/tests/shell_out_rules.rs (testkit `git: {commits}` makes empty commits; a real two-commit co-change diff can't be expressed)",
-    ),
-];
+/// Rule kinds whose firing case can't be expressed in scenario YAML. Now
+/// EMPTY: Phase 2 (ADR-0014) grew the testkit's `$exec`/`$symlink` tree nodes
+/// and the git commits DSL (custom messages, `GIT_AUTHOR_DATE`, staged file
+/// deltas), so every registered kind now fires in a YAML scenario. Kept as a
+/// tripwire - `native_fires_allowlist_is_empty` fails if a future kind re-adds
+/// an exemption, forcing the "can this fire in YAML?" question first.
+const NATIVE_FIRES_ALLOWLIST: &[(&str, &str)] = &[];
+
+#[test]
+fn native_fires_allowlist_is_empty() {
+    assert!(
+        NATIVE_FIRES_ALLOWLIST.is_empty(),
+        "the native-fires allowlist should stay empty (Phase 2 zeroed it); a new \
+         entry means a kind cannot express firing in YAML - reconsider before re-adding"
+    );
+}
 
 /// Same alias map as `coverage_audit.rs`. Normalise before
 /// recording status so a single scenario using either form

--- a/crates/alint-e2e/tests/coverage_audit_pass_fail.rs
+++ b/crates/alint-e2e/tests/coverage_audit_pass_fail.rs
@@ -134,18 +134,6 @@ fn walkdir(root: &Path) -> Vec<std::path::PathBuf> {
 /// removed.
 const NATIVE_FIRES_ALLOWLIST: &[(&str, &str)] = &[
     (
-        "executable_bit",
-        "crates/alint-e2e/tests/unix_metadata.rs (testkit can't write +x bits)",
-    ),
-    (
-        "executable_has_shebang",
-        "crates/alint-e2e/tests/unix_metadata.rs (testkit can't write +x bits)",
-    ),
-    (
-        "no_symlinks",
-        "crates/alint-e2e/tests/unix_metadata.rs (testkit can't materialise symlinks)",
-    ),
-    (
         "git_blame_age",
         "crates/alint-rules/tests/git_blame_age.rs (testkit runner doesn't backdate commits via GIT_AUTHOR_DATE)",
     ),

--- a/crates/alint-testkit/src/lib.rs
+++ b/crates/alint-testkit/src/lib.rs
@@ -19,7 +19,7 @@ pub mod strategies;
 pub mod treespec;
 
 pub use error::{Error, Result};
-pub use runner::{ScenarioRun, StepOutcome, assert_scenario, run_scenario};
+pub use runner::{ScenarioRun, StepOutcome, assert_scenario, run_scenario, setup_git};
 pub use scenario::{
     CommitSpec, DetailedCommit, DocsCase, DocsExample, ExpectStep, ExpectTreeMode, ExpectViolation,
     Given, GivenGit, LevelName, Scenario, Step,

--- a/crates/alint-testkit/src/lib.rs
+++ b/crates/alint-testkit/src/lib.rs
@@ -21,8 +21,8 @@ pub mod treespec;
 pub use error::{Error, Result};
 pub use runner::{ScenarioRun, StepOutcome, assert_scenario, run_scenario};
 pub use scenario::{
-    DocsCase, DocsExample, ExpectStep, ExpectTreeMode, ExpectViolation, Given, LevelName, Scenario,
-    Step,
+    CommitSpec, DetailedCommit, DocsCase, DocsExample, ExpectStep, ExpectTreeMode, ExpectViolation,
+    Given, GivenGit, LevelName, Scenario, Step,
 };
 pub use treespec::{
     Discrepancy, ExecNode, ExtractOpts, SymlinkNode, TreeNode, TreeSpec, VerifyMode, VerifyReport,

--- a/crates/alint-testkit/src/lib.rs
+++ b/crates/alint-testkit/src/lib.rs
@@ -25,6 +25,6 @@ pub use scenario::{
     Step,
 };
 pub use treespec::{
-    Discrepancy, ExtractOpts, TreeNode, TreeSpec, VerifyMode, VerifyReport, extract, materialize,
-    verify,
+    Discrepancy, ExecNode, ExtractOpts, SymlinkNode, TreeNode, TreeSpec, VerifyMode, VerifyReport,
+    extract, materialize, verify,
 };

--- a/crates/alint-testkit/src/runner.rs
+++ b/crates/alint-testkit/src/runner.rs
@@ -9,7 +9,7 @@ use alint_core::{Engine, FixReport, FixStatus, Level, Report, RuleEntry, WalkOpt
 use tempfile::TempDir;
 
 use crate::error::{Error, Result};
-use crate::scenario::{ExpectStep, GivenGit, Scenario, Step};
+use crate::scenario::{CommitSpec, ExpectStep, GivenGit, Scenario, Step};
 use crate::treespec::{VerifyReport, materialize, verify};
 
 /// Concrete outcome of one step. The runner collects these in order;
@@ -110,21 +110,8 @@ fn init_git_for_scenario(root: &Path, spec: &GivenGit) -> Result<()> {
                     .to_string(),
             ));
         }
-        for subject in &spec.commits {
-            git(
-                root,
-                &[
-                    "-c",
-                    "user.name=alint scenario",
-                    "-c",
-                    "user.email=scenario@alint.test",
-                    "commit",
-                    "-q",
-                    "--allow-empty",
-                    "-m",
-                    subject,
-                ],
-            )?;
+        for commit in &spec.commits {
+            commit_one(root, commit)?;
         }
         return Ok(());
     }
@@ -149,16 +136,56 @@ fn init_git_for_scenario(root: &Path, spec: &GivenGit) -> Result<()> {
     Ok(())
 }
 
+/// Apply one `commits:` entry. A bare subject is an empty commit; a detailed
+/// entry stages its `add` paths (or `--allow-empty` when it stages none),
+/// commits with the given message, and backdates when `date` is set.
+fn commit_one(root: &Path, commit: &CommitSpec) -> Result<()> {
+    let (message, add, date): (&str, &[String], Option<&str>) = match commit {
+        CommitSpec::Subject(subject) => (subject.as_str(), &[], None),
+        CommitSpec::Detailed(d) => (d.message.as_str(), d.add.as_slice(), d.date.as_deref()),
+    };
+    if !add.is_empty() {
+        let mut args: Vec<&str> = vec!["add", "--"];
+        args.extend(add.iter().map(String::as_str));
+        git(root, &args)?;
+    }
+    let mut args: Vec<&str> = vec![
+        "-c",
+        "user.name=alint scenario",
+        "-c",
+        "user.email=scenario@alint.test",
+        "commit",
+        "-q",
+    ];
+    if add.is_empty() {
+        args.push("--allow-empty");
+    }
+    args.push("-m");
+    args.push(message);
+    match date {
+        Some(date) => git_env(
+            root,
+            &args,
+            &[("GIT_AUTHOR_DATE", date), ("GIT_COMMITTER_DATE", date)],
+        ),
+        None => git(root, &args),
+    }
+}
+
 fn git(root: &Path, args: &[&str]) -> Result<()> {
-    let out = Command::new("git")
-        .arg("-C")
-        .arg(root)
-        .args(args)
-        .output()
-        .map_err(|source| Error::Io {
-            path: root.to_path_buf(),
-            source,
-        })?;
+    git_env(root, args, &[])
+}
+
+fn git_env(root: &Path, args: &[&str], envs: &[(&str, &str)]) -> Result<()> {
+    let mut cmd = Command::new("git");
+    cmd.arg("-C").arg(root).args(args);
+    for (key, val) in envs {
+        cmd.env(key, val);
+    }
+    let out = cmd.output().map_err(|source| Error::Io {
+        path: root.to_path_buf(),
+        source,
+    })?;
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);
         return Err(Error::scenario(format!(

--- a/crates/alint-testkit/src/runner.rs
+++ b/crates/alint-testkit/src/runner.rs
@@ -52,7 +52,7 @@ pub fn run_scenario(scenario: &Scenario) -> Result<ScenarioRun> {
     })?;
 
     if let Some(git_spec) = &scenario.given.git {
-        init_git_for_scenario(&root, git_spec)?;
+        setup_git(&root, git_spec)?;
     }
 
     let mut steps = Vec::with_capacity(scenario.when.len());
@@ -68,17 +68,17 @@ pub fn run_scenario(scenario: &Scenario) -> Result<ScenarioRun> {
     })
 }
 
-/// Run the scenario's `given.git:` setup against the tempdir.
-/// Each git invocation is shelled out via the `git` on PATH;
-/// scenarios in environments without git skip the setup with a
-/// clear error rather than silently producing a non-git tempdir.
+/// Run a scenario's `given.git:` setup against a materialised tempdir:
+/// `git init`, optional `git add`/`add -f`, and the commit chain. Public so
+/// docs-export can drive git for a documented git-rule example (ADR-0014).
+/// Each git invocation is shelled out via the `git` on PATH.
 ///
 /// The runner sets minimal user.name / user.email config so
 /// `git commit` doesn't fail in CI environments whose default
 /// identity isn't configured. Both values are scoped to the
 /// scenario tempdir (`-c user.…=`) and don't touch the host's
 /// global config.
-fn init_git_for_scenario(root: &Path, spec: &GivenGit) -> Result<()> {
+pub fn setup_git(root: &Path, spec: &GivenGit) -> Result<()> {
     if !spec.init {
         return Ok(());
     }

--- a/crates/alint-testkit/src/scenario.rs
+++ b/crates/alint-testkit/src/scenario.rs
@@ -142,15 +142,41 @@ pub struct GivenGit {
     /// "fully checked-in repo."
     #[serde(default = "default_true")]
     pub commit: bool,
-    /// Make a chain of empty commits, oldest first. Each entry is
-    /// the subject line of one commit; the runner uses
-    /// `git commit --allow-empty -m <subject>` for every entry so
-    /// no working-tree file is required. Mutually exclusive with
-    /// `add:`/`commit:` (which write one mass commit of the
-    /// staged files). Used to fixture multi-commit shapes the
-    /// `git_commit_message` rule's `since:` mode needs to walk.
+    /// Make a chain of commits, oldest first. Each entry is either a bare
+    /// subject string (an empty commit with that subject) or a detailed
+    /// `{ message, add, date }` mapping that stages the listed paths and can
+    /// backdate the commit. Mutually exclusive with the top-level
+    /// `add:`/`commit:` path (which writes one mass commit of the staged
+    /// files). Used to fixture multi-commit shapes and the real file-delta
+    /// history the git rules inspect.
     #[serde(default)]
-    pub commits: Vec<String>,
+    pub commits: Vec<CommitSpec>,
+}
+
+/// One entry in `git.commits`: either a bare subject (an empty commit) or a
+/// detailed commit that stages files, sets a message, and optionally backdates.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum CommitSpec {
+    /// An empty commit with this subject line.
+    Subject(String),
+    /// A commit that stages `add` paths (empty -> `--allow-empty`), uses a
+    /// custom `message`, and optionally backdates via `date`.
+    Detailed(DetailedCommit),
+}
+
+/// The detailed form of a [`CommitSpec`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DetailedCommit {
+    /// Commit message (subject).
+    pub message: String,
+    /// Paths to `git add` before committing. Empty commits with `--allow-empty`.
+    #[serde(default)]
+    pub add: Vec<String>,
+    /// Sets `GIT_AUTHOR_DATE` + `GIT_COMMITTER_DATE`, e.g. `2000-01-01T00:00:00`.
+    #[serde(default)]
+    pub date: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -378,6 +404,31 @@ given:
                 "omitting `{}` should fail to parse",
                 line.trim()
             );
+        }
+    }
+
+    #[test]
+    fn parses_commit_spec_forms() {
+        let src = r#"
+name: x
+given:
+  tree: {}
+  config: "version: 1\nrules: []\n"
+  git:
+    commits:
+      - "bare subject"
+      - { message: "detailed", add: ["a.txt"], date: "2000-01-01T00:00:00" }
+"#;
+        let s = Scenario::from_yaml(src).unwrap();
+        let commits = &s.given.git.unwrap().commits;
+        assert!(matches!(commits[0], CommitSpec::Subject(_)));
+        match &commits[1] {
+            CommitSpec::Detailed(d) => {
+                assert_eq!(d.message, "detailed");
+                assert_eq!(d.add, vec!["a.txt"]);
+                assert_eq!(d.date.as_deref(), Some("2000-01-01T00:00:00"));
+            }
+            CommitSpec::Subject(_) => panic!("expected Detailed"),
         }
     }
 }

--- a/crates/alint-testkit/src/treespec/materialize.rs
+++ b/crates/alint-testkit/src/treespec/materialize.rs
@@ -45,8 +45,9 @@ fn write_map(children: &std::collections::BTreeMap<String, TreeNode>, parent: &P
                 })?;
                 // The executable bit is the only mode any consuming rule checks;
                 // it is a Unix concept, so the chmod is Unix-only. The node still
-                // materialises its content on other targets (the firing scenarios
-                // are `unix-only`-tagged and skipped there anyway).
+                // materialises its content on other targets. The exec/symlink
+                // firing scenarios are `unix-only`-tagged: scenarios.rs skips them
+                // off Unix, and docs-export renders only on its Linux host.
                 #[cfg(unix)]
                 {
                     use std::os::unix::fs::PermissionsExt;

--- a/crates/alint-testkit/src/treespec/materialize.rs
+++ b/crates/alint-testkit/src/treespec/materialize.rs
@@ -32,6 +32,50 @@ fn write_map(children: &std::collections::BTreeMap<String, TreeNode>, parent: &P
                     source,
                 })?;
             }
+            TreeNode::Exec(exec) => {
+                if let Some(pp) = path.parent() {
+                    std::fs::create_dir_all(pp).map_err(|source| Error::Io {
+                        path: pp.to_path_buf(),
+                        source,
+                    })?;
+                }
+                std::fs::write(&path, &exec.content).map_err(|source| Error::Io {
+                    path: path.clone(),
+                    source,
+                })?;
+                // The executable bit is the only mode any consuming rule checks;
+                // it is a Unix concept, so the chmod is Unix-only. The node still
+                // materialises its content on other targets (the firing scenarios
+                // are `unix-only`-tagged and skipped there anyway).
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+                        .map_err(|source| Error::Io {
+                            path: path.clone(),
+                            source,
+                        })?;
+                }
+            }
+            TreeNode::Symlink(link) => {
+                if let Some(pp) = path.parent() {
+                    std::fs::create_dir_all(pp).map_err(|source| Error::Io {
+                        path: pp.to_path_buf(),
+                        source,
+                    })?;
+                }
+                #[cfg(unix)]
+                std::os::unix::fs::symlink(&link.target, &path).map_err(|source| Error::Io {
+                    path: path.clone(),
+                    source,
+                })?;
+                #[cfg(not(unix))]
+                return Err(Error::scenario(format!(
+                    "cannot materialise symlink {} -> {}: symlinks are unix-only",
+                    path.display(),
+                    link.target
+                )));
+            }
             TreeNode::Dir(sub) => {
                 std::fs::create_dir_all(&path).map_err(|source| Error::Io {
                     path: path.clone(),
@@ -119,5 +163,28 @@ empty: {}
         let spec = TreeSpec::from_yaml(r#"a.txt: "x""#).unwrap();
         let err = materialize(&spec, &bogus).unwrap_err();
         assert!(matches!(err, Error::NotADirectory(_)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn materialises_executable_bit_and_symlink() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        let spec = TreeSpec::from_yaml(
+            "hook.sh: { \"$exec\": \"#!/bin/sh\\n\" }\nlatest: { \"$symlink\": \"hook.sh\" }\n",
+        )
+        .unwrap();
+        materialize(&spec, tmp.path()).unwrap();
+        let mode = std::fs::metadata(tmp.path().join("hook.sh"))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o111, 0o111, "executable bit must be set");
+        let link = std::fs::symlink_metadata(tmp.path().join("latest")).unwrap();
+        assert!(link.file_type().is_symlink(), "latest must be a symlink");
+        assert_eq!(
+            std::fs::read_link(tmp.path().join("latest")).unwrap(),
+            std::path::Path::new("hook.sh")
+        );
     }
 }

--- a/crates/alint-testkit/src/treespec/mod.rs
+++ b/crates/alint-testkit/src/treespec/mod.rs
@@ -10,5 +10,5 @@ mod verify;
 
 pub use extract::{ExtractOpts, extract};
 pub use materialize::materialize;
-pub use spec::{TreeNode, TreeSpec, TreeSpecIter};
+pub use spec::{ExecNode, SymlinkNode, TreeNode, TreeSpec, TreeSpecIter};
 pub use verify::{Discrepancy, VerifyMode, VerifyReport, verify};

--- a/crates/alint-testkit/src/treespec/spec.rs
+++ b/crates/alint-testkit/src/treespec/spec.rs
@@ -18,7 +18,30 @@ use serde::{Deserialize, Serialize};
 #[serde(untagged)]
 pub enum TreeNode {
     File(String),
+    Exec(ExecNode),
+    Symlink(SymlinkNode),
     Dir(BTreeMap<String, TreeNode>),
+}
+
+/// An executable (`0755`) regular file, written as a reserved-key mapping:
+/// `{ "$exec": "content" }`. Serde tries this before [`TreeNode::Dir`], so a
+/// mapping carrying `$exec` is always this node - `$exec` is therefore a
+/// reserved filename (a fixture cannot materialise a literal file named
+/// `$exec`; nothing needs to).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecNode {
+    #[serde(rename = "$exec")]
+    pub content: String,
+}
+
+/// A symbolic link, written as a reserved-key mapping: `{ "$symlink": "target" }`.
+/// `$symlink` is a reserved filename like `$exec`. Unix-only to materialise.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SymlinkNode {
+    #[serde(rename = "$symlink")]
+    pub target: String,
 }
 
 impl TreeNode {
@@ -28,6 +51,14 @@ impl TreeNode {
 
     pub fn is_dir(&self) -> bool {
         matches!(self, TreeNode::Dir(_))
+    }
+
+    pub fn is_exec(&self) -> bool {
+        matches!(self, TreeNode::Exec(_))
+    }
+
+    pub fn is_symlink(&self) -> bool {
+        matches!(self, TreeNode::Symlink(_))
     }
 }
 
@@ -169,5 +200,24 @@ z.txt: "y"
         let yaml = spec.to_yaml().unwrap();
         let re = TreeSpec::from_yaml(&yaml).unwrap();
         assert_eq!(spec, re);
+    }
+
+    #[test]
+    fn parses_and_roundtrips_exec_and_symlink() {
+        let src = r##"
+hook.sh: { "$exec": "#!/bin/sh\necho hi\n" }
+latest: { "$symlink": "releases/v2" }
+plain.txt: "regular"
+src:
+  main.rs: "fn main() {}"
+"##;
+        let spec = TreeSpec::from_yaml(src).unwrap();
+        assert!(spec.root["hook.sh"].is_exec());
+        assert!(spec.root["latest"].is_symlink());
+        assert!(spec.root["plain.txt"].is_file());
+        assert!(spec.root["src"].is_dir());
+        // The reserved-key nodes serialize back to the same mappings.
+        let yaml = spec.to_yaml().unwrap();
+        assert_eq!(TreeSpec::from_yaml(&yaml).unwrap(), spec);
     }
 }

--- a/crates/alint-testkit/src/treespec/verify.rs
+++ b/crates/alint-testkit/src/treespec/verify.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-use super::spec::{TreeNode, TreeSpec};
+use super::spec::{ExecNode, SymlinkNode, TreeNode, TreeSpec};
 use crate::error::{Error, Result};
 
 /// Strictness of the tree comparison.
@@ -127,6 +127,20 @@ fn visit_spec(
         };
         seen.insert(rel.clone());
         let abs = root.join(&rel);
+        // Symlink/Exec need lstat-style checks: the `exists()`/`is_file()` in the
+        // match below FOLLOW symlinks (a valid dangling link would read as
+        // Missing) and ignore the mode. Handle them first.
+        match node {
+            TreeNode::Symlink(want) => {
+                verify_symlink(&abs, want, rel, report);
+                continue;
+            }
+            TreeNode::Exec(want) => {
+                verify_exec(&abs, want, rel, report)?;
+                continue;
+            }
+            _ => {}
+        }
         match (node, abs.is_dir(), abs.is_file(), abs.exists()) {
             (_, _, _, false) => {
                 report
@@ -164,6 +178,78 @@ fn visit_spec(
                 });
             }
             _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Verify a `$symlink` node with an lstat (don't follow the link), so a valid
+/// dangling symlink isn't reported `Missing`.
+fn verify_symlink(abs: &Path, want: &SymlinkNode, rel: String, report: &mut VerifyReport) {
+    match std::fs::symlink_metadata(abs) {
+        Err(_) => report
+            .discrepancies
+            .push(Discrepancy::Missing { path: rel }),
+        Ok(meta) if !meta.file_type().is_symlink() => {
+            report.discrepancies.push(Discrepancy::Kind {
+                path: rel,
+                expected: "symlink",
+                actual: if meta.is_dir() { "dir" } else { "file" },
+            });
+        }
+        Ok(_) => {
+            let got = std::fs::read_link(abs)
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            if got != want.target {
+                report.discrepancies.push(Discrepancy::Content {
+                    path: rel,
+                    expected: want.target.clone(),
+                    actual: got,
+                });
+            }
+        }
+    }
+}
+
+/// Verify a `$exec` node: a regular file with matching content and, on Unix,
+/// the executable bit set.
+fn verify_exec(abs: &Path, want: &ExecNode, rel: String, report: &mut VerifyReport) -> Result<()> {
+    if abs.is_dir() {
+        report.discrepancies.push(Discrepancy::Kind {
+            path: rel,
+            expected: "file",
+            actual: "dir",
+        });
+        return Ok(());
+    }
+    if !abs.is_file() {
+        report
+            .discrepancies
+            .push(Discrepancy::Missing { path: rel });
+        return Ok(());
+    }
+    let got = std::fs::read_to_string(abs).map_err(|source| Error::Io {
+        path: abs.to_path_buf(),
+        source,
+    })?;
+    if got != want.content {
+        report.discrepancies.push(Discrepancy::Content {
+            path: rel.clone(),
+            expected: want.content.clone(),
+            actual: got,
+        });
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let executable = std::fs::metadata(abs).is_ok_and(|m| m.permissions().mode() & 0o111 != 0);
+        if !executable {
+            report.discrepancies.push(Discrepancy::Kind {
+                path: rel,
+                expected: "executable file",
+                actual: "non-executable file",
+            });
         }
     }
     Ok(())
@@ -217,6 +303,34 @@ mod tests {
 
     fn spec(src: &str) -> TreeSpec {
         TreeSpec::from_yaml(src).unwrap()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn verifies_exec_and_symlink_nodes() {
+        let tmp = TempDir::new().unwrap();
+        let s = spec(
+            "hook.sh: { \"$exec\": \"#!/bin/sh\\n\" }\n\
+             latest: { \"$symlink\": \"hook.sh\" }\n\
+             dangling: { \"$symlink\": \"does/not/exist\" }\n",
+        );
+        materialize(&s, tmp.path()).unwrap();
+        // exec content+bit, a valid symlink, AND a dangling symlink all verify
+        // clean - the dangling link must not read as `Missing`.
+        assert!(
+            verify(&s, tmp.path(), VerifyMode::Strict)
+                .unwrap()
+                .is_match(),
+            "exec + symlinks (incl. dangling) should verify clean"
+        );
+        // A wrong symlink target is flagged, not silently passed.
+        let wrong = spec("latest: { \"$symlink\": \"wrong-target\" }\n");
+        assert!(
+            !verify(&wrong, tmp.path(), VerifyMode::Contains)
+                .unwrap()
+                .is_match(),
+            "a wrong symlink target must be flagged"
+        );
     }
 
     #[test]

--- a/docs/design/v0.15/documented-example-fixtures.md
+++ b/docs/design/v0.15/documented-example-fixtures.md
@@ -269,10 +269,14 @@ For a documented (migrated) kind it additionally asserts:
   `fail` must assert a violation and produce non-empty output, a `pass` must exit
   clean and assert none - so a mislabeled case can't ship.
 - **Shape.** A documented scenario is a single `check` step (`when: [check]`, so
-  the asserted `expect:` matches the rendered run) with no `given.git` block (the
-  render doesn't drive git yet - Phase 2). A documented kind's `docs/rules.md` H3
-  must also carry **no hand-written** ```` ```yaml ```` block, or the page would
-  double-render the generated example alongside a stale hand-written one.
+  the asserted `expect:` matches the rendered run). A git-rule example may carry a
+  `given.git` block - docs-export drives it (Phase 2 shipped the git harness:
+  `$exec`/`$symlink` tree nodes and the `commits` DSL, zeroing
+  `NATIVE_FIRES_ALLOWLIST`). A documented kind's `docs/rules.md` H3 must also carry
+  **no hand-written config** ```` ```yaml ```` block (one whose `kind:` is the
+  documented kind - a non-config yaml like a CI-workflow recipe is fine), or the
+  page would double-render the generated example alongside a stale hand-written
+  one.
 - **Config fidelity.** The config rendered on the page is byte-for-byte the
   scenario's `given.config`.
 - **Hermeticity.** `given.config` (including any transitively resolved `extends:`)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -826,25 +826,6 @@ Two modes, selected by the optional `since:` field:
 - **HEAD-only** (default, `since:` omitted): validate the tip commit. Right shape for push-trigger CI and post-commit hooks.
 - **Range** (`since:` set): validate every commit reachable from HEAD but not from `since`. Right shape for `pull_request`-trigger CI, where `actions/checkout` checks out a synthetic merge commit whose subject the rule would always flag.
 
-```yaml
-# HEAD-only. The tip commit must follow Conventional Commits and be <= 72 chars.
-- id: conventional-commit
-  kind: git_commit_message
-  pattern: '^(feat|fix|chore|docs|refactor|test)(\([a-z-]+\))?: '
-  subject_max_length: 72
-  level: warning
-
-# Range mode for PR CI. `ALINT_BASE_SHA` is exported in the workflow from
-# `github.event.pull_request.base.sha`; on push-trigger or local runs where
-# the env var is unset, falls back to `origin/main`.
-- id: pr-conventional-commits
-  kind: git_commit_message
-  pattern: '^(feat|fix|chore|docs|refactor|test|build|ci|perf|style|revert)(\(.+\))?!?: '
-  subject_max_length: 72
-  since: ${ALINT_BASE_SHA:-origin/main}
-  level: error
-```
-
 #### `since:` semantics
 
 `since:` accepts anything `git rev-parse` resolves: a 40-char or abbreviated SHA, a branch (`origin/main`), a tag (`v1.2.3`), or a relative ref (`HEAD~5`). The rule walks `<since>..HEAD` oldest-first, validates each commit, and emits one violation per failing commit with the short SHA + a subject snippet so you know which to amend.
@@ -980,22 +961,6 @@ The rule reflects git's own verdict and deliberately does **not** distinguish "u
 
 Fire on lines matching a regex whose `git blame` author-time is older than `max_age_days`. Same regex match shape as `file_content_forbidden`, but with a per-line age gate: a TODO added yesterday passes silently; a TODO that has sat in tree for 18 months fires. Closes the gap between `level: warning` on every TODO (too noisy) and `level: off` (accepts unbounded debt accumulation).
 
-```yaml
-- id: stale-todos
-  kind: git_blame_age
-  paths:
-    include: ["**/*.{rs,ts,tsx,js,jsx,py,go,java,kt,rb}"]
-    exclude:
-      - "**/*test*/**"
-      - "**/fixtures/**"
-      - "vendor/**"
-      - "third_party/**"
-  pattern: '\b(TODO|FIXME|XXX|HACK)\b'
-  max_age_days: 180
-  level: warning
-  message: "`{{ctx.match}}` has been here for over 180 days — resolve, convert to a tracked issue, or remove."
-```
-
 `{{ctx.match}}` substitutes the regex capture group 1 when present, otherwise the full match — useful for surfacing which marker was caught (`TODO` vs `FIXME` vs …).
 
 Heuristic notes:
@@ -1013,15 +978,6 @@ Outside a git repo, on untracked files, or when blame fails for any other reason
 
 The `<since>...HEAD` diff must **add** (git status `A`) at least one path matching `add_glob:` — the "did you add a changelog entry?" gate. Three corpus signals: prettier's `changelog_unreleased/`, cpython's `Misc/NEWS.d/next/`, pnpm's `.changeset/*.md`. `since:` (the base ref) is required — the rule asserts about the *set of files a contribution adds*, so it's diff-scoped. An optional `when_changed:` gates the requirement on some other glob having changed (don't demand a changelog for a docs-only PR); with no gate, any non-empty changeset triggers it. Builds on the same `<since>...HEAD` three-dot (merge-base) diff as `alint check --changed`. Silent no-op outside a git repo or when nothing relevant changed; a `since:` that fails to resolve hard-fails with a shallow-clone hint.
 
-```yaml
-- id: changelog-per-pr
-  kind: changeset_requires_path
-  add_glob: ".changeset/*.md"          # the PR must add a changeset file…
-  when_changed: "src/**"               # …but only when it touches src/
-  since: "{{env.ALINT_BASE_SHA | default('origin/main')}}"
-  level: error
-```
-
 ---
 
 ### `pair_changed_together`
@@ -1029,15 +985,6 @@ The `<since>...HEAD` diff must **add** (git status `A`) at least one path matchi
 **Categories:** Git hygiene, Cross-file
 
 If the `<since>...HEAD` diff changes any path matching `if_changed:`, at least one path matching `then_changed:` must change in the same range — the **co-change** gate. Corpus signals: rust's `rustdoc-json-types` `FORMAT_VERSION` must bump when the format struct changes; "`version.txt` and the lockfile change together" release guards. Both globs and `since:` (the base ref) are required. **Directional** — the trigger is `if_changed`, the obligation is `then_changed`; a `then_changed`-only change never fires it, so add a second rule with the globs swapped for a bidirectional pact. The `changeset_requires_path` sibling, built on the same merge-base diff as `alint check --changed`. Silent no-op outside a git repo or when `if_changed` didn't change; a `since:` that fails to resolve hard-fails with a shallow-clone hint.
-
-```yaml
-- id: format-version-bumped
-  kind: pair_changed_together
-  if_changed: "src/rustdoc-json-types/lib.rs"     # if the format struct changes…
-  then_changed: "src/rustdoc-json-types/FORMAT_VERSION"  # …the version file must too
-  since: "{{env.ALINT_BASE_SHA | default('origin/main')}}"
-  level: error
-```
 
 ---
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -686,28 +686,13 @@ Flag tracked paths that are symbolic links. Symlinks are a portability footgun: 
 
 Caveat: a symlink whose target escapes the repository root (`link -> /etc`) is pruned by the walker *before* indexing, so it is **not** flagged — the rule reports in-tree symlinks (to files or directories), not escaping ones. The escaping symlink can't be read out-of-root either (path confinement blocks that), so this is a reporting gap, not a disclosure one; recording escaping symlinks safely is a tracked follow-up.
 
-```yaml
-- id: no-symlinks
-  kind: no_symlinks
-  paths: "**"
-  level: warning
-  fix:
-    file_remove: {}   # unlinks the symlink; target is untouched
-```
+Fix: `file_remove` — unlinks the symlink; the target is untouched.
 
 ### `executable_bit`
 
 **Categories:** Unix metadata
 
 Assert every file in scope either has the `+x` bit set (`require: true`) or does not (`require: false`).
-
-```yaml
-- id: ci-scripts-exec
-  kind: executable_bit
-  paths: "ci/**/*.sh"
-  require: true
-  level: warning
-```
 
 No fix op — chmod auto-apply is deferred.
 
@@ -716,13 +701,6 @@ No fix op — chmod auto-apply is deferred.
 **Categories:** Unix metadata, Content
 
 Every file with `+x` set must begin with `#!`. Catches plain text files accidentally marked executable.
-
-```yaml
-- id: executables-have-shebangs
-  kind: executable_has_shebang
-  paths: "**"
-  level: error
-```
 
 ### `shebang_has_executable`
 

--- a/xtask/src/docs_export.rs
+++ b/xtask/src/docs_export.rs
@@ -587,21 +587,20 @@ fn process_family_h3s(
         if !h3.body.contains("```yaml") && !group_kinds.iter().all(|k| documented.contains_key(k)) {
             missing_examples.push(format!("{} → {}", h2.title, h3.title));
         }
-        // ...and a documented kind must NOT also keep a hand-written ```yaml
-        // block, or the page double-renders (the generated example plus a stale
-        // hand-written one). Enforce the atomic-swap invariant (ADR-0014).
-        if h3.body.contains("```yaml") && group_kinds.iter().any(|k| documented.contains_key(k)) {
-            let dup: Vec<&str> = group_kinds
-                .iter()
-                .filter(|k| documented.contains_key(*k))
-                .map(String::as_str)
-                .collect();
-            anyhow::bail!(
-                "docs/rules.md H3 '{}' documents {dup:?} via a `docs:` scenario but \
-                 still contains a hand-written ```yaml example - remove the \
-                 hand-written block; the example now renders from the fixture.",
-                h3.title,
-            );
+        // ...and a documented kind must NOT keep a hand-written CONFIG example
+        // (a ```yaml block whose top-level `kind:` is the documented kind), or
+        // the page double-renders the generated example alongside a stale
+        // hand-written one. A non-config yaml block (e.g. a CI-workflow recipe)
+        // is fine. Enforce the atomic-swap invariant (ADR-0014).
+        if let Some(ex_kind) = example_first_kind(&h3.body) {
+            if documented.contains_key(&ex_kind) {
+                anyhow::bail!(
+                    "docs/rules.md H3 '{}' documents `{ex_kind}` via a `docs:` scenario \
+                     but still contains a hand-written config example for it - remove the \
+                     hand-written block; the example now renders from the fixture.",
+                    h3.title,
+                );
+            }
         }
         // The example must demonstrate the H3's CANONICAL kind, not an alias:
         // the generated page is slugged/titled by the canonical name, so an

--- a/xtask/src/docs_export.rs
+++ b/xtask/src/docs_export.rs
@@ -591,16 +591,21 @@ fn process_family_h3s(
         // (a ```yaml block whose top-level `kind:` is the documented kind), or
         // the page double-renders the generated example alongside a stale
         // hand-written one. A non-config yaml block (e.g. a CI-workflow recipe)
-        // is fine. Enforce the atomic-swap invariant (ADR-0014).
-        if let Some(ex_kind) = example_first_kind(&h3.body) {
-            if documented.contains_key(&ex_kind) {
-                anyhow::bail!(
-                    "docs/rules.md H3 '{}' documents `{ex_kind}` via a `docs:` scenario \
-                     but still contains a hand-written config example for it - remove the \
-                     hand-written block; the example now renders from the fixture.",
-                    h3.title,
-                );
-            }
+        // is fine. Scan EVERY yaml block, not just the leading one: a documented
+        // kind can keep a non-config recipe as its first block (git_commit_message
+        // keeps a CI-workflow yaml), so a stale config re-added after it would sit
+        // in a later block. Match only against `documented` kind names, so an
+        // incidental `kind:` in a recipe can't false-fire. Atomic-swap (ADR-0014).
+        if let Some(ex_kind) = example_block_kinds(&h3.body)
+            .into_iter()
+            .find(|k| documented.contains_key(k))
+        {
+            anyhow::bail!(
+                "docs/rules.md H3 '{}' documents `{ex_kind}` via a `docs:` scenario \
+                 but still contains a hand-written config example for it - remove the \
+                 hand-written block; the example now renders from the fixture.",
+                h3.title,
+            );
         }
         // The example must demonstrate the H3's CANONICAL kind, not an alias:
         // the generated page is slugged/titled by the canonical name, so an
@@ -1071,6 +1076,37 @@ fn example_first_kind(body: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// The first top-level `kind:` of EACH fenced yaml block in a rule H3's body, in
+/// document order (a block with no `kind:` contributes nothing). Unlike
+/// `example_first_kind` (which reads only the leading block, to police that
+/// block's canonical kind), the double-example gate must see a stale config block
+/// wherever it sits - e.g. a later block after a non-config recipe. Callers
+/// filter the result against the documented-kind set, so an incidental `kind:`
+/// in a recipe can't false-fire.
+fn example_block_kinds(body: &str) -> Vec<String> {
+    let mut kinds = Vec::new();
+    let mut offset = 0;
+    while let Some(rel_open) = body[offset..].find("```yaml") {
+        let after_fence = offset + rel_open + "```yaml".len();
+        let Some(nl) = body[after_fence..].find('\n') else {
+            break;
+        };
+        let content_start = after_fence + nl + 1;
+        let Some(close_rel) = body[content_start..].find("```") else {
+            break;
+        };
+        let block_end = content_start + close_rel;
+        for line in body[content_start..block_end].lines() {
+            if let Some(v) = line.trim().strip_prefix("kind:") {
+                kinds.push(v.trim().to_string());
+                break; // the FIRST kind: of this block only
+            }
+        }
+        offset = block_end + 3; // step past the closing fence
+    }
+    kinds
 }
 
 /// Enforce the two per-rule-example docs gates and bail on the first failure:

--- a/xtask/src/docs_export/examples.rs
+++ b/xtask/src/docs_export/examples.rs
@@ -13,7 +13,9 @@ use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use alint_testkit::{DocsCase, DocsExample, Scenario, Step, TreeNode, TreeSpec, materialize};
+use alint_testkit::{
+    DocsCase, DocsExample, Scenario, Step, TreeNode, TreeSpec, materialize, setup_git,
+};
 use anyhow::{Context, Result, bail};
 
 /// One rendered documented example: the markdown subsection injected onto the
@@ -110,9 +112,6 @@ fn validate_documented(scenario: &Scenario, docs: &DocsExample) -> Result<()> {
              hermetic (inline rules or `alint://bundled/...` only)"
         );
     }
-    if scenario.given.git.is_some() {
-        bail!("`given.git` is not supported for documented examples yet (Phase 2)");
-    }
     if scenario.when.as_slice() != [Step::Check] {
         bail!(
             "documented examples must be a single `check` scenario (when: [check]), \
@@ -147,6 +146,11 @@ fn run_and_capture(bin: &Path, scenario: &Scenario, docs: &DocsExample) -> Resul
     let repo = tmp.path().join("repo");
     std::fs::create_dir_all(&repo)?;
     materialize(&scenario.given.tree, &repo).context("materialising example tree")?;
+
+    // Git-rule examples drive a real repo (init + commits) inside the tree.
+    if let Some(git_spec) = &scenario.given.git {
+        setup_git(&repo, git_spec).context("git setup for the documented example")?;
+    }
 
     // Config OUTSIDE the walked tree, reached via `-c`, so `.alint.yml` is never
     // itself a rule-matchable file.

--- a/xtask/src/docs_export/examples.rs
+++ b/xtask/src/docs_export/examples.rs
@@ -310,6 +310,8 @@ fn render_tree(tree: &TreeSpec) -> String {
         .iter()
         .map(|(path, node)| match node {
             TreeNode::File(_) => path,
+            TreeNode::Exec(_) => format!("{path}  (executable)"),
+            TreeNode::Symlink(link) => format!("{path} -> {}", link.target),
             TreeNode::Dir(_) => format!("{path}/"),
         })
         .collect();

--- a/xtask/src/docs_export/examples.rs
+++ b/xtask/src/docs_export/examples.rs
@@ -14,7 +14,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use alint_testkit::{
-    DocsCase, DocsExample, Scenario, Step, TreeNode, TreeSpec, materialize, setup_git,
+    CommitSpec, DocsCase, DocsExample, GivenGit, Scenario, Step, TreeNode, TreeSpec, materialize,
+    setup_git,
 };
 use anyhow::{Context, Result, bail};
 
@@ -92,16 +93,18 @@ fn render_one(
         markdown: render_markdown(
             docs,
             &scenario.given.tree,
+            scenario.given.git.as_ref(),
             &scenario.given.config,
             output.as_deref(),
         ),
     })
 }
 
-/// Gate a documented scenario before it can back a page: hermetic config, no
-/// git (Phase 2), a single `check` step so the `expect:` the `scenarios.rs`
-/// harness asserts matches the run the page renders, and exactly one top-level
-/// rule whose kind is the documented kind (so the label cannot lie).
+/// Gate a documented scenario before it can back a page: hermetic config, a
+/// single `check` step so the `expect:` the `scenarios.rs` harness asserts
+/// matches the run the page renders, and exactly one top-level rule whose kind
+/// is the documented kind (so the label cannot lie). A git-rule example may
+/// carry a `given.git` block - the render drives it.
 fn validate_documented(scenario: &Scenario, docs: &DocsExample) -> Result<()> {
     let config: serde_yaml_ng::Value = serde_yaml_ng::from_str(&scenario.given.config)
         .context("parsing the documented example config")?;
@@ -254,6 +257,7 @@ fn has_remote_extends(config: &serde_yaml_ng::Value) -> bool {
 fn render_markdown(
     docs: &DocsExample,
     tree: &TreeSpec,
+    git: Option<&GivenGit>,
     config: &str,
     output: Option<&str>,
 ) -> String {
@@ -271,6 +275,14 @@ fn render_markdown(
     let _ = writeln!(&mut md, "With this `.alint.yml`:");
     let _ = writeln!(&mut md);
     push_fenced(&mut md, "yaml", config);
+    // Git-rule examples turn on the repo's history (a backdated commit, a bad
+    // subject) - surface it, or the worked example's premise is off-screen.
+    if let Some(history) = git.and_then(render_git_history) {
+        let _ = writeln!(&mut md);
+        let _ = writeln!(&mut md, "committed with this history (oldest first):");
+        let _ = writeln!(&mut md);
+        push_fenced(&mut md, "text", &history);
+    }
     if let Some(output) = output {
         let _ = writeln!(&mut md);
         let _ = writeln!(&mut md, "`alint check` reports:");
@@ -279,6 +291,35 @@ fn render_markdown(
     }
     let _ = writeln!(&mut md);
     md
+}
+
+/// A `git log --oneline`-style summary of the scenario's commits (oldest
+/// first), so a git-rule page shows the message, backdate, and staged files
+/// that drive the example. `None` when there are no commits.
+fn render_git_history(git: &GivenGit) -> Option<String> {
+    if git.commits.is_empty() {
+        return None;
+    }
+    let mut lines = Vec::with_capacity(git.commits.len());
+    for commit in &git.commits {
+        match commit {
+            CommitSpec::Subject(subject) => lines.push(subject.clone()),
+            CommitSpec::Detailed(d) => {
+                let date = d
+                    .date
+                    .as_deref()
+                    .map(|x| format!("{x}  "))
+                    .unwrap_or_default();
+                let files = if d.add.is_empty() {
+                    String::new()
+                } else {
+                    format!("  (adds {})", d.add.join(", "))
+                };
+                lines.push(format!("{date}{}{files}", d.message));
+            }
+        }
+    }
+    Some(lines.join("\n"))
 }
 
 /// Append a fenced code block, sizing the fence one backtick longer than the
@@ -405,7 +446,7 @@ mod tests {
             kind: "file_exists".into(),
             order: 0,
         };
-        let md = render_markdown(&docs, &tree("README.md: \"x\""), "version: 1\n", None);
+        let md = render_markdown(&docs, &tree("README.md: \"x\""), None, "version: 1\n", None);
         assert!(md.contains("### T"));
         assert!(md.contains("With this `.alint.yml`:"));
         assert!(!md.contains("alint check` reports"));

--- a/xtask/src/docs_export/tests.rs
+++ b/xtask/src/docs_export/tests.rs
@@ -387,6 +387,70 @@ fn pascal_to_kebab_examples() {
     assert_eq!(pascal_to_kebab("Lsp"), "lsp");
 }
 
+/// `example_first_kind` reads ONLY the leading yaml block (the canonical-kind
+/// gate polices that block); `example_block_kinds` reads EVERY block (the
+/// double-example gate must catch a stale config wherever it sits). The
+/// `git_commit_message` shape - a non-config recipe first, a config after -
+/// is exactly where the two diverge, so lock both in.
+#[test]
+fn block_kind_scanners_read_first_vs_all_yaml_blocks() {
+    // A CI-workflow recipe (no `kind:`) followed by a config block: the leading
+    // scan sees nothing, the all-blocks scan finds the config's kind.
+    let body = "\
+Intro prose.
+
+```yaml
+# .github/workflows/lint.yml
+on: [push]
+jobs: {}
+```
+
+More prose.
+
+```yaml
+- id: r
+  kind: git_commit_message
+  max_subject_length: 50
+```
+";
+    assert_eq!(
+        example_first_kind(body),
+        None,
+        "leading block is a recipe with no kind:"
+    );
+    assert_eq!(
+        example_block_kinds(body),
+        vec!["git_commit_message".to_string()],
+        "the config in a later block must still be seen"
+    );
+
+    // Leading config block: both scanners agree, and a later block's kind is
+    // still collected in document order.
+    let two_configs = "\
+```yaml
+- id: a
+  kind: file_exists
+```
+
+```yaml
+- id: b
+  kind: file_absent
+```
+";
+    assert_eq!(
+        example_first_kind(two_configs).as_deref(),
+        Some("file_exists")
+    );
+    assert_eq!(
+        example_block_kinds(two_configs),
+        vec!["file_exists".to_string(), "file_absent".to_string()]
+    );
+
+    // No yaml at all: both empty.
+    assert_eq!(example_first_kind("just prose"), None);
+    assert!(example_block_kinds("just prose").is_empty());
+}
+
 /// Design invariant (docs/design/rule-categories.md): the `**Categories:**` line
 /// is stripped from every H3 body BEFORE it is summarized or rendered, so no
 /// generated summary or page body ever carries the literal marker. Tested


### PR DESCRIPTION
## Summary

Phase 2 of ADR-0014 (rule-page examples from executed fixtures). Grows the e2e
testkit with the filesystem and git primitives the seven
`NATIVE_FIRES_ALLOWLIST` kinds needed, then migrates all seven so their pages
render a real `alint check` run - **zeroing the allowlist**.

## Harness (the new subsystem)

- **`TreeNode` `$exec` / `$symlink` nodes** - `{ "$exec": "content" }` → a 0755
  file, `{ "$symlink": "target" }` → a symlink. Newtype-over-named-struct serde
  (an inline variant can't carry `deny_unknown_fields`); the fs-write arms are
  `cfg(unix)`, the variants deserialise on all targets (so scenarios still parse
  on Windows before the unix-only skip).
- **`git.commits` DSL** - each entry is a bare subject (empty commit, as before)
  or `{ message, add, date }`: stages files, uses a custom message, and backdates
  via `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE`. Untagged, so existing bare-subject
  fixtures still parse.
- **`setup_git`** made public; the docs-export render drives it, so a git-rule
  page renders a real repo.

## Migrations (allowlist 7 → 0)

- **FS** (unix-only, `$exec`/`$symlink`): `executable_bit`,
  `executable_has_shebang`, `no_symlinks`.
- **git**: `git_commit_message` (HEAD-mode, a custom subject), `git_blame_age`
  (year-2000 backdate + a static `message:` so the page is date-stable), and
  `changeset_requires_path` / `pair_changed_together` (two commits with real
  added-file deltas, `since: HEAD~1`).

`NATIVE_FIRES_ALLOWLIST` is now empty, with a tripwire test
(`native_fires_allowlist_is_empty`) that fails if a future kind re-adds an
exemption.

## Also

- Refined the double-example gate to flag only a hand-written **config** example
  (a yaml block whose `kind:` is the documented kind), so `git_commit_message`
  keeps its CI-workflow recipe alongside the rendered example.

## Verification

`cargo fmt --check` · `cargo clippy --workspace -D warnings` ·
`cargo test --workspace` (326 scenarios; the allowlist tripwire passes) ·
`docs-export --check` (all seven pages render real output) ·
`RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace` · dogfood
`alint check` - all green.

## Follow-ups

Phase 3 (the remaining ~74 kinds via the per-family workflow) - first needs
canonical-alias handling in the gate (it currently exact-matches `docs.kind`
against the config kind, which the existence/FS/git families didn't exercise).
