### PR TITLE
fix(docs-bundle): render live alint check output on rule-page refreshes

### DIFF
--- a/.github/workflows/docs-bundle.yml
+++ b/.github/workflows/docs-bundle.yml
@@ -198,9 +198,15 @@ jobs:
           # hygiene and safe if the job ever moves to a persistent host.
           trap 'git worktree remove --force "$main_tree" >/dev/null 2>&1 || true; rm -rf "$main_tree"' EXIT
           # --rules-only: the bridge reads only rules/ below, so skip the rest of
-          # the export — most importantly the CLI-reference step's `cargo build
-          # --release -p alint`, which this second (cold) build would otherwise
-          # redo from scratch on top of the tag build above.
+          # the export (long-form prose, the CLI reference, arch diagrams, …).
+          # This DOES build the alint release binary once, from main: each rule
+          # page's `alint check` block is the live output of a real run, so a
+          # doc-only refresh deploys pages WITH their output rather than a
+          # stripped-down tree+config (ADR-0014 Phase 5 — the whole point of the
+          # #82 "deploy rule-page fixes without a release" bridge). What
+          # --rules-only still skips is the CLI-reference step's SECOND
+          # `cargo build --release -p alint`; this one build (~7 min, on top of
+          # the tag build above) is the price of faithful, current output.
           #
           # --released-version: this bridge runs MAIN's docs-export against MAIN's
           # schema/rules.md, so an option (schema `x-since`) or prose block

--- a/docs/design/v0.15/documented-example-fixtures.md
+++ b/docs/design/v0.15/documented-example-fixtures.md
@@ -161,8 +161,9 @@ Two structural points the review surfaced:
   (~line 171) - where both the output-capture and the upgraded gate now live. So
   "as it already does for `--help`" hides an ordering change: Phase 1 must **hoist
   `build_release_binary()` above `generate_rules_pages`** and thread the path into
-  the emit path and the gate. (The `--rules-only` mode has no binary at all - the
-  same root as the Phase-5 bridge conflict.)
+  the emit path and the gate. (The `--rules-only` mode originally built no binary
+  at all - the same root as the Phase-5 bridge conflict, now resolved in #98 by
+  having that mode capture output too.)
 - **The shared setup helper is the tree + git, not the config.** Extract a shared
   `materialize(tree, root)` (already exists) and a `setup_git(root, spec)` helper
   that `run_scenario` and docs-export both call. The runner writes `.alint.yml`
@@ -457,14 +458,17 @@ Once all seven fixtures fire natively, `NATIVE_FIRES_ALLOWLIST` is deleted and
   `probed` floors are already lowered per-family, so only the final scoping
   remains.
 - **Phase 5 - alint.org presentation.** An Astro component renders the blocks
-  consistently. **Resolve the `--rules-only` bridge conflict** (it binds once the
-  pilot injects real output): the docs-bundle bridge runs `docs-export --rules-only`
-  to skip the release build, but the output block needs a real `alint check` spawn.
-  Recommended: the bridge builds the binary + takes `alint-testkit` in its
-  worktree (undoing the `--rules-only` speed optimisation but preserving the #82
-  "deploy rule-page fixes without a release" contract for the output block); the
-  alternative skips output-injection under `--rules-only` and ships that block only
-  via a release-tag export. Tree + config blocks deploy via the bridge regardless.
+  consistently. **The `--rules-only` bridge conflict is resolved (#98):** the
+  docs-bundle bridge still runs `docs-export --rules-only` to skip the rest of the
+  export, but that mode now passes `capture_output: true`, so it builds the alint
+  release binary once and each rule page's output block renders from a real
+  `alint check` spawn (the recommended option). `alint-testkit` is already a
+  workspace member, so the origin/main worktree the bridge builds in has it. The
+  `--rules-only` speed optimisation is undone for the examples' one build only; the
+  CLI-reference step's *second* release build stays skipped. This keeps the #82
+  "deploy rule-page fixes without a release" contract intact for the output block:
+  a doc-only refresh deploys pages whose `alint check` output is byte-identical to
+  a full release-tag export (verified by diffing the two `rules/` subtrees).
 
 ## Determinism and cost
 
@@ -512,8 +516,11 @@ Once all seven fixtures fire natively, `NATIVE_FIRES_ALLOWLIST` is deleted and
 1. **Output-block length** - some kinds emit verbose output; decide full stdout vs
    a bounded, elided form (leaning: full, since a minimal fixture's output is
    short and real).
-2. **`--rules-only` bridge** - confirm the recommended "build the binary in the
-   bridge worktree" option against the docs-bundle build-time budget (Phase 5).
+2. **`--rules-only` bridge** - RESOLVED (#98): the recommended "build the binary in
+   the bridge worktree" option shipped. The bridge accepts one ~7 min release build
+   from the origin/main worktree (on top of the tag build) as the cost of faithful,
+   current output; measured against the docs-bundle budget it is acceptable for a
+   background workflow that gates no merges.
 3. **`.gitignore` in a documented tree** - a `given.tree` may include a
    `.gitignore`, which the run respects (as a real repo would), so the shown tree
    can list files alint skips. Leaning: allow it but prefer trees without one

--- a/xtask/src/docs_export.rs
+++ b/xtask/src/docs_export.rs
@@ -86,6 +86,15 @@ fn copy_c4_model(workspace: &Path, target_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Whether the per-rule reference pages render each documented example's live
+/// `alint check` output (ADR-0014 Phase 5). The full export and the
+/// `--rules-only` docs-bundle bridge MUST pass the same value: a doc-only
+/// refresh has to deploy pages byte-identical to a release-tag export, so the
+/// bridge cannot omit the output a release build would emit. `--check` exercises
+/// only the full path, so it would not catch the two call sites diverging — a
+/// single source of truth keeps them from silently drifting.
+const RULE_PAGES_CAPTURE_OUTPUT: bool = true;
+
 pub(crate) fn docs_export(
     out: Option<PathBuf>,
     check: bool,
@@ -127,13 +136,13 @@ pub(crate) fn docs_export(
         // The docs-bundle rule-page bridge overlays ONLY the per-rule reference
         // pages from main, so generate just those and skip the rest of the
         // export (`copy_site_tree`, `generate_cli_reference`, the arch diagrams,
-        // …). We pass `capture_output: true`: each rule page's `alint check`
-        // block renders from a real run of the freshly built binary, so a
-        // doc-only refresh deploys pages WITH their live output — not a
-        // stripped-down tree+config (ADR-0014 Phase 5). That costs one release
-        // build; the redundant *second* build --rules-only still avoids is
-        // `generate_cli_reference`'s (the bridge never reads the CLI reference).
-        generate_rules_pages(&workspace, &target_dir, released, true)?;
+        // …). It still passes RULE_PAGES_CAPTURE_OUTPUT, so each rule page's
+        // `alint check` block renders from a real run of the freshly built
+        // binary and a doc-only refresh deploys exactly what a release export
+        // would — not a stripped-down tree+config (ADR-0014 Phase 5). One
+        // release build is the cost; what --rules-only still saves is
+        // `generate_cli_reference`'s SECOND build, which the bridge never reads.
+        generate_rules_pages(&workspace, &target_dir, released, RULE_PAGES_CAPTURE_OUTPUT)?;
         eprintln!(
             "[xtask] docs-export --rules-only wrote {}/rules",
             target_dir.display()
@@ -172,7 +181,8 @@ pub(crate) fn docs_export(
     // overviews and a master alphabetical index. Returns a
     // kind → family-slug map used below to render kind names
     // as links from the bundled-ruleset pages.
-    let kind_to_family = generate_rules_pages(&workspace, &target_dir, released, true)?;
+    let kind_to_family =
+        generate_rules_pages(&workspace, &target_dir, released, RULE_PAGES_CAPTURE_OUTPUT)?;
 
     // 3. Per-bundled-ruleset reference page. `kind_to_family`
     //    drives the cross-links from `**kind**: <name>` →

--- a/xtask/src/docs_export.rs
+++ b/xtask/src/docs_export.rs
@@ -124,12 +124,16 @@ pub(crate) fn docs_export(
     eprintln!("[xtask] docs-export → {}", target_dir.display());
 
     if rules_only {
-        // The docs-bundle rule-page bridge overlays ONLY the per-rule
-        // reference pages from main, so generate just those and skip the rest
-        // of the export — most importantly step 5 (`generate_cli_reference`),
-        // which builds the alint release binary. That redundant build is the
-        // bulk of the bridge's cost, and the bridge never reads its output.
-        generate_rules_pages(&workspace, &target_dir, released, false)?;
+        // The docs-bundle rule-page bridge overlays ONLY the per-rule reference
+        // pages from main, so generate just those and skip the rest of the
+        // export (`copy_site_tree`, `generate_cli_reference`, the arch diagrams,
+        // …). We pass `capture_output: true`: each rule page's `alint check`
+        // block renders from a real run of the freshly built binary, so a
+        // doc-only refresh deploys pages WITH their live output — not a
+        // stripped-down tree+config (ADR-0014 Phase 5). That costs one release
+        // build; the redundant *second* build --rules-only still avoids is
+        // `generate_cli_reference`'s (the bridge never reads the CLI reference).
+        generate_rules_pages(&workspace, &target_dir, released, true)?;
         eprintln!(
             "[xtask] docs-export --rules-only wrote {}/rules",
             target_dir.display()

--- a/xtask/src/docs_export/examples.rs
+++ b/xtask/src/docs_export/examples.rs
@@ -33,11 +33,11 @@ pub(crate) struct RenderedExample {
 /// (fail before pass, then by `order`). An empty map means no kind has opted
 /// in yet, so nothing is rendered and the legacy hand-written examples stand.
 ///
-/// `capture_output` controls whether the live `alint check` run is captured:
-/// the full export passes `true`; the `--rules-only` docs-bundle bridge passes
-/// `false` so it renders tree + config only and never cold-builds the release
-/// binary (the cost `--rules-only` exists to avoid). Validation gates run in
-/// both modes.
+/// `capture_output` controls whether the live `alint check` run is captured.
+/// Both the full export and the `--rules-only` docs-bundle bridge pass `true`,
+/// so a doc-only refresh still renders each page's `alint check` output block
+/// from a real run (ADR-0014 Phase 5). Passing `false` renders tree + config
+/// only, skipping the release build. Validation gates run in either mode.
 pub(crate) fn render_documented(
     workspace: &Path,
     capture_output: bool,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -237,10 +237,11 @@ enum Commands {
         #[arg(long)]
         check: bool,
         /// Generate ONLY the per-rule reference pages (`rules/`), skipping the
-        /// rest of the bundle — most importantly the CLI-reference step, which
-        /// builds the alint release binary. Used by the docs-bundle rule-page
-        /// bridge, which overlays only those pages from main; the redundant
-        /// release build was the bulk of that bridge's cost.
+        /// rest of the bundle (long-form prose, the CLI reference, arch
+        /// diagrams, …). Used by the docs-bundle rule-page bridge, which
+        /// overlays only those pages from main. Still builds the release binary
+        /// once so each page's live `alint check` output renders from a real
+        /// run; what it skips is the CLI-reference step's *second* release build.
         #[arg(long)]
         rules_only: bool,
         /// The released version the per-rule reference pages must not document


### PR DESCRIPTION
## What

Make the docs-bundle **rule-page bridge** render each page's live `alint check` output block, closing the last gap in ADR-0014 (executed-fixture examples).

Closes #98.

## Why

The docs-bundle bridge refreshes a release's per-rule pages from `origin/main` via `docs-export --rules-only`, so a doc-only fix (a corrected example, the structured-query lead-kind ordering) reaches alint.org **without cutting a release** (the #82 contract).

But `--rules-only` passed `capture_output: false` to skip the release build. Once ADR-0014 started rendering a real `alint check` output block into every rule page, that made the bridge **strip the output block on every doc-only deploy** — the refreshed page carried only the tree + config blocks, silently a full export behind the released page.

## How

Flip the `--rules-only` branch to `capture_output: true`:

- It now builds the alint release binary **once**, from the `origin/main` worktree (which already carries `alint-testkit` as a workspace member), so every rule page's output block renders from a real run.
- It still skips the rest of the export — most importantly the CLI-reference step's **second** release build, which is what `--rules-only` exists to avoid.
- Net cost: one ~7 min release build on top of the tag build. Acceptable for a background workflow that gates no merges (design doc "Determinism and cost").

This is the design doc's recommended resolution of the "`--rules-only` bridge conflict" (`docs/design/v0.15/documented-example-fixtures.md`, Phase 5), which is updated to mark it resolved.

## Verification

- `docs-export --rules-only` → **78/78** canonical rule pages carry a ```ansi``` output block (the 14 pages without are category `index.md` files, which have no example — correct).
- The refreshed `rules/` subtree is **byte-identical** to a full release-tag export (`diff -rq` of the two `rules/` trees: identical).
- Confirmed in the bridge's exact invocation shape (`--rules-only --released-version 0.14.2`): output still renders; `--released-version` gating (Options rows / since-blocks) is orthogonal to output capture.
- `cargo fmt --check`, `cargo clippy -p xtask --all-targets -- -D warnings`, `cargo test -p xtask` (118), `cargo test -p alint-e2e --test coverage_audit_doc_examples` (3): all green.
- Self-lint clean apart from the pre-existing `rust-file-max-lines` warning on `docs_export.rs` (main is already 2263 > 2000; this PR adds 4 comment lines).
