### PR TITLE
refactor(registry): canonical alias resolution + alias-aware docs gate (#90)

### DIFF
--- a/crates/alint-core/src/registry.rs
+++ b/crates/alint-core/src/registry.rs
@@ -14,15 +14,23 @@ type BoxedBuilder = Box<dyn Fn(&RuleSpec) -> Result<Box<dyn Rule>> + Send + Sync
 
 /// Map from `kind` string → factory function. Built-in rule crates register
 /// themselves here at startup, and plugin rules (in later phases) will too.
+///
+/// A kind may be registered under more than one spelling: `register_alias`
+/// records that the alias resolves to a canonical kind, so `canonical_kind`
+/// can collapse the two. The alias still builds the same rule.
 #[derive(Default)]
 pub struct RuleRegistry {
     builders: HashMap<String, BoxedBuilder>,
+    /// alias kind → canonical kind. Only populated by `register_alias*`; a
+    /// canonical (or unregistered) name is absent and resolves to itself.
+    aliases: HashMap<String, String>,
 }
 
 impl std::fmt::Debug for RuleRegistry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RuleRegistry")
             .field("kinds", &self.builders.keys().collect::<Vec<_>>())
+            .field("aliases", &self.aliases)
             .finish()
     }
 }
@@ -49,6 +57,51 @@ impl RuleRegistry {
                 builder(spec)
             }),
         );
+    }
+
+    /// Register `alias` as another spelling of `canonical`: it builds the same
+    /// rule (same `builder`, as [`register`](Self::register) would) AND records
+    /// the alias → canonical mapping that [`canonical_kind`](Self::canonical_kind)
+    /// and [`canonical_kinds`](Self::canonical_kinds) expose. `canonical` should
+    /// itself be registered (as a non-alias) so an alias always resolves to a
+    /// real page/kind; the built-in registry's consistency test enforces this.
+    pub fn register_alias(&mut self, alias: &str, canonical: &str, builder: RuleBuilder) {
+        self.register(alias, builder);
+        self.aliases
+            .insert(alias.to_string(), canonical.to_string());
+    }
+
+    /// [`register_alias`](Self::register_alias) for an OPTION-LESS canonical
+    /// kind: the alias gets the same unknown-option rejection as
+    /// [`register_optionless`](Self::register_optionless).
+    pub fn register_alias_optionless(
+        &mut self,
+        alias: &str,
+        canonical: &str,
+        builder: RuleBuilder,
+    ) {
+        self.register_optionless(alias, builder);
+        self.aliases
+            .insert(alias.to_string(), canonical.to_string());
+    }
+
+    /// Resolve `name` to its canonical kind: the target of an alias registered
+    /// via [`register_alias`](Self::register_alias), or `name` itself when it is
+    /// already canonical (or not registered at all). Alias-aware equality —
+    /// `canonical_kind(a) == canonical_kind(b)` — is how a caller tells whether
+    /// two spellings name the same rule.
+    pub fn canonical_kind<'a>(&'a self, name: &'a str) -> &'a str {
+        self.aliases.get(name).map_or(name, String::as_str)
+    }
+
+    /// Every registered kind that is NOT an alias, in arbitrary order — the
+    /// canonical set the coverage audits enumerate (each alias collapses into
+    /// the canonical it points at).
+    pub fn canonical_kinds(&self) -> impl Iterator<Item = &str> {
+        self.builders
+            .keys()
+            .map(String::as_str)
+            .filter(|k| !self.aliases.contains_key(*k))
     }
 
     pub fn build(&self, spec: &RuleSpec) -> Result<Box<dyn Rule>> {
@@ -139,6 +192,26 @@ mod tests {
             Error::UnknownRuleKind(name) => assert_eq!(name, "not_real"),
             other => panic!("expected UnknownRuleKind, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn register_alias_records_canonical_and_still_builds() {
+        let mut r = RuleRegistry::new();
+        r.register("file_content_matches", ok_builder);
+        r.register_alias("content_matches", "file_content_matches", ok_builder);
+        // The alias is a real, buildable kind (both spellings are known).
+        assert_eq!(r.known_kinds().count(), 2);
+        // canonical_kind collapses the alias; a canonical / unknown name is itself.
+        assert_eq!(r.canonical_kind("content_matches"), "file_content_matches");
+        assert_eq!(
+            r.canonical_kind("file_content_matches"),
+            "file_content_matches"
+        );
+        assert_eq!(r.canonical_kind("not_registered"), "not_registered");
+        // canonical_kinds omits the alias.
+        let mut canon: Vec<&str> = r.canonical_kinds().collect();
+        canon.sort_unstable();
+        assert_eq!(canon, vec!["file_content_matches"]);
     }
 
     #[test]

--- a/crates/alint-e2e/tests/coverage_audit.rs
+++ b/crates/alint-e2e/tests/coverage_audit.rs
@@ -103,52 +103,27 @@ fn every_registered_rule_kind_has_a_scenario() {
     let scenario_kinds = collect_scenario_kinds(&scenarios_dir);
 
     let registry = alint_rules::builtin_registry();
-    let registered: HashSet<String> = registry.known_kinds().map(str::to_string).collect();
 
-    // Aliases register both `file_content_matches` and
-    // `content_matches` to the same builder. For coverage
-    // purposes, we accept either form — adding both to scenarios
-    // is wasteful. Build the alias→canonical mapping inline so
-    // a scenario using just one form satisfies the audit.
-    let aliased: &[(&str, &str)] = &[
-        ("content_matches", "file_content_matches"),
-        ("content_forbidden", "file_content_forbidden"),
-        ("header", "file_header"),
-        ("footer", "file_footer"),
-        ("shebang", "file_shebang"),
-        ("max_size", "file_max_size"),
-        ("min_size", "file_min_size"),
-        ("min_lines", "file_min_lines"),
-        ("max_lines", "file_max_lines"),
-        ("is_text", "file_is_text"),
-    ];
-    let alias_set: HashSet<&str> = aliased.iter().map(|(alias, _)| *alias).collect();
-
-    let canonical_registered: HashSet<&String> = registered
-        .iter()
-        .filter(|k| !alias_set.contains(k.as_str()))
-        .collect();
-
+    // Aliases (e.g. `content_matches` == `file_content_matches`,
+    // `cross_file_value_equals` == `cross_file`) build the same rule, so a
+    // scenario using either spelling counts. Collapse the registered set and
+    // the scenario set through the registry's canonical map so they agree.
+    let canonical_registered: Vec<String> =
+        registry.canonical_kinds().map(str::to_string).collect();
     let scenario_canonical: HashSet<String> = scenario_kinds
         .iter()
-        .map(|k| {
-            aliased
-                .iter()
-                .find(|(alias, _)| alias == k)
-                .map_or_else(|| k.clone(), |(_, canon)| (*canon).to_string())
-        })
+        .map(|k| registry.canonical_kind(k).to_string())
         .collect();
 
-    let missing: Vec<&&String> = canonical_registered
+    let mut missing: Vec<&String> = canonical_registered
         .iter()
         .filter(|k| !scenario_canonical.contains(k.as_str()))
         .collect();
 
     if !missing.is_empty() {
-        let mut sorted: Vec<&&String> = missing.clone();
-        sorted.sort();
+        missing.sort();
         let mut bullets = String::new();
-        for k in &sorted {
+        for k in &missing {
             let _ = writeln!(bullets, "  - {k}");
         }
         panic!(

--- a/crates/alint-e2e/tests/coverage_audit_baseline_safety.rs
+++ b/crates/alint-e2e/tests/coverage_audit_baseline_safety.rs
@@ -113,8 +113,9 @@ fn findings_of(
 ) {
     let mut cache: BTreeMap<PathBuf, Option<Vec<u8>>> = BTreeMap::new();
     for r in &report.results {
-        // `id_kind` values are already canonicalised at build time, so use them
-        // as-is; fall back to the rule id when the kind is unknown.
+        // Both call sites (scenarios + multi-fixtures) build `id_kind` with
+        // canonical kinds, so use the value as-is; fall back to the rule id when
+        // the kind is unknown.
         let kind = id_kind
             .get(r.rule_id.as_ref())
             .map_or_else(|| r.rule_id.to_string(), Clone::clone);
@@ -140,6 +141,7 @@ fn findings_of(
 
 /// Run every scenario under `dir` and collect findings + which kinds fired.
 fn collect_from_scenarios(dir: &Path, all: &mut Vec<Vec<Finding>>, fired: &mut BTreeSet<String>) {
+    let registry = builtin_registry();
     for path in yml_files(dir) {
         let Ok(text) = std::fs::read_to_string(&path) else {
             continue;
@@ -147,7 +149,13 @@ fn collect_from_scenarios(dir: &Path, all: &mut Vec<Vec<Finding>>, fired: &mut B
         let Ok(scenario) = serde_yaml_ng::from_str::<Scenario>(&text) else {
             continue;
         };
-        let id_kind = id_to_kind(&scenario.given.config);
+        // Canonicalise the id -> kind map (matching `collect_from_multi_fixtures`)
+        // so an alias-spelled `kind:` resolves to its canonical, keeping `fired`
+        // and the finding labels in a single namespace.
+        let id_kind: BTreeMap<String, String> = id_to_kind(&scenario.given.config)
+            .into_iter()
+            .map(|(id, kind)| (id, registry.canonical_kind(&kind).to_string()))
+            .collect();
         let Ok(run) = run_scenario(&scenario) else {
             continue;
         };

--- a/crates/alint-e2e/tests/coverage_audit_baseline_safety.rs
+++ b/crates/alint-e2e/tests/coverage_audit_baseline_safety.rs
@@ -38,29 +38,6 @@ use alint_core::{Engine, RuleEntry, WalkOptions, walk};
 use alint_rules::builtin_registry;
 use alint_testkit::{Scenario, StepOutcome, run_scenario};
 
-/// Kind-name aliases (same set the other coverage audits use): a scenario
-/// using either spelling counts for the canonical kind.
-const ALIASES: &[(&str, &str)] = &[
-    ("content_matches", "file_content_matches"),
-    ("content_forbidden", "file_content_forbidden"),
-    ("header", "file_header"),
-    ("footer", "file_footer"),
-    ("shebang", "file_shebang"),
-    ("max_size", "file_max_size"),
-    ("min_size", "file_min_size"),
-    ("min_lines", "file_min_lines"),
-    ("max_lines", "file_max_lines"),
-    ("is_text", "file_is_text"),
-];
-
-fn canonical(kind: &str) -> String {
-    ALIASES
-        .iter()
-        .find(|(a, _)| *a == kind)
-        .map_or(kind, |(_, c)| *c)
-        .to_string()
-}
-
 /// One emitted violation, reduced to what the invariants need.
 struct Finding {
     kind: String,
@@ -136,9 +113,11 @@ fn findings_of(
 ) {
     let mut cache: BTreeMap<PathBuf, Option<Vec<u8>>> = BTreeMap::new();
     for r in &report.results {
+        // `id_kind` values are already canonicalised at build time, so use them
+        // as-is; fall back to the rule id when the kind is unknown.
         let kind = id_kind
             .get(r.rule_id.as_ref())
-            .map_or_else(|| r.rule_id.to_string(), |k| canonical(k));
+            .map_or_else(|| r.rule_id.to_string(), Clone::clone);
         for v in &r.violations {
             let bytes = v.path.as_ref().and_then(|p| {
                 cache
@@ -209,7 +188,7 @@ fn collect_from_multi_fixtures(
         let id_kind: BTreeMap<String, String> = config
             .rules
             .iter()
-            .map(|s| (s.id.clone(), canonical(&s.kind)))
+            .map(|s| (s.id.clone(), registry.canonical_kind(&s.kind).to_string()))
             .collect();
         let mut entries = Vec::new();
         for spec in &config.rules {
@@ -304,7 +283,7 @@ fn every_kind_emits_baseline_safe_fingerprints() {
 
     // Sanity: the corpus must actually exercise a broad set of kinds, else a
     // broken testkit would vacuously pass this gate.
-    let canonical_kinds = builtin_registry().known_kinds().count();
+    let canonical_kinds = builtin_registry().canonical_kinds().count();
     assert!(
         fired.len() >= 60,
         "baseline audit only saw {} kinds fire (of {canonical_kinds}); the scenario \

--- a/crates/alint-e2e/tests/coverage_audit_bench_listing.rs
+++ b/crates/alint-e2e/tests/coverage_audit_bench_listing.rs
@@ -14,26 +14,6 @@ use std::collections::HashSet;
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
-const ALIASES: &[(&str, &str)] = &[
-    ("content_matches", "file_content_matches"),
-    ("content_forbidden", "file_content_forbidden"),
-    ("header", "file_header"),
-    ("footer", "file_footer"),
-    ("shebang", "file_shebang"),
-    ("max_size", "file_max_size"),
-    ("min_size", "file_min_size"),
-    ("min_lines", "file_min_lines"),
-    ("max_lines", "file_max_lines"),
-    ("is_text", "file_is_text"),
-];
-
-fn canonical(kind: &str) -> &str {
-    ALIASES
-        .iter()
-        .find(|(alias, _)| *alias == kind)
-        .map_or(kind, |(_, canon)| *canon)
-}
-
 fn collect_kinds_from_yaml(yaml: &str, out: &mut HashSet<String>) {
     let Ok(parsed) = serde_yaml_ng::from_str::<serde_yaml_ng::Value>(yaml) else {
         return;
@@ -48,7 +28,9 @@ fn walk(v: &serde_yaml_ng::Value, out: &mut HashSet<String>) {
                 .get(serde_yaml_ng::Value::String("kind".into()))
                 .and_then(|v| v.as_str())
             {
-                out.insert(canonical(kind).to_string());
+                // Harvest the raw spelling; canonicalisation happens once the
+                // registry is in scope (an alias here collapses to its canonical).
+                out.insert(kind.to_string());
             }
             for (_, child) in m {
                 walk(child, out);
@@ -131,12 +113,13 @@ fn list_rule_kinds_not_covered_by_bench_scale() {
     }
 
     let registry = alint_rules::builtin_registry();
-    let alias_set: HashSet<&str> = ALIASES.iter().map(|(alias, _)| *alias).collect();
-    let canonical_kinds: Vec<String> = registry
-        .known_kinds()
-        .filter(|k| !alias_set.contains(k))
-        .map(str::to_string)
+    // Canonicalise the kinds harvested from bench YAML (they may use an alias
+    // spelling) so they line up with the canonical set below.
+    let bench_kinds: HashSet<String> = bench_kinds
+        .iter()
+        .map(|k| registry.canonical_kind(k).to_string())
         .collect();
+    let canonical_kinds: Vec<String> = registry.canonical_kinds().map(str::to_string).collect();
 
     let uncovered: Vec<&String> = canonical_kinds
         .iter()

--- a/crates/alint-e2e/tests/coverage_audit_pass_fail.rs
+++ b/crates/alint-e2e/tests/coverage_audit_pass_fail.rs
@@ -138,29 +138,6 @@ fn native_fires_allowlist_is_empty() {
     );
 }
 
-/// Same alias map as `coverage_audit.rs`. Normalise before
-/// recording status so a single scenario using either form
-/// satisfies the audit.
-const ALIASES: &[(&str, &str)] = &[
-    ("content_matches", "file_content_matches"),
-    ("content_forbidden", "file_content_forbidden"),
-    ("header", "file_header"),
-    ("footer", "file_footer"),
-    ("shebang", "file_shebang"),
-    ("max_size", "file_max_size"),
-    ("min_size", "file_min_size"),
-    ("min_lines", "file_min_lines"),
-    ("max_lines", "file_max_lines"),
-    ("is_text", "file_is_text"),
-];
-
-fn canonical(kind: &str) -> &str {
-    ALIASES
-        .iter()
-        .find(|(alias, _)| *alias == kind)
-        .map_or(kind, |(_, canon)| *canon)
-}
-
 // 101 lines — the test enumerates every registered rule kind,
 // classifies each as having a pass scenario / fail scenario /
 // both / neither, and emits a structured failure report when
@@ -170,6 +147,7 @@ fn canonical(kind: &str) -> &str {
 #[test]
 fn every_registered_rule_kind_has_pass_and_fail_scenarios() {
     let scenarios_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("scenarios");
+    let registry = alint_rules::builtin_registry();
     let mut status: HashMap<String, Status> = HashMap::new();
 
     for path in walkdir(&scenarios_dir) {
@@ -197,7 +175,7 @@ fn every_registered_rule_kind_has_pass_and_fail_scenarios() {
         // "silent" — that's correct, the rule did stay silent.
         let mut kinds_in_scenario: HashMap<String, bool> = HashMap::new();
         for (id, kind) in &rules {
-            let canon = canonical(kind).to_string();
+            let canon = registry.canonical_kind(kind).to_string();
             let entry = kinds_in_scenario.entry(canon).or_insert(false);
             if fired.contains(id) {
                 *entry = true;
@@ -213,13 +191,7 @@ fn every_registered_rule_kind_has_pass_and_fail_scenarios() {
         }
     }
 
-    let registry = alint_rules::builtin_registry();
-    let alias_set: HashSet<&str> = ALIASES.iter().map(|(alias, _)| *alias).collect();
-    let canonical_kinds: Vec<String> = registry
-        .known_kinds()
-        .filter(|k| !alias_set.contains(k))
-        .map(str::to_string)
-        .collect();
+    let canonical_kinds: Vec<String> = registry.canonical_kinds().map(str::to_string).collect();
 
     let native_allowlist: HashSet<&str> = NATIVE_FIRES_ALLOWLIST
         .iter()

--- a/crates/alint-rules/src/lib.rs
+++ b/crates/alint-rules/src/lib.rs
@@ -325,23 +325,31 @@ pub fn register_builtin(registry: &mut RuleRegistry) {
     registry.register("dir_absent", dir_absent::build);
 
     registry.register("file_content_matches", file_content_matches::build);
-    registry.register("content_matches", file_content_matches::build);
+    registry.register_alias(
+        "content_matches",
+        "file_content_matches",
+        file_content_matches::build,
+    );
     registry.register("file_content_forbidden", file_content_forbidden::build);
-    registry.register("content_forbidden", file_content_forbidden::build);
+    registry.register_alias(
+        "content_forbidden",
+        "file_content_forbidden",
+        file_content_forbidden::build,
+    );
     registry.register("file_header", file_header::build);
-    registry.register("header", file_header::build);
+    registry.register_alias("header", "file_header", file_header::build);
     registry.register("file_max_size", file_max_size::build);
-    registry.register("max_size", file_max_size::build);
+    registry.register_alias("max_size", "file_max_size", file_max_size::build);
     registry.register("file_min_size", file_min_size::build);
-    registry.register("min_size", file_min_size::build);
+    registry.register_alias("min_size", "file_min_size", file_min_size::build);
     registry.register("file_min_lines", file_min_lines::build);
-    registry.register("min_lines", file_min_lines::build);
+    registry.register_alias("min_lines", "file_min_lines", file_min_lines::build);
     registry.register("file_max_lines", file_max_lines::build);
-    registry.register("max_lines", file_max_lines::build);
+    registry.register_alias("max_lines", "file_max_lines", file_max_lines::build);
     registry.register("file_footer", file_footer::build);
-    registry.register("footer", file_footer::build);
+    registry.register_alias("footer", "file_footer", file_footer::build);
     registry.register("file_shebang", file_shebang::build);
-    registry.register("shebang", file_shebang::build);
+    registry.register_alias("shebang", "file_shebang", file_shebang::build);
 
     // Structured-query family — JSONPath queries over
     // JSON / YAML / TOML documents.
@@ -381,7 +389,7 @@ pub fn register_builtin(registry: &mut RuleRegistry) {
     registry.register("git_blame_age", git_blame_age::build);
     registry.register("changeset_requires_path", changeset_requires_path::build);
     registry.register_optionless("file_is_text", file_is_text::build);
-    registry.register_optionless("is_text", file_is_text::build);
+    registry.register_alias_optionless("is_text", "file_is_text", file_is_text::build);
 
     registry.register("filename_case", filename_case::build);
     registry.register("filename_regex", filename_regex::build);
@@ -398,7 +406,7 @@ pub fn register_builtin(registry: &mut RuleRegistry) {
     // The unified cross-file value-relation kind; `cross_file_value_equals`
     // (v0.10) is a byte-compatible alias with `relation` defaulting to `equals`.
     registry.register("cross_file", cross_file::build);
-    registry.register("cross_file_value_equals", cross_file::build);
+    registry.register_alias("cross_file_value_equals", "cross_file", cross_file::build);
     registry.register("file_graph", file_graph::build);
     registry.register("ordered_block", ordered_block::build);
     registry.register("for_each_match", for_each_match::build);
@@ -467,6 +475,36 @@ pub fn builtin_registry() -> RuleRegistry {
 #[cfg(test)]
 mod registry_tests {
     use super::*;
+
+    #[test]
+    fn every_alias_resolves_to_a_known_non_alias_canonical() {
+        // Guards `register_alias`: each alias must point at a canonical kind
+        // that is itself registered and is NOT an alias (no alias chains), so
+        // `canonical_kind` always lands on a real rule/page in one hop. Catches
+        // a typo'd or reordered `register_alias` at test time.
+        let r = builtin_registry();
+        let known: std::collections::HashSet<&str> = r.known_kinds().collect();
+        let mut alias_count = 0usize;
+        for kind in r.known_kinds() {
+            let canon = r.canonical_kind(kind);
+            if canon == kind {
+                continue; // canonical (or standalone) kind
+            }
+            alias_count += 1;
+            assert!(
+                known.contains(canon),
+                "alias `{kind}` resolves to unregistered canonical `{canon}`"
+            );
+            assert_eq!(
+                r.canonical_kind(canon),
+                canon,
+                "alias `{kind}` points at `{canon}`, which is itself an alias (chain)"
+            );
+        }
+        // The 11 known aliases: the 10 short-name `file_*` forms + is_text, plus
+        // `cross_file_value_equals`. A drift in that count is a deliberate change.
+        assert_eq!(alias_count, 11, "unexpected number of registered aliases");
+    }
 
     #[test]
     fn every_documented_kind_is_registered() {

--- a/xtask/src/docs_export.rs
+++ b/xtask/src/docs_export.rs
@@ -393,13 +393,12 @@ fn generate_rules_pages(
     let registry = alint_rules::builtin_registry();
     let known_kinds: HashSet<String> = registry.known_kinds().map(str::to_string).collect();
 
-    // Aliases declared in rules.md H3 titles via `(alias: \`X\`)`.
-    // The registry has no concept of "alias" — both canonical and
-    // alias names are registered as independent builders that
-    // happen to share an implementation. We harvest the alias
-    // names from rules.md so the "registered but missing" check
-    // below doesn't false-positive on aliases that ARE
-    // documented, just under their canonical name's heading.
+    // Alias names declared in rules.md H3 titles via `(alias: \`X\`)`. The
+    // registry now records alias->canonical too (`canonical_kind`), and the
+    // gen-facts gate cross-checks the two agree; we harvest from rules.md here so
+    // the "registered but missing" page check validates the documentation's own
+    // alias declarations. Excludes aliases that ARE documented under their
+    // canonical name's heading so that check doesn't false-positive on them.
     let aliases: HashSet<String> = harvest_aliases(&src);
 
     // Source of truth for the per-rule "## Options" tables: the
@@ -474,6 +473,7 @@ fn generate_rules_pages(
             &mut missing_examples,
             &mut wrong_kind_examples,
             &documented,
+            &registry,
             released,
         )?;
         families_meta.push((h2.title.clone(), family_order, family_slug.clone()));
@@ -556,6 +556,7 @@ fn process_family_h3s(
     missing_examples: &mut Vec<String>,
     wrong_kind_examples: &mut Vec<String>,
     documented: &std::collections::BTreeMap<String, Vec<examples::RenderedExample>>,
+    registry: &alint_core::RuleRegistry,
     released: Option<crate::rule_options_table::Version>,
 ) -> Result<()> {
     let mut kind_order: u32 = 0;
@@ -594,17 +595,21 @@ fn process_family_h3s(
         // is fine. Scan EVERY yaml block, not just the leading one: a documented
         // kind can keep a non-config recipe as its first block (git_commit_message
         // keeps a CI-workflow yaml), so a stale config re-added after it would sit
-        // in a later block. Match only against `documented` kind names, so an
-        // incidental `kind:` in a recipe can't false-fire. Atomic-swap (ADR-0014).
+        // in a later block. Match against `documented` kind names (which are
+        // canonical) after canonicalising each block kind, so a stale config using
+        // the ALIAS spelling (e.g. `kind: header` under a documented `file_header`)
+        // is caught too, and an incidental `kind:` in a recipe can't false-fire.
+        // Atomic-swap (ADR-0014).
         if let Some(ex_kind) = example_block_kinds(&h3.body)
             .into_iter()
-            .find(|k| documented.contains_key(k))
+            .find(|k| documented.contains_key(registry.canonical_kind(k)))
         {
             anyhow::bail!(
-                "docs/rules.md H3 '{}' documents `{ex_kind}` via a `docs:` scenario \
-                 but still contains a hand-written config example for it - remove the \
-                 hand-written block; the example now renders from the fixture.",
+                "docs/rules.md H3 '{}' documents `{}` via a `docs:` scenario but still \
+                 contains a hand-written config example (`kind: {ex_kind}`) for it - remove \
+                 the hand-written block; the example now renders from the fixture.",
                 h3.title,
+                registry.canonical_kind(&ex_kind),
             );
         }
         // The example must demonstrate the H3's CANONICAL kind, not an alias:

--- a/xtask/src/docs_export/examples.rs
+++ b/xtask/src/docs_export/examples.rs
@@ -13,6 +13,7 @@ use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use alint_core::RuleRegistry;
 use alint_testkit::{
     CommitSpec, DocsCase, DocsExample, GivenGit, Scenario, Step, TreeNode, TreeSpec, materialize,
     setup_git,
@@ -64,10 +65,16 @@ pub(crate) fn render_documented(
     } else {
         None
     };
+    let registry = alint_rules::builtin_registry();
     for (path, scenario, docs) in &documented {
-        let rendered = render_one(bin.as_deref(), scenario, docs)
+        let rendered = render_one(bin.as_deref(), &registry, scenario, docs)
             .with_context(|| format!("documented example {}", path.display()))?;
-        out.entry(docs.kind.clone()).or_default().push(rendered);
+        // Key by the CANONICAL kind: the page/H3 lookup and the double-example /
+        // page-target gates all use canonical names, so an alias-spelled
+        // `docs.kind` still lands its example on the canonical rule's page.
+        out.entry(registry.canonical_kind(&docs.kind).to_string())
+            .or_default()
+            .push(rendered);
     }
     for examples in out.values_mut() {
         examples.sort_by_key(|e| (matches!(e.case, DocsCase::Pass), e.order));
@@ -79,10 +86,11 @@ pub(crate) fn render_documented(
 /// render its markdown subsection.
 fn render_one(
     bin: Option<&Path>,
+    registry: &RuleRegistry,
     scenario: &Scenario,
     docs: &DocsExample,
 ) -> Result<RenderedExample> {
-    validate_documented(scenario, docs)?;
+    validate_documented(scenario, docs, registry)?;
     let output = match bin {
         Some(bin) => Some(run_and_capture(bin, scenario, docs)?),
         None => None,
@@ -103,9 +111,15 @@ fn render_one(
 /// Gate a documented scenario before it can back a page: hermetic config, a
 /// single `check` step so the `expect:` the `scenarios.rs` harness asserts
 /// matches the run the page renders, and exactly one top-level rule whose kind
-/// is the documented kind (so the label cannot lie). A git-rule example may
-/// carry a `given.git` block - the render drives it.
-fn validate_documented(scenario: &Scenario, docs: &DocsExample) -> Result<()> {
+/// is the documented kind (so the label cannot lie). The kind check is
+/// alias-aware: a config `kind: cross_file_value_equals` satisfies a
+/// `docs.kind: cross_file` page (both canonicalise to `cross_file`). A git-rule
+/// example may carry a `given.git` block - the render drives it.
+fn validate_documented(
+    scenario: &Scenario,
+    docs: &DocsExample,
+    registry: &RuleRegistry,
+) -> Result<()> {
     let config: serde_yaml_ng::Value = serde_yaml_ng::from_str(&scenario.given.config)
         .context("parsing the documented example config")?;
 
@@ -125,10 +139,13 @@ fn validate_documented(scenario: &Scenario, docs: &DocsExample) -> Result<()> {
 
     let kinds = config_rule_kinds(&config);
     match kinds.as_slice() {
-        [k] if *k == docs.kind => Ok(()),
+        [k] if registry.canonical_kind(k) == registry.canonical_kind(&docs.kind) => Ok(()),
         [k] => bail!(
-            "`docs.kind: {}` but the config's rule is `kind: {k}` - they must match",
-            docs.kind
+            "`docs.kind: {}` but the config's rule is `kind: {k}` - they must name the \
+             same rule; `{k}` canonicalises to `{}`, `docs.kind` to `{}`",
+            docs.kind,
+            registry.canonical_kind(k),
+            registry.canonical_kind(&docs.kind),
         ),
         _ => bail!(
             "a documented example's config must declare exactly one top-level rule \
@@ -436,6 +453,50 @@ mod tests {
         assert_eq!(fence_for("no backticks"), "```");
         assert_eq!(fence_for("a ``` b"), "````");
         assert_eq!(fence_for("```` deep"), "`````");
+    }
+
+    #[test]
+    fn validate_documented_matches_kinds_alias_aware() {
+        let registry = alint_rules::builtin_registry();
+        // `docs.kind: cross_file` (canonical) fed by a config that spells the
+        // rule as its alias `cross_file_value_equals`. The gate must accept it:
+        // both canonicalise to `cross_file`.
+        let yaml = |config_kind: &str| {
+            format!(
+                r#"name: t
+docs:
+  title: X
+  case: fail
+  kind: cross_file
+given:
+  tree:
+    a.txt: "x"
+  config: |
+    version: 1
+    rules:
+      - id: r
+        kind: {config_kind}
+when: [check]
+expect:
+  - violations: []
+"#
+            )
+        };
+
+        let aliased = Scenario::from_yaml(&yaml("cross_file_value_equals")).unwrap();
+        let docs = aliased.docs.clone().unwrap();
+        assert!(
+            validate_documented(&aliased, &docs, &registry).is_ok(),
+            "an alias-spelled config must satisfy its canonical page"
+        );
+
+        // A genuinely different rule is still rejected.
+        let mismatch = Scenario::from_yaml(&yaml("file_header")).unwrap();
+        let docs2 = mismatch.docs.clone().unwrap();
+        assert!(
+            validate_documented(&mismatch, &docs2, &registry).is_err(),
+            "a config naming a different rule must still fail the gate"
+        );
     }
 
     #[test]

--- a/xtask/src/facts.rs
+++ b/xtask/src/facts.rs
@@ -230,12 +230,18 @@ fn rule_source_files(root: &Path) -> Result<BTreeMap<String, String>> {
         .context("register_builtin closing brace not found")?;
     let body = &body[..end];
 
-    // `registry.register("<kind>", <module>::<builder>)` OR the
-    // `.register_optionless(…)` variant — kind is the string literal, the source
-    // stem is the module path segment before `::`. `\s` spans the newline in the
-    // multi-line register calls.
-    let re = Regex::new(r#"\.register(?:_optionless)?\(\s*"([A-Za-z0-9_]+)"\s*,\s*([a-z0-9_]+)::"#)
-        .expect("static regex compiles");
+    // `registry.register("<kind>", <module>::<builder>)`, its
+    // `.register_optionless(…)` variant, OR the alias forms
+    // `.register_alias("<alias>", "<canonical>", <module>::<builder>)` /
+    // `.register_alias_optionless(…)`. The captured kind is the FIRST string
+    // literal (the alias name, for the alias forms); the optional second string
+    // literal (the canonical) is skipped; the source stem is the builder's module
+    // segment before `::` (so an alias maps to its canonical rule's file). `\s`
+    // spans the newline in the multi-line register calls.
+    let re = Regex::new(
+        r#"\.register(?:_alias_optionless|_optionless|_alias)?\(\s*"([A-Za-z0-9_]+)"\s*,\s*(?:"[A-Za-z0-9_]+"\s*,\s*)?([a-z0-9_]+)::"#,
+    )
+    .expect("static regex compiles");
     let src_dir = root.join("crates/alint-rules/src");
     let mut map = BTreeMap::new();
     for cap in re.captures_iter(body) {


### PR DESCRIPTION
## Phase 3 prep (#90): canonical-alias handling as registry-backed single source of truth

Before Phase 3 (migrating the ~74 non-native kinds to executed docs fixtures), two gaps around rule-kind aliases:

1. **Docs gate false-fail.** The ADR-0014 gate (`validate_documented`) exact-matched `docs.kind` against the config's rule kind. That's fine for the content family (its scenarios already use canonical spellings), but **cross_file** is a live mismatch: its page is `docs.kind: cross_file` while the scenario declares the alias `kind: cross_file_value_equals` — the gate would bail.
2. **Four hardcoded alias maps.** `content_matches → file_content_matches` (×10) was duplicated across four coverage-audit files, and **all omitted** `cross_file_value_equals → cross_file` (masked only because both spellings happen to have their own scenarios).

### Approach — the registry is the single source of truth
- **`alint-core` `RuleRegistry`**: `register_alias` / `register_alias_optionless` record an alias→canonical mapping alongside the (unchanged) builder registration. `canonical_kind(name)` resolves an alias to its canonical; `canonical_kinds()` yields the non-alias set.
- **`register_builtin`**: the 11 aliases (10 short-name `file_*` forms + `is_text`, plus `cross_file_value_equals`) now register via `register_alias*`. A new test asserts every alias resolves to a known, non-alias canonical in one hop.
- **Docs gate**: compares `canonical_kind(config) == canonical_kind(docs.kind)`, and keys rendered examples by the canonical kind so an alias-spelled `docs.kind` still lands on the canonical page.
- **Coverage audits (×4)**: the hardcoded `ALIASES` consts + `canonical()` helpers are deleted in favour of `registry.canonical_kind()`/`canonical_kinds()` — which folds in the previously-missing `cross_file_value_equals` entry.
- **`facts.rs`**: `rule_source_files` parses the `register_alias*` forms too (an alias maps to its canonical rule's source file). `facts.json` is byte-identical.

### Verification
`fmt`, workspace `clippy -D warnings`, `rustdoc -D warnings`, `cargo test --workspace`, and `docs-export` / `gen-categories` / `gen-arch` `--check` all green locally. `gen-categories --check` reports "78 canonical kinds, 11 aliases" against rules.md + the registry.

No end-user behavior change: `build()` and `known_kinds()` are unchanged; this is internal consolidation + Phase 3 groundwork.
