### PR TITLE
feat(scope_filter): manifest-derived rule scope (ADR-0010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   dispatched against the `--changed` filtered index matched nothing (a silent
   false negative); the resolved diff is now copied onto the filtered index, the
   same way the manifest path sets are.
+- `scope_filter` now applies on rule kinds dispatched in the rule-major partition
+  (`filename_case`, `filename_regex`, `file_max_size`, `file_min_size`,
+  `executable_bit`, `no_empty_files`, `json_schema_passes`, and others), not only
+  per-file content rules. Those kinds applied their scope per file but didn't
+  expose it for the engine to pre-resolve, and the scope caches were resolved
+  after the rule-major dispatch — so a `changed_since:` predicate silently
+  matched nothing on them (affected since v0.11). A per-file rule that applies a
+  scope now exposes it (also enabling `--changed` to skip it), and the scope
+  caches resolve before every dispatch path.
 - Diagnostic warnings now write to stderr, never stdout, so a `warn!` (such as an
   empty `include_manifest_paths` set) no longer corrupts the machine-readable
   `--format json` / SARIF output that consumers read from stdout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   completes the explain output: id, kind, categories, level, paths, options,
   message, policy_url, when, and fix.
 
+### Fixed
+
+- Diagnostic warnings now write to stderr, never stdout, so a `warn!` (such as an
+  empty `include_manifest_paths` set) no longer corrupts the machine-readable
+  `--format json` / SARIF output that consumers read from stdout.
+
 ## [0.14.2] - 2026-08-06
 
 A fixes-and-hardening patch on top of 0.14.1. The `hygiene-no-macos-junk`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `scope_filter:` gains `include_manifest_paths:` / `exclude_manifest_paths:`
+  (ADR-0010): scope a per-file rule by membership in a path set a manifest
+  declares, instead of a hand-maintained `paths.exclude` that drifts from the
+  manifest that owns the truth. Each takes a `source:` manifest, the shared
+  `{json|toml|yaml|lines|regex}` `extract:`, and an optional
+  `derive_target: {from, to}` that maps a declared build output (`package.json`
+  `bin`'s `dist/cli.js`) back to source (`src/cli.ts`). Membership is
+  directory-aware (a declared `workspace.members` entry scopes a rule to files
+  under it); the set resolves once per run; a manifest value gates which files a
+  rule sees, never what it decides about a file. `alint explain` prints the
+  resolved set.
 - `alint explain <rule>` now shows a one-line `summary:` of what the rule's KIND
   checks, plus a `docs:` deep link to the full reference. Both are compiled into
   the binary from `docs/rules.md` (so they work offline); `--no-docs` suppresses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- `scope_filter.changed_since:` now resolves under `--changed` / `--base`. Its
+  per-rule diff set was cached only on the full index, so a `changed_since` rule
+  dispatched against the `--changed` filtered index matched nothing (a silent
+  false negative); the resolved diff is now copied onto the filtered index, the
+  same way the manifest path sets are.
 - Diagnostic warnings now write to stderr, never stdout, so a `warn!` (such as an
   empty `include_manifest_paths` set) no longer corrupts the machine-readable
   `--format json` / SARIF output that consumers read from stdout.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,14 +90,19 @@ version = "0.14.2"
 dependencies = [
  "globset",
  "ignore",
+ "proptest",
  "rayon",
  "regex",
+ "roxmltree",
+ "schemars",
  "serde",
  "serde_json",
+ "serde_json_path",
  "serde_yaml_ng",
  "sha2",
  "tempfile",
  "thiserror 2.0.19",
+ "toml",
  "tracing",
 ]
 

--- a/crates/alint-core/Cargo.toml
+++ b/crates/alint-core/Cargo.toml
@@ -23,9 +23,17 @@ ignore.workspace = true
 rayon.workspace = true
 regex.workspace = true
 tracing.workspace = true
+# Structured-document extract machinery hoisted from alint-rules:
+# TOML/XML/JSONPath parsing behind `Format`/`ExtractSpec`, whose
+# schemars derives feed `xtask gen-schema`.
+schemars.workspace = true
+serde_json_path.workspace = true
+toml.workspace = true
+roxmltree.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+proptest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/alint-core/src/engine.rs
+++ b/crates/alint-core/src/engine.rs
@@ -458,7 +458,17 @@ impl Engine {
         // Resolve `scope_filter.changed_since:` diffs once, before the
         // per-file dispatch reads the per-file `Scope::matches` cache.
         self.resolve_changed_paths(root, index)?;
+        // Resolve manifest path sets against the FULL index (so the manifest
+        // itself is reachable even when it didn't change), then copy the result
+        // onto the `--changed` filtered index that per-file dispatch actually
+        // matches against — otherwise an `include`/`exclude` manifest predicate
+        // silently sees an empty set under `--changed`.
         self.resolve_manifest_paths(root, index);
+        if let Some(fi) = &filtered_index
+            && let Some(map) = index.manifest_paths_map()
+        {
+            fi.set_manifest_paths(map.clone());
+        }
 
         // Per-file partition: file-major loop reads each file
         // once and dispatches to every per-file rule whose scope
@@ -890,6 +900,13 @@ impl Engine {
         // fix pass respects per-rule diff scoping too.
         self.resolve_changed_paths(root, index)?;
         self.resolve_manifest_paths(root, index);
+        // Propagate the manifest sets onto the `--changed` filtered index (see
+        // `run`), so `fix --changed` scopes excluded files out of the fix too.
+        if let Some(fi) = &filtered_index
+            && let Some(map) = index.manifest_paths_map()
+        {
+            fi.set_manifest_paths(map.clone());
+        }
 
         let mut results: Vec<FixRuleResult> = Vec::new();
         for entry in &self.entries {
@@ -1215,15 +1232,28 @@ impl Engine {
         }
         let mut map = std::collections::HashMap::new();
         for (key, pred) in preds {
-            let manifest = root.join(pred.source());
-            let set = match std::fs::read_to_string(&manifest) {
-                Ok(text) => pred.resolve_set(&text),
-                Err(_) => std::collections::HashSet::new(),
+            // Read the manifest through the walked index, not a raw path read:
+            // `find_file` returns None for a source that is absent OR an escaping
+            // symlink the walk pruned (ADR-0004 confinement) — so a symlinked
+            // `source` can't read out-of-tree bytes. `read_capped_or_skip` bounds
+            // the read with the walk-time size (a huge / device manifest is
+            // skipped, not slurped), matching how `registry_paths_resolve` /
+            // `file_graph` read their extract sources. Either way -> empty set,
+            // and the predicate contributes nothing.
+            let set = match index.find_file(pred.source()) {
+                Some(entry) => {
+                    match crate::walker::read_capped_or_skip(&root.join(&entry.path), entry.size) {
+                        Some(bytes) => pred.resolve_set(&String::from_utf8_lossy(&bytes)),
+                        None => std::collections::HashSet::new(),
+                    }
+                }
+                None => std::collections::HashSet::new(),
             };
             if set.is_empty() && pred.warns_on_empty() {
                 tracing::warn!(
-                    "scope_filter.include_manifest_paths: `{}` extracted no paths, so the rule \
-                     matches nothing. Set `expect_nonempty: false` if that is intended.",
+                    "scope_filter.include_manifest_paths: `{}` resolved to no paths (the manifest \
+                     is missing, unreadable, or declares none), so the rule matches nothing. Set \
+                     `expect_nonempty: false` if that is intended.",
                     pred.source().display()
                 );
             }

--- a/crates/alint-core/src/engine.rs
+++ b/crates/alint-core/src/engine.rs
@@ -286,6 +286,7 @@ impl Engine {
     #[allow(clippy::too_many_lines)]
     pub fn run(&self, root: &Path, index: &FileIndex) -> Result<Report> {
         let t_total = Instant::now();
+        self.ensure_manifest_scope_resolvable()?;
         // Empty changed-set fast path: nothing to lint, return
         // an empty report rather than walk the entries list at
         // all. Saves the fact-evaluation pass too.
@@ -368,6 +369,36 @@ impl Engine {
             iter: None,
             env: None,
         };
+
+        // Resolve `scope_filter.changed_since:` diffs + manifest path sets ONCE,
+        // before ANY dispatch. BOTH the cross-file/rule-major partition below and
+        // the per-file partition read these caches via `Scope::matches` — a
+        // non-per-file rule (e.g. `filename_case`) dispatches in the rule-major
+        // loop, so resolving *after* it silently emptied its manifest/diff scope.
+        // Resolve against the FULL index (so the manifest is reachable even when
+        // unchanged), then copy the maps onto every alternate index a context may
+        // dispatch against (the `--changed` filtered index and the git-tracked
+        // file-only / dir-aware indexes) — each is a fresh FileIndex with empty
+        // caches, and the declared set is independent of which files it holds.
+        self.resolve_changed_paths(root, index)?;
+        self.resolve_manifest_paths(root, index);
+        let alt_indexes = [
+            filtered_index.as_ref(),
+            git_tracked_indexes
+                .as_ref()
+                .and_then(|g| g.file_only.as_ref()),
+            git_tracked_indexes
+                .as_ref()
+                .and_then(|g| g.dir_aware.as_ref()),
+        ];
+        for fi in alt_indexes.into_iter().flatten() {
+            if let Some(map) = index.manifest_paths_map() {
+                fi.set_manifest_paths(map.clone());
+            }
+            if let Some(map) = index.changed_paths_map() {
+                fi.set_changed_paths(map.clone());
+            }
+        }
 
         // Per-rule wall-time accumulator for the cross-file
         // partition. One AtomicU64 per entry, indexed by
@@ -455,26 +486,9 @@ impl Engine {
             }
         }
 
-        // Resolve `scope_filter.changed_since:` diffs once, before the
-        // per-file dispatch reads the per-file `Scope::matches` cache.
-        self.resolve_changed_paths(root, index)?;
-        // Resolve manifest path sets against the FULL index (so the manifest
-        // itself is reachable even when it didn't change).
-        self.resolve_manifest_paths(root, index);
-        // Copy BOTH resolved caches onto the `--changed` filtered index that
-        // per-file dispatch actually matches against: the manifest sets AND the
-        // `changed_since:` diffs. The filtered index is rebuilt from the changed
-        // files with fresh caches, so without the copy an `include`/`exclude`
-        // manifest predicate — or a `scope_filter.changed_since:` — silently sees
-        // an empty set under `--changed`.
-        if let Some(fi) = &filtered_index {
-            if let Some(map) = index.manifest_paths_map() {
-                fi.set_manifest_paths(map.clone());
-            }
-            if let Some(map) = index.changed_paths_map() {
-                fi.set_changed_paths(map.clone());
-            }
-        }
+        // (`scope_filter.changed_since:` diffs + manifest path sets were resolved
+        // and propagated to every index before the cross-file partition above, so
+        // both partitions see a populated `Scope::matches` cache.)
 
         // Per-file partition: file-major loop reads each file
         // once and dispatches to every per-file rule whose scope
@@ -834,6 +848,7 @@ impl Engine {
     /// result, same as [`Engine::run`]'s usual behaviour.
     #[allow(clippy::too_many_lines)]
     pub fn fix(&self, root: &Path, index: &FileIndex, dry_run: bool) -> Result<FixReport> {
+        self.ensure_manifest_scope_resolvable()?;
         if self.changed_paths.as_ref().is_some_and(HashSet::is_empty) {
             return Ok(FixReport {
                 results: Vec::new(),
@@ -906,9 +921,20 @@ impl Engine {
         // fix pass respects per-rule diff scoping too.
         self.resolve_changed_paths(root, index)?;
         self.resolve_manifest_paths(root, index);
-        // Propagate BOTH resolved caches onto the `--changed` filtered index (see
-        // `run`), so `fix --changed` respects manifest scope AND `changed_since:`.
-        if let Some(fi) = &filtered_index {
+        // Propagate BOTH resolved caches onto every alternate index the fix loop
+        // may `pick_ctx` (see `run`): the `--changed` filtered index and the
+        // git-tracked file-only / dir-aware indexes, so `fix` respects manifest
+        // scope AND `changed_since:` on every dispatch path.
+        let alt_indexes = [
+            filtered_index.as_ref(),
+            git_tracked_indexes
+                .as_ref()
+                .and_then(|g| g.file_only.as_ref()),
+            git_tracked_indexes
+                .as_ref()
+                .and_then(|g| g.dir_aware.as_ref()),
+        ];
+        for fi in alt_indexes.into_iter().flatten() {
             if let Some(map) = index.manifest_paths_map() {
                 fi.set_manifest_paths(map.clone());
             }
@@ -1214,6 +1240,34 @@ impl Engine {
     /// `include_manifest_paths:` predicate that expects one is warned about (an
     /// empty include would otherwise silently no-op the whole rule). Reads are
     /// confined to the repo root; `source` was confined at build time.
+    /// Fail loud if a rule declares a manifest-derived scope (`include`/
+    /// `exclude_manifest_paths`) but exposes no scope for the engine to resolve
+    /// (`as_per_file` and `path_scope` both `None`). Without this the predicate
+    /// silently no-ops: the resolver never discovers it, so its cache stays empty
+    /// and `Scope::matches` reads the empty set (include matches nothing, exclude
+    /// excludes nothing) — the exact silent-no-op class fuzzing found on rule
+    /// kinds that apply a scope but forgot to expose it (see `Rule::path_scope`).
+    fn ensure_manifest_scope_resolvable(&self) -> Result<()> {
+        for entry in &self.entries {
+            let Some(sf) = entry.scope_filter() else {
+                continue;
+            };
+            if sf.include_manifest_paths.is_none() && sf.exclude_manifest_paths.is_none() {
+                continue;
+            }
+            if entry.rule.as_per_file().is_none() && entry.rule.path_scope().is_none() {
+                return Err(Error::rule_config(
+                    entry.rule.id(),
+                    "this rule kind does not support `scope_filter.include_manifest_paths` / \
+                     `exclude_manifest_paths`: it exposes no per-file scope for the engine to \
+                     resolve, so the manifest set would silently never apply"
+                        .to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
     fn resolve_manifest_paths(&self, root: &Path, index: &FileIndex) {
         if index.manifest_paths_initialized() {
             return;
@@ -1247,24 +1301,21 @@ impl Engine {
         let mut map = std::collections::HashMap::new();
         for (key, group) in groups {
             // Every predicate in the group shares one `(source, extract,
-            // derive_target)`, so any member resolves the same set. Read it
-            // through the walked index, not a raw path read: `find_file` returns
-            // None for a source that is absent OR an escaping symlink the walk
-            // pruned (ADR-0004 confinement) — so a symlinked `source` can't read
-            // out-of-tree bytes. `read_capped_or_skip` bounds the read with the
-            // walk-time size (a huge / device manifest is skipped, not slurped),
-            // matching how `registry_paths_resolve` / `file_graph` read their
-            // extract sources. Either way -> empty set, contributing nothing.
+            // derive_target)`, so any member resolves the same set. Read the
+            // manifest with the same confined direct read `explain` uses
+            // (`read_manifest_confined`: canonicalize-confined + is_file +
+            // size-capped), NOT through the walked index: `find_file` also honors
+            // `.gitignore`, so a gitignored manifest would resolve to the empty
+            // set here while `explain` (a direct read) showed a non-empty set — a
+            // legibility split undercutting ADR-0010's "explain shows the resolved
+            // set". A direct confined read matches `registry_paths_resolve` /
+            // `file_graph`, which read their sources via `read_capped(root.join())`
+            // regardless of the walk. Absent / oversized / escaping -> empty set.
             let rep = group[0];
-            let set = match index.find_file(rep.source()) {
-                Some(entry) => {
-                    match crate::walker::read_capped_or_skip(&root.join(&entry.path), entry.size) {
-                        Some(bytes) => rep.resolve_set(&String::from_utf8_lossy(&bytes)),
-                        None => std::collections::HashSet::new(),
-                    }
-                }
-                None => std::collections::HashSet::new(),
-            };
+            let set = rep.resolve_set(&crate::scope_filter::read_manifest_confined(
+                root,
+                rep.source(),
+            ));
             // Warn per group, not per first-iterated predicate: an `include` that
             // expects a non-empty set must be flagged even when an `exclude`
             // sharing the manifest sorted first (the empty-include silent no-op is

--- a/crates/alint-core/src/engine.rs
+++ b/crates/alint-core/src/engine.rs
@@ -459,15 +459,21 @@ impl Engine {
         // per-file dispatch reads the per-file `Scope::matches` cache.
         self.resolve_changed_paths(root, index)?;
         // Resolve manifest path sets against the FULL index (so the manifest
-        // itself is reachable even when it didn't change), then copy the result
-        // onto the `--changed` filtered index that per-file dispatch actually
-        // matches against — otherwise an `include`/`exclude` manifest predicate
-        // silently sees an empty set under `--changed`.
+        // itself is reachable even when it didn't change).
         self.resolve_manifest_paths(root, index);
-        if let Some(fi) = &filtered_index
-            && let Some(map) = index.manifest_paths_map()
-        {
-            fi.set_manifest_paths(map.clone());
+        // Copy BOTH resolved caches onto the `--changed` filtered index that
+        // per-file dispatch actually matches against: the manifest sets AND the
+        // `changed_since:` diffs. The filtered index is rebuilt from the changed
+        // files with fresh caches, so without the copy an `include`/`exclude`
+        // manifest predicate — or a `scope_filter.changed_since:` — silently sees
+        // an empty set under `--changed`.
+        if let Some(fi) = &filtered_index {
+            if let Some(map) = index.manifest_paths_map() {
+                fi.set_manifest_paths(map.clone());
+            }
+            if let Some(map) = index.changed_paths_map() {
+                fi.set_changed_paths(map.clone());
+            }
         }
 
         // Per-file partition: file-major loop reads each file
@@ -900,12 +906,15 @@ impl Engine {
         // fix pass respects per-rule diff scoping too.
         self.resolve_changed_paths(root, index)?;
         self.resolve_manifest_paths(root, index);
-        // Propagate the manifest sets onto the `--changed` filtered index (see
-        // `run`), so `fix --changed` scopes excluded files out of the fix too.
-        if let Some(fi) = &filtered_index
-            && let Some(map) = index.manifest_paths_map()
-        {
-            fi.set_manifest_paths(map.clone());
+        // Propagate BOTH resolved caches onto the `--changed` filtered index (see
+        // `run`), so `fix --changed` respects manifest scope AND `changed_since:`.
+        if let Some(fi) = &filtered_index {
+            if let Some(map) = index.manifest_paths_map() {
+                fi.set_manifest_paths(map.clone());
+            }
+            if let Some(map) = index.changed_paths_map() {
+                fi.set_changed_paths(map.clone());
+            }
         }
 
         let mut results: Vec<FixRuleResult> = Vec::new();
@@ -1209,10 +1218,15 @@ impl Engine {
         if index.manifest_paths_initialized() {
             return;
         }
-        // Dedup by cache key: identical configs resolve once. BTreeMap keeps the
-        // resolution order deterministic (ADR-0003).
-        let mut preds: std::collections::BTreeMap<&str, &crate::scope_filter::ManifestPredicate> =
-            std::collections::BTreeMap::new();
+        // Group predicates by cache key: rules sharing a `(source, extract,
+        // derive_target)` config resolve once. BTreeMap keeps the resolution
+        // order deterministic (ADR-0003). The key deliberately omits `sense` /
+        // `expect_nonempty` (the resolved SET doesn't depend on them), so a group
+        // can mix `include` and `exclude` predicates over the same manifest.
+        let mut groups: std::collections::BTreeMap<
+            &str,
+            Vec<&crate::scope_filter::ManifestPredicate>,
+        > = std::collections::BTreeMap::new();
         for entry in &self.entries {
             let scope = entry
                 .rule
@@ -1223,38 +1237,44 @@ impl Engine {
                 && let Some(filter) = scope.scope_filter()
             {
                 for pred in filter.manifest_predicates() {
-                    preds.entry(pred.cache_key()).or_insert(pred);
+                    groups.entry(pred.cache_key()).or_default().push(pred);
                 }
             }
         }
-        if preds.is_empty() {
+        if groups.is_empty() {
             return;
         }
         let mut map = std::collections::HashMap::new();
-        for (key, pred) in preds {
-            // Read the manifest through the walked index, not a raw path read:
-            // `find_file` returns None for a source that is absent OR an escaping
-            // symlink the walk pruned (ADR-0004 confinement) — so a symlinked
-            // `source` can't read out-of-tree bytes. `read_capped_or_skip` bounds
-            // the read with the walk-time size (a huge / device manifest is
-            // skipped, not slurped), matching how `registry_paths_resolve` /
-            // `file_graph` read their extract sources. Either way -> empty set,
-            // and the predicate contributes nothing.
-            let set = match index.find_file(pred.source()) {
+        for (key, group) in groups {
+            // Every predicate in the group shares one `(source, extract,
+            // derive_target)`, so any member resolves the same set. Read it
+            // through the walked index, not a raw path read: `find_file` returns
+            // None for a source that is absent OR an escaping symlink the walk
+            // pruned (ADR-0004 confinement) — so a symlinked `source` can't read
+            // out-of-tree bytes. `read_capped_or_skip` bounds the read with the
+            // walk-time size (a huge / device manifest is skipped, not slurped),
+            // matching how `registry_paths_resolve` / `file_graph` read their
+            // extract sources. Either way -> empty set, contributing nothing.
+            let rep = group[0];
+            let set = match index.find_file(rep.source()) {
                 Some(entry) => {
                     match crate::walker::read_capped_or_skip(&root.join(&entry.path), entry.size) {
-                        Some(bytes) => pred.resolve_set(&String::from_utf8_lossy(&bytes)),
+                        Some(bytes) => rep.resolve_set(&String::from_utf8_lossy(&bytes)),
                         None => std::collections::HashSet::new(),
                     }
                 }
                 None => std::collections::HashSet::new(),
             };
-            if set.is_empty() && pred.warns_on_empty() {
+            // Warn per group, not per first-iterated predicate: an `include` that
+            // expects a non-empty set must be flagged even when an `exclude`
+            // sharing the manifest sorted first (the empty-include silent no-op is
+            // exactly the footgun `expect_nonempty` guards).
+            if set.is_empty() && group.iter().any(|p| p.warns_on_empty()) {
                 tracing::warn!(
                     "scope_filter.include_manifest_paths: `{}` resolved to no paths (the manifest \
                      is missing, unreadable, or declares none), so the rule matches nothing. Set \
                      `expect_nonempty: false` if that is intended.",
-                    pred.source().display()
+                    rep.source().display()
                 );
             }
             map.insert(key.to_string(), set);

--- a/crates/alint-core/src/engine.rs
+++ b/crates/alint-core/src/engine.rs
@@ -141,6 +141,13 @@ impl RuleEntry {
         self.spec.as_ref().and_then(|s| s.paths.as_ref())
     }
 
+    /// The rule's `scope_filter:` config, if set — for `alint explain` to render
+    /// the manifest / diff / ancestor gates the `paths:` glob alone doesn't show.
+    #[must_use]
+    pub fn scope_filter(&self) -> Option<&crate::ScopeFilterSpec> {
+        self.spec.as_ref().and_then(|s| s.scope_filter.as_ref())
+    }
+
     /// The rule's custom `message:`, if set (see [`RuleEntry::spec`]).
     #[must_use]
     pub fn message(&self) -> Option<&str> {

--- a/crates/alint-core/src/engine.rs
+++ b/crates/alint-core/src/engine.rs
@@ -451,6 +451,7 @@ impl Engine {
         // Resolve `scope_filter.changed_since:` diffs once, before the
         // per-file dispatch reads the per-file `Scope::matches` cache.
         self.resolve_changed_paths(root, index)?;
+        self.resolve_manifest_paths(root, index);
 
         // Per-file partition: file-major loop reads each file
         // once and dispatches to every per-file rule whose scope
@@ -730,6 +731,7 @@ impl Engine {
         // Per-file rules may carry `scope_filter.changed_since:`; resolve
         // (and cache) the diff before any `Scope::matches` reads it.
         self.resolve_changed_paths(root, index)?;
+        self.resolve_manifest_paths(root, index);
 
         let ctx = Context {
             root,
@@ -880,6 +882,7 @@ impl Engine {
         // Same `scope_filter.changed_since:` resolution as `run`, so a
         // fix pass respects per-rule diff scoping too.
         self.resolve_changed_paths(root, index)?;
+        self.resolve_manifest_paths(root, index);
 
         let mut results: Vec<FixRuleResult> = Vec::new();
         for entry in &self.entries {
@@ -1167,6 +1170,59 @@ impl Engine {
         }
         index.set_changed_paths(map);
         Ok(())
+    }
+
+    /// Resolve every per-file rule's manifest-derived path set once per run and
+    /// cache them on the index, mirroring [`resolve_changed_paths`](Self::resolve_changed_paths).
+    /// Keyed by each predicate's cache key, so rules sharing a `(source,
+    /// extract, derive_target)` config resolve once. A manifest that is absent /
+    /// unreadable yields the empty set (the predicate contributes nothing,
+    /// consistent with `has_ancestor`); an empty set on an
+    /// `include_manifest_paths:` predicate that expects one is warned about (an
+    /// empty include would otherwise silently no-op the whole rule). Reads are
+    /// confined to the repo root; `source` was confined at build time.
+    fn resolve_manifest_paths(&self, root: &Path, index: &FileIndex) {
+        if index.manifest_paths_initialized() {
+            return;
+        }
+        // Dedup by cache key: identical configs resolve once. BTreeMap keeps the
+        // resolution order deterministic (ADR-0003).
+        let mut preds: std::collections::BTreeMap<&str, &crate::scope_filter::ManifestPredicate> =
+            std::collections::BTreeMap::new();
+        for entry in &self.entries {
+            let scope = entry
+                .rule
+                .as_per_file()
+                .map(super::rule::PerFileRule::path_scope)
+                .or_else(|| entry.rule.path_scope());
+            if let Some(scope) = scope
+                && let Some(filter) = scope.scope_filter()
+            {
+                for pred in filter.manifest_predicates() {
+                    preds.entry(pred.cache_key()).or_insert(pred);
+                }
+            }
+        }
+        if preds.is_empty() {
+            return;
+        }
+        let mut map = std::collections::HashMap::new();
+        for (key, pred) in preds {
+            let manifest = root.join(pred.source());
+            let set = match std::fs::read_to_string(&manifest) {
+                Ok(text) => pred.resolve_set(&text),
+                Err(_) => std::collections::HashSet::new(),
+            };
+            if set.is_empty() && pred.warns_on_empty() {
+                tracing::warn!(
+                    "scope_filter.include_manifest_paths: `{}` extracted no paths, so the rule \
+                     matches nothing. Set `expect_nonempty: false` if that is intended.",
+                    pred.source().display()
+                );
+            }
+            map.insert(key.to_string(), set);
+        }
+        index.set_manifest_paths(map);
     }
 }
 

--- a/crates/alint-core/src/extract.rs
+++ b/crates/alint-core/src/extract.rs
@@ -1,20 +1,20 @@
 //! Shared structured / line / regex extraction for the
 //! manifest-driven cross-file rules (`registry_paths_resolve`,
-//! `cross_file`, `file_graph`). One place so the one-of decode
-//! (`serde_yaml` can't decode an externally-tagged enum from a
-//! `{ key: value }` map; an untagged enum can't tell the three
-//! `JSONPath` string variants apart) and the non-literal skip
+//! `cross_file`, `file_graph`) and core-side predicates. One place so
+//! the one-of decode (`serde_yaml` can't decode an externally-tagged
+//! enum from a `{ key: value }` map; an untagged enum can't tell the
+//! three `JSONPath` string variants apart) and the non-literal skip
 //! can't drift between consumers.
 
 use regex::Regex;
 use serde::Deserialize;
 use serde_json_path::JsonPath;
 
-use crate::structured_path::Format;
+use crate::structured_format::Format;
 
 /// Runtime extraction mode, resolved from [`ExtractSpec`].
 #[derive(Debug, Clone)]
-pub(crate) enum Extract {
+pub enum Extract {
     /// Structured-query (RFC 9535 `JSONPath` over the parsed tree).
     Toml(String),
     Json(String),
@@ -35,7 +35,7 @@ pub(crate) enum Extract {
 #[derive(Debug, Clone, Default, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 #[schemars(rename = "extract_spec", extend("minProperties" = 1, "maxProperties" = 1))]
-pub(crate) struct ExtractSpec {
+pub struct ExtractSpec {
     #[serde(default)]
     toml: Option<String>,
     #[serde(default)]
@@ -51,7 +51,7 @@ pub(crate) struct ExtractSpec {
 }
 
 impl ExtractSpec {
-    pub(crate) fn resolve(self) -> std::result::Result<Extract, String> {
+    pub fn resolve(self) -> std::result::Result<Extract, String> {
         let set: Vec<&str> = [
             ("toml", self.toml.is_some()),
             ("json", self.json.is_some()),
@@ -109,11 +109,11 @@ impl From<Extract> for ExtractSpec {
 /// breaking change.
 #[derive(Debug, Clone, Default, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct WholeFileOpts {}
+pub struct WholeFileOpts {}
 
 #[derive(Debug, Clone, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct LinesOpts {
+pub struct LinesOpts {
     /// Lines starting with this (after trim) are skipped.
     #[serde(default = "default_comment")]
     pub(crate) comment: String,
@@ -146,7 +146,7 @@ impl Default for LinesOpts {
 /// intentionally silent; visibly surfacing skipped entries is a
 /// tracked v0.11 item (`alint check` has no `--explain` /
 /// informational-finding channel).
-pub(crate) fn is_non_literal(entry: &str) -> bool {
+pub fn is_non_literal(entry: &str) -> bool {
     entry.contains("${") || entry.contains("$(") || entry.contains("{{") || entry.contains("+ ")
 }
 
@@ -154,10 +154,7 @@ pub(crate) fn is_non_literal(entry: &str) -> bool {
 /// applies [`is_non_literal`] filtering as it needs). Structured
 /// modes yield string-valued `JSONPath` matches; `lines` yields
 /// trimmed non-comment lines; `regex` yields capture group 1.
-pub(crate) fn extract_values(
-    extract: &Extract,
-    text: &str,
-) -> std::result::Result<Vec<String>, String> {
+pub fn extract_values(extract: &Extract, text: &str) -> std::result::Result<Vec<String>, String> {
     Ok(match extract {
         Extract::Toml(q) => structured(Format::Toml, q, text)?,
         Extract::Json(q) => structured(Format::Json, q, text)?,

--- a/crates/alint-core/src/lib.rs
+++ b/crates/alint-core/src/lib.rs
@@ -49,8 +49,8 @@ pub use rule::{
 };
 pub use scope::Scope;
 pub use scope_filter::{
-    ScopeFilter, ScopeFilterSpec, reject_scope_filter_on_cross_file,
-    reject_scope_filter_with_reason,
+    ManifestDeriveTarget, ManifestPathSpec, ScopeFilter, ScopeFilterSpec,
+    reject_scope_filter_on_cross_file, reject_scope_filter_with_reason,
 };
 pub use structured_format::{Format, MAX_XML_DEPTH};
 pub use walker::{FileEntry, FileIndex, MAX_ANALYZE_BYTES, WalkOptions, read_capped_or_skip, walk};

--- a/crates/alint-core/src/lib.rs
+++ b/crates/alint-core/src/lib.rs
@@ -49,7 +49,7 @@ pub use rule::{
 };
 pub use scope::Scope;
 pub use scope_filter::{
-    ManifestDeriveTarget, ManifestPathSpec, ScopeFilter, ScopeFilterSpec,
+    ManifestDeriveTarget, ManifestPathSpec, ResolvedManifestScope, ScopeFilter, ScopeFilterSpec,
     reject_scope_filter_on_cross_file, reject_scope_filter_with_reason,
 };
 pub use structured_format::{Format, MAX_XML_DEPTH};

--- a/crates/alint-core/src/lib.rs
+++ b/crates/alint-core/src/lib.rs
@@ -9,15 +9,18 @@ mod config;
 pub mod did_you_mean;
 mod engine;
 mod error;
+mod extract;
 pub mod facts;
 pub mod git;
 pub mod jsonpath_diagnostics;
 mod level;
+mod pathsafe;
 mod registry;
 mod report;
 mod rule;
 mod scope;
 mod scope_filter;
+mod structured_format;
 pub mod template;
 mod walker;
 pub mod when;
@@ -34,8 +37,10 @@ pub use config::{
 };
 pub use engine::{Engine, RuleEntry};
 pub use error::{Error, Result};
+pub use extract::{Extract, ExtractSpec, LinesOpts, WholeFileOpts, extract_values, is_non_literal};
 pub use facts::{FactKind, FactSpec, FactValue, FactValues, evaluate_facts};
 pub use level::Level;
+pub use pathsafe::{derive_target, normalize_confined};
 pub use registry::{RuleBuilder, RuleRegistry};
 pub use report::{FixItem, FixReport, FixRuleResult, FixStatus, Report};
 pub use rule::{
@@ -47,5 +52,6 @@ pub use scope_filter::{
     ScopeFilter, ScopeFilterSpec, reject_scope_filter_on_cross_file,
     reject_scope_filter_with_reason,
 };
+pub use structured_format::{Format, MAX_XML_DEPTH};
 pub use walker::{FileEntry, FileIndex, MAX_ANALYZE_BYTES, WalkOptions, read_capped_or_skip, walk};
 pub use when::{WhenEnv, WhenError, WhenExpr};

--- a/crates/alint-core/src/pathsafe.rs
+++ b/crates/alint-core/src/pathsafe.rs
@@ -1,0 +1,305 @@
+//! Path confinement — lexical primitives that keep a
+//! config-author-controlled path inside the repo root (the untrusted
+//! `extends:` threat the `SPAWNING_RULE_KINDS` gate also defends
+//! against).
+//!
+//! [`normalize_confined`] is the *lexical* gate: pure, no filesystem
+//! access, and the subject of the Kani proof below. It rejects absolute
+//! and `..`-escaping paths but is **symlink-blind** — a
+//! lexically-confined `link/x` still resolves outside the tree if `link`
+//! is an in-repo symlink pointing out of it. The *filesystem* gate that
+//! closes that gap (`confine_read` / `resolved_within_root`) lives in
+//! `alint-rules`, layered on top of this.
+//!
+//! [`derive_target`] applies a `from`→`to` capture template to a path
+//! and confines the result — the `file_graph` `derive_target` edge.
+//!
+//! Design: `docs/design/v0.12/path-confinement.md`.
+
+use std::path::{Component, Path, PathBuf};
+
+/// Normalise `p` lexically (collapsing `.` and `a/../b`) and return it
+/// **only if it stays within the repo root**.
+///
+/// Returns `None` when the path escapes the root:
+/// - an absolute component (`RootDir` / Windows `Prefix`) — because
+///   `root.join(absolute)` discards `root`, so reading it would touch
+///   an arbitrary host path;
+/// - a `..` that cannot pop a real component (caught *during* the
+///   walk, so `../../escape` and `a/../../x` are rejected, not merely
+///   inspected after the fact);
+/// - a result that collapses to empty (`.`, `a/..`) — the root itself
+///   is never a valid edge / target / reference.
+///
+/// A `Some(_)` result is guaranteed root-relative *lexically*: safe to
+/// look up in the (symlink-pruned) `FileIndex`. For a direct filesystem
+/// **read** it is **not** sufficient — `root.join(result)` still follows
+/// any in-repo symlink out of the tree — so reads must go through
+/// `confine_read` / `resolved_within_root` (in `alint-rules`), never
+/// this result alone.
+pub fn normalize_confined(p: &Path) -> Option<PathBuf> {
+    let mut out = PathBuf::new();
+    for comp in p.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                // A `..` that can't pop a real component escapes root.
+                if !out.pop() {
+                    return None;
+                }
+            }
+            Component::Normal(c) => out.push(c),
+            // Absolute (Unix root or Windows prefix) escapes by
+            // definition — never let it reach `root.join`.
+            Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    if out.as_os_str().is_empty() {
+        return None;
+    }
+    debug_assert!(
+        is_confined(&out),
+        "normalize_confined produced a non-confined path: {}",
+        out.display()
+    );
+    Some(out)
+}
+
+/// The confinement invariant every `Some(_)` from [`normalize_confined`]
+/// upholds: a non-empty, purely root-relative path — every component is
+/// `Normal` (no `..`, no `.`, no absolute `RootDir`/`Prefix`). Checked at
+/// runtime by the `debug_assert` above and exhaustively-for-bounded-inputs
+/// by the `confinement_invariant` property test. This is the security
+/// contract: a value satisfying it is safe to `root.join(..)`.
+fn is_confined(p: &Path) -> bool {
+    !p.as_os_str().is_empty() && p.components().all(|c| matches!(c, Component::Normal(_)))
+}
+
+/// Derive a target path from `path` by matching it against the `from`
+/// regex and expanding its captures into the `to` replacement template,
+/// then lexically confining the result to the repo root (via
+/// [`normalize_confined`]).
+///
+/// Returns `None` in two cases the caller may need to tell apart: `path`
+/// did not match `from` (no derived edge at all), or it matched but the
+/// derived path escapes the repo root (an out-of-repo target that must
+/// never be read). The `file_graph` `derive_target` edge (source path →
+/// generated file) is the caller.
+pub fn derive_target(from: &regex::Regex, to: &str, path: &str) -> Option<PathBuf> {
+    let caps = from.captures(path)?;
+    let mut derived = String::new();
+    caps.expand(to, &mut derived);
+    normalize_confined(Path::new(&derived))
+}
+
+/// A bounded, verifiable model of the confinement policy — the only
+/// distinction the walk makes between path components, decoupled from
+/// `std::path::Component` (which carries an unbounded `OsStr`) so the
+/// policy is provable over fixed-size inputs. `normalize_confined` is the
+/// real, `PathBuf`-building implementation this abstracts; the
+/// `agrees_with_proven_model` property checks they never disagree.
+#[cfg(any(test, kani))]
+mod model {
+    use std::path::Component;
+
+    #[cfg_attr(kani, derive(kani::Arbitrary))]
+    #[derive(Clone, Copy)]
+    pub(super) enum Step {
+        Normal,
+        Parent,
+        Cur,
+        AbsRoot,
+    }
+
+    pub(super) fn step_of(c: &Component) -> Step {
+        match c {
+            Component::Normal(_) => Step::Normal,
+            Component::CurDir => Step::Cur,
+            Component::ParentDir => Step::Parent,
+            Component::RootDir | Component::Prefix(_) => Step::AbsRoot,
+        }
+    }
+
+    /// Fold component steps into the surviving root-relative depth, or
+    /// `None` on any escape (an absolute component, or a `..` that
+    /// underflows the root). `Some(depth)` requires `depth > 0` — the
+    /// root itself is never a valid confined path.
+    pub(super) fn confine_steps(steps: impl IntoIterator<Item = Step>) -> Option<usize> {
+        let mut depth = 0usize;
+        for s in steps {
+            match s {
+                Step::Normal => depth += 1,
+                Step::Cur => {}
+                Step::Parent => depth = depth.checked_sub(1)?,
+                Step::AbsRoot => return None,
+            }
+        }
+        (depth > 0).then_some(depth)
+    }
+}
+
+/// Kani bounded proof of the confinement policy. Run with `cargo kani`
+/// (not part of standard preflight — Kani is a separate, heavier
+/// toolchain). See `docs/design/formal-methods.md`.
+#[cfg(kani)]
+mod kani_proofs {
+    use super::model::{Step, confine_steps};
+
+    /// For every bounded component sequence, `confine_steps` implements
+    /// the confinement policy *exactly*: it escapes (`None`) on any
+    /// absolute component or on a `..` that underflows the root, and
+    /// otherwise yields the surviving depth `#Normal - #Parent` (with the
+    /// empty root, depth 0, rejected). The proof checks this against an
+    /// **independent counting formulation** of the spec — a different
+    /// algorithm shape from the early-return fold under test — so it
+    /// catches a real escape bug (e.g. a `..` that fails to pop), not just
+    /// the weaker side-conditions (`AbsRoot => None`, `depth <= #Normal`)
+    /// an earlier version proved. It also proves the `..` arithmetic never
+    /// underflows or panics.
+    #[kani::proof]
+    #[kani::unwind(7)]
+    fn confine_steps_is_sound() {
+        let steps: [Step; 6] = kani::any();
+        let result = confine_steps(steps);
+
+        // Independent spec: walk the whole sequence counting a running
+        // balance; the policy escapes iff any absolute component is
+        // present or the balance ever goes negative (a `..` underflowing
+        // the root). When no escape occurs, the depth is the final
+        // balance, and depth 0 (the bare root) is not a valid path.
+        let has_abs = steps.iter().any(|s| matches!(s, Step::AbsRoot));
+        let mut balance: i64 = 0;
+        let mut underflowed = false;
+        for s in &steps {
+            match s {
+                Step::Normal => balance += 1,
+                Step::Parent => {
+                    balance -= 1;
+                    if balance < 0 {
+                        underflowed = true;
+                    }
+                }
+                Step::Cur | Step::AbsRoot => {}
+            }
+        }
+        let expected = if has_abs || underflowed || balance <= 0 {
+            None
+        } else {
+            Some(balance as usize)
+        };
+
+        assert!(
+            result == expected,
+            "confine_steps must implement the confinement policy exactly"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_confined;
+    use proptest::prelude::*;
+    use std::path::{Path, PathBuf};
+
+    fn confined(s: &str) -> Option<PathBuf> {
+        normalize_confined(Path::new(s))
+    }
+
+    #[test]
+    fn in_tree_paths_normalise_and_pass() {
+        assert_eq!(confined("a/b.rs"), Some(PathBuf::from("a/b.rs")));
+        assert_eq!(confined("./a/./b"), Some(PathBuf::from("a/b")));
+        assert_eq!(confined("a/x/../b"), Some(PathBuf::from("a/b")));
+        // pops back to root then descends — stays in-tree.
+        assert_eq!(confined("a/../b"), Some(PathBuf::from("b")));
+    }
+
+    #[test]
+    fn absolute_paths_are_rejected() {
+        // root.join(absolute) would discard root — the read-oracle.
+        assert_eq!(confined("/etc/passwd"), None);
+        assert_eq!(confined("/tmp/secret.txt"), None);
+    }
+
+    #[test]
+    fn root_escaping_dotdot_is_rejected_including_cancellation() {
+        assert_eq!(confined("../x"), None);
+        // The double-dot-cancellation escape a first-component check
+        // misses: `../../escape` must NOT collapse to in-tree `escape`.
+        assert_eq!(confined("../../escape"), None);
+        assert_eq!(confined("a/../../x"), None);
+        assert_eq!(confined("a/b/../../../c"), None);
+    }
+
+    #[test]
+    fn empty_or_root_collapse_is_rejected() {
+        assert_eq!(confined(""), None);
+        assert_eq!(confined("."), None);
+        assert_eq!(confined("a/.."), None); // collapses to the root itself
+    }
+
+    /// A path strategy that actually exercises the confinement logic: each
+    /// component is a short name, `..`, or `.`, joined by `/` and
+    /// optionally absolute. A flat character regex produces `..` in well
+    /// under 0.01% of cases, so it almost never hits the `..`-underflow
+    /// rejection (the headline cancellation attack); this makes escapes,
+    /// cancellation, and root underflow common, so the properties stress
+    /// the security-critical rejection paths, not just the in-tree case.
+    fn confinement_paths() -> impl Strategy<Value = String> {
+        let component = prop_oneof![
+            3 => "[a-z]{1,4}",
+            2 => Just("..".to_string()),
+            1 => Just(".".to_string()),
+        ];
+        (any::<bool>(), prop::collection::vec(component, 0..8)).prop_map(|(absolute, comps)| {
+            let body = comps.join("/");
+            if absolute { format!("/{body}") } else { body }
+        })
+    }
+
+    proptest! {
+        /// The security invariant, as a property: whatever path the
+        /// config author supplies, a `Some(_)` result is always
+        /// root-confined — every component `Normal`, never empty — so
+        /// `root.join(it)` can never escape the tree.
+        #[test]
+        fn confinement_invariant(s in confinement_paths()) {
+            if let Some(out) = normalize_confined(Path::new(&s)) {
+                prop_assert!(super::is_confined(&out));
+            }
+        }
+
+        /// Normalisation is idempotent: a confined path is a fixed point,
+        /// so re-normalising never changes it (a non-stable normaliser
+        /// would make `equals`/index lookups order-dependent).
+        #[test]
+        fn normalize_confined_is_idempotent(s in confinement_paths()) {
+            if let Some(out) = normalize_confined(Path::new(&s)) {
+                prop_assert_eq!(normalize_confined(&out), Some(out.clone()));
+            }
+        }
+
+        /// The real implementation agrees with the Kani-proven `model`:
+        /// it returns `Some` with N components exactly when the model
+        /// returns `Some(N)`. This ties the bounded proof to the actual
+        /// `PathBuf`-building code.
+        #[test]
+        fn agrees_with_proven_model(s in confinement_paths()) {
+            let p = Path::new(&s);
+            let model = super::model::confine_steps(p.components().map(|c| super::model::step_of(&c)));
+            let real = normalize_confined(p).map(|o| o.components().count());
+            prop_assert_eq!(real, model);
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_prefix_and_unc_paths_are_rejected() {
+        // On Windows a drive-letter `Prefix` or a UNC `\\server\share`
+        // is absolute → escapes the root, same as a Unix `/etc`. (On
+        // Unix these parse as ordinary `Normal` components, so the test
+        // is Windows-only.)
+        assert_eq!(confined(r"C:\Windows\System32"), None);
+        assert_eq!(confined(r"\\server\share\x"), None);
+    }
+}

--- a/crates/alint-core/src/scope_filter.rs
+++ b/crates/alint-core/src/scope_filter.rs
@@ -309,17 +309,21 @@ impl ManifestPredicate {
                 let mapped = if let Some((from, to)) = &self.derive_target {
                     derive_target(from, to, &entry)?
                 } else {
-                    // Reject an entry that is vacuous or escaping on its own
-                    // (``, `.`, `x/..`, `../y`) BEFORE joining `base`, mirroring
-                    // the derive_target branch. Otherwise, for a nested manifest,
-                    // `base.join("")` == `base`, so a stray `.` / empty entry
-                    // would scope the manifest's WHOLE subtree — the silent
-                    // footgun the empty-set safety is meant to prevent (at the
-                    // repo root such entries already normalize to `None` below).
-                    normalize_confined(Path::new(&entry))?;
                     PathBuf::from(entry)
                 };
-                normalize_confined(&base.join(mapped))
+                let resolved = normalize_confined(&base.join(mapped))?;
+                // Drop an entry that resolves to EXACTLY the manifest's own
+                // directory (``, `.`, `x/..` — `base.join` collapses to `base`):
+                // it would silently scope the manifest's WHOLE subtree, the footgun
+                // the empty-set safety guards. A sibling (`../shared` ->
+                // `packages/shared`) or a child resolves elsewhere and is kept — a
+                // nested `tsconfig` referencing a sibling package via `../` is a
+                // documented supported case. (At the repo root `base` is empty and
+                // vacuous entries already normalize to `None` above, a no-op here.)
+                if resolved.as_path() == base {
+                    return None;
+                }
+                Some(resolved)
             })
             .collect()
     }
@@ -1243,6 +1247,32 @@ mod tests {
             "a real child resolves under the manifest dir: {set:?}"
         );
         assert_eq!(set.len(), 1, "only the real child survives: {set:?}");
+    }
+
+    #[test]
+    fn resolve_set_keeps_nested_sibling_reference() {
+        // Only an entry collapsing to the manifest's OWN dir is dropped; an
+        // in-root `../sibling` reference (a nested `tsconfig` pointing at a sibling
+        // package, a documented supported case) resolves elsewhere and is KEPT.
+        // (Regression: an over-broad standalone-`..` drop silently unscoped it.)
+        let f = manifest_filter(
+            "include_manifest_paths:\n  source: packages/web/tsconfig.json\n  extract: { json: \"$.include[*]\" }",
+        );
+        let set =
+            f.manifest_predicates()[0].resolve_set(r#"{"include": ["src", "../shared/src", "."]}"#);
+        assert!(
+            set.contains(Path::new("packages/web/src")),
+            "the child `src` is kept: {set:?}"
+        );
+        assert!(
+            set.contains(Path::new("packages/shared/src")),
+            "the in-root sibling `../shared/src` is kept: {set:?}"
+        );
+        assert!(
+            !set.contains(Path::new("packages/web")),
+            "the vacuous `.` is dropped (not the whole subtree): {set:?}"
+        );
+        assert_eq!(set.len(), 2, "src + shared/src, not `.`: {set:?}");
     }
 
     #[test]

--- a/crates/alint-core/src/scope_filter.rs
+++ b/crates/alint-core/src/scope_filter.rs
@@ -44,11 +44,15 @@
 //! ~750 ms — and that's before the file-read savings the
 //! filter unlocks.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use regex::Regex;
 use serde::{Deserialize, Deserializer};
 
 use crate::error::{Error, Result};
+use crate::extract::{Extract, ExtractSpec, extract_values, is_non_literal};
+use crate::pathsafe::{derive_target, normalize_confined};
 use crate::walker::FileIndex;
 
 /// Per-file rule gate. Today's only primitive is
@@ -68,6 +72,11 @@ pub struct ScopeFilter {
     /// [`FileIndex`]). AND-composes with `has_ancestor`. Empty
     /// `has_ancestor` + `Some` `changed_since` is a diff-only filter.
     changed_since: Option<String>,
+    /// `include_manifest_paths:` / `exclude_manifest_paths:` — gate each file by
+    /// membership in a path set extracted from a manifest (ADR-0010). Each
+    /// predicate's set is resolved once per run and cached on the [`FileIndex`],
+    /// exactly like `changed_since`. AND-composes with the others.
+    manifest_predicates: Vec<ManifestPredicate>,
 }
 
 /// YAML-level shape of `scope_filter:`. Deserialised by
@@ -86,9 +95,59 @@ pub struct ScopeFilterSpec {
     /// `changed_since: <git-ref>` — narrow the rule to files in the
     /// `<ref>...HEAD` diff. Accepts the `{{env.X}}` interpolation
     /// (resolved at config load). At least one of `has_ancestor:` /
-    /// `changed_since:` must be present.
+    /// `changed_since:` / `include_manifest_paths:` / `exclude_manifest_paths:`
+    /// must be present.
     #[serde(default)]
     pub changed_since: Option<String>,
+    /// `include_manifest_paths:` — keep only files whose path is in the
+    /// manifest-derived set (ADR-0010). A file the base `paths:` glob matched
+    /// but the manifest does not declare is dropped.
+    #[serde(default)]
+    pub include_manifest_paths: Option<ManifestPathSpec>,
+    /// `exclude_manifest_paths:` — drop files whose path is in the
+    /// manifest-derived set. The complement of `include_manifest_paths:`.
+    #[serde(default)]
+    pub exclude_manifest_paths: Option<ManifestPathSpec>,
+}
+
+/// YAML shape of a manifest-derived path set, shared by
+/// `include_manifest_paths:` / `exclude_manifest_paths:`. The set is extracted
+/// from `source` once per run, optionally mapped by `derive_target`, resolved
+/// relative to the manifest's own directory, and confined to the repo root. See
+/// ADR-0010 and `docs/design/v0.15/manifest-derived-scope.md`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ManifestPathSpec {
+    /// The manifest file, always repo-root-confined (a manifest a rule scopes
+    /// by lives in the repo; an escaping `source` is a build-time error). Its
+    /// declared paths resolve relative to its own directory.
+    pub source: String,
+    /// The `{toml|json|yaml|lines|regex}` extractor shared with
+    /// `registry_paths_resolve` / `file_graph`. Non-literal / interpolated
+    /// entries are dropped, not failed.
+    pub extract: ExtractSpec,
+    /// Optional `{from, to}` regex mapping applied to each extracted path — e.g.
+    /// map a `package.json` `bin` output (`dist/cli.js`) back to its source
+    /// (`src/cli.ts`). An entry that does not match `from` is dropped, exactly
+    /// as `file_graph`'s `derive_target` drops a non-matching node.
+    #[serde(default)]
+    pub derive_target: Option<ManifestDeriveTarget>,
+    /// `include_manifest_paths:` only — warn when the extracted set is empty
+    /// (default `true`). An empty include set silently no-ops the whole rule, a
+    /// footgun; set `false` for a rule that legitimately tolerates it.
+    #[serde(default)]
+    pub expect_nonempty: Option<bool>,
+}
+
+/// `{from, to}` output-to-source mapping (the same shape `file_graph` uses).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ManifestDeriveTarget {
+    /// A regex matched against each extracted path; `$1`-style capture groups
+    /// substitute into `to`.
+    pub from: String,
+    /// The replacement template producing the mapped (source) path.
+    pub to: String,
 }
 
 fn deserialize_opt_string_or_list<'de, D>(
@@ -106,6 +165,126 @@ where
     match OneOrMany::deserialize(deserializer)? {
         OneOrMany::One(s) => Ok(Some(vec![s])),
         OneOrMany::Many(v) => Ok(Some(v)),
+    }
+}
+
+/// Whether a manifest predicate keeps or drops files in its set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ManifestSense {
+    /// `include_manifest_paths:` — keep only files IN the set.
+    Include,
+    /// `exclude_manifest_paths:` — drop files IN the set.
+    Exclude,
+}
+
+/// The validated, resolve-ready form of one `*_manifest_paths:` predicate. The
+/// path SET it gates by is resolved once per run by the engine and cached on the
+/// [`FileIndex`] under [`Self::cache_key`]; this struct holds only the config
+/// needed to key that cache and resolve the set from the manifest text.
+#[derive(Debug, Clone)]
+pub(crate) struct ManifestPredicate {
+    /// Canonical `(source, extract, derive_target)` key. Two predicates with an
+    /// identical config share one resolved set — resolved and cached once.
+    cache_key: String,
+    /// The manifest path, relative to the repo root (confined at build time).
+    source: PathBuf,
+    /// The resolved extractor.
+    extract: Extract,
+    /// The compiled `derive_target`, if any: `(from regex, to template)`.
+    derive_target: Option<(Regex, String)>,
+    /// Include vs exclude.
+    sense: ManifestSense,
+    /// Warn on an empty extracted set (include predicates only).
+    expect_nonempty: bool,
+}
+
+impl ManifestPredicate {
+    /// Build + validate from the config half: confine `source`, resolve the
+    /// extractor, compile the `derive_target` regex, and compute the cache key.
+    fn from_spec(rule_id: &str, spec: ManifestPathSpec, sense: ManifestSense) -> Result<Self> {
+        let source = normalize_confined(Path::new(&spec.source)).ok_or_else(|| {
+            Error::rule_config(
+                rule_id,
+                format!(
+                    "scope_filter manifest `source:` must be a repo-root-relative path, got {:?}",
+                    spec.source
+                ),
+            )
+        })?;
+        let extract = spec.extract.resolve().map_err(|e| {
+            Error::rule_config(rule_id, format!("scope_filter manifest `extract:` {e}"))
+        })?;
+        let derive_target = match spec.derive_target {
+            Some(dt) => {
+                let re = Regex::new(&dt.from).map_err(|e| {
+                    Error::rule_config(
+                        rule_id,
+                        format!(
+                            "scope_filter manifest `derive_target.from:` is not a valid regex: {e}"
+                        ),
+                    )
+                })?;
+                Some((re, dt.to))
+            }
+            None => None,
+        };
+        let dt_key = derive_target
+            .as_ref()
+            .map(|(from, to)| format!("{}=>{to}", from.as_str()))
+            .unwrap_or_default();
+        // `Extract`'s Debug is a stable, injective rendering of the resolved
+        // extractor — enough to co-cache two rules with an identical config.
+        let cache_key = format!("{}\u{0}{extract:?}\u{0}{dt_key}", source.display());
+        Ok(Self {
+            cache_key,
+            source,
+            extract,
+            derive_target,
+            sense,
+            expect_nonempty: spec.expect_nonempty.unwrap_or(true),
+        })
+    }
+
+    /// The cache key the engine resolves under and [`ScopeFilter::matches`]
+    /// looks the resolved set up by.
+    pub(crate) fn cache_key(&self) -> &str {
+        &self.cache_key
+    }
+
+    /// The manifest path (repo-root-relative) the engine reads.
+    pub(crate) fn source(&self) -> &Path {
+        &self.source
+    }
+
+    /// True for an `include_manifest_paths:` predicate that wants a non-empty
+    /// set — the engine warns when its resolved set is empty.
+    pub(crate) fn warns_on_empty(&self) -> bool {
+        self.sense == ManifestSense::Include && self.expect_nonempty
+    }
+
+    /// Resolve the declared path set from the manifest's text: extract, drop
+    /// non-literal entries, optionally `derive_target`-map, resolve relative to
+    /// the manifest's directory, and confine each result to the repo root. Pure
+    /// — the engine does the file read and caches the result on the
+    /// [`FileIndex`]. An unparseable manifest / bad extract yields the empty set
+    /// (the engine warns); the predicate then contributes nothing.
+    pub(crate) fn resolve_set(&self, text: &str) -> HashSet<PathBuf> {
+        let base = self.source.parent().unwrap_or_else(|| Path::new(""));
+        let Ok(raw) = extract_values(&self.extract, text) else {
+            return HashSet::new();
+        };
+        raw.into_iter()
+            .filter(|e| !is_non_literal(e))
+            .filter_map(|entry| {
+                let mapped = match &self.derive_target {
+                    // A non-matching entry is not a mapped output — dropped,
+                    // matching file_graph's derive_target.
+                    Some((from, to)) => derive_target(from, to, &entry)?,
+                    None => PathBuf::from(entry),
+                };
+                normalize_confined(&base.join(mapped))
+            })
+            .collect()
     }
 }
 
@@ -137,15 +316,33 @@ impl ScopeFilter {
             }
             None => Vec::new(),
         };
-        if has_ancestor.is_empty() && spec.changed_since.is_none() {
+        let mut manifest_predicates = Vec::new();
+        if let Some(inc) = spec.include_manifest_paths {
+            manifest_predicates.push(ManifestPredicate::from_spec(
+                rule_id,
+                inc,
+                ManifestSense::Include,
+            )?);
+        }
+        if let Some(exc) = spec.exclude_manifest_paths {
+            manifest_predicates.push(ManifestPredicate::from_spec(
+                rule_id,
+                exc,
+                ManifestSense::Exclude,
+            )?);
+        }
+        if has_ancestor.is_empty() && spec.changed_since.is_none() && manifest_predicates.is_empty()
+        {
             return Err(Error::rule_config(
                 rule_id,
-                "scope_filter must set at least one of `has_ancestor:` or `changed_since:`",
+                "scope_filter must set at least one of `has_ancestor:`, `changed_since:`, \
+                 `include_manifest_paths:`, or `exclude_manifest_paths:`",
             ));
         }
         Ok(Self {
             has_ancestor,
             changed_since: spec.changed_since,
+            manifest_predicates,
         })
     }
 
@@ -155,6 +352,7 @@ impl ScopeFilter {
         Self {
             has_ancestor: names.into_iter().map(PathBuf::from).collect(),
             changed_since: None,
+            manifest_predicates: Vec::new(),
         }
     }
 
@@ -164,6 +362,7 @@ impl ScopeFilter {
         Self {
             has_ancestor: Vec::new(),
             changed_since: Some(since.to_string()),
+            manifest_predicates: Vec::new(),
         }
     }
 
@@ -199,7 +398,29 @@ impl ScopeFilter {
                 return false;
             }
         }
+        for pred in &self.manifest_predicates {
+            // The manifest set is resolved once per run and cached on the index
+            // (like `changed_since`); a missing entry (manifest absent /
+            // unresolved) is the empty set. `include` keeps only files whose
+            // path is IN the set; `exclude` drops files whose path is IN it.
+            let in_set = index
+                .manifest_paths(pred.cache_key())
+                .is_some_and(|set| set.contains(file));
+            let keep = match pred.sense {
+                ManifestSense::Include => in_set,
+                ManifestSense::Exclude => !in_set,
+            };
+            if !keep {
+                return false;
+            }
+        }
         true
+    }
+
+    /// The manifest predicates configured on this filter. The engine reads these
+    /// from every per-file rule to resolve each declared path set once per run.
+    pub(crate) fn manifest_predicates(&self) -> &[ManifestPredicate] {
+        &self.manifest_predicates
     }
 
     /// The `has_ancestor` walk, factored out so [`matches`](Self::matches)
@@ -447,6 +668,8 @@ mod tests {
             ScopeFilterSpec {
                 has_ancestor: Some(vec![]),
                 changed_since: None,
+                include_manifest_paths: None,
+                exclude_manifest_paths: None,
             },
         )
         .unwrap_err();
@@ -460,6 +683,8 @@ mod tests {
             ScopeFilterSpec {
                 has_ancestor: Some(vec![String::new()]),
                 changed_since: None,
+                include_manifest_paths: None,
+                exclude_manifest_paths: None,
             },
         )
         .unwrap_err();
@@ -473,6 +698,8 @@ mod tests {
             ScopeFilterSpec {
                 has_ancestor: Some(vec!["foo/bar".into()]),
                 changed_since: None,
+                include_manifest_paths: None,
+                exclude_manifest_paths: None,
             },
         )
         .unwrap_err();
@@ -487,6 +714,8 @@ mod tests {
                 ScopeFilterSpec {
                     has_ancestor: Some(vec![(*bad).into()]),
                     changed_since: None,
+                    include_manifest_paths: None,
+                    exclude_manifest_paths: None,
                 },
             )
             .unwrap_err();
@@ -511,6 +740,8 @@ mod tests {
                 ScopeFilterSpec {
                     has_ancestor: Some(vec![(*good).into()]),
                     changed_since: None,
+                    include_manifest_paths: None,
+                    exclude_manifest_paths: None,
                 },
             )
             .unwrap_or_else(|e| panic!("{good:?} should be valid; got {e}"));
@@ -587,6 +818,7 @@ mod tests {
         let f = ScopeFilter {
             has_ancestor: vec![PathBuf::from("Cargo.toml")],
             changed_since: Some("origin/main".to_string()),
+            manifest_predicates: Vec::new(),
         };
         let i = idx_with_diff(
             &["crates/x/Cargo.toml", "crates/x/a.rs", "loose/b.rs"],
@@ -607,6 +839,8 @@ mod tests {
             ScopeFilterSpec {
                 has_ancestor: None,
                 changed_since: None,
+                include_manifest_paths: None,
+                exclude_manifest_paths: None,
             },
         )
         .unwrap_err();
@@ -620,10 +854,209 @@ mod tests {
             ScopeFilterSpec {
                 has_ancestor: None,
                 changed_since: Some("origin/main".into()),
+                include_manifest_paths: None,
+                exclude_manifest_paths: None,
             },
         )
         .unwrap();
         assert_eq!(f.changed_since(), Some("origin/main"));
         assert!(f.has_ancestor_names().is_empty());
+    }
+
+    // ── manifest-derived path scope (ADR-0010) ────────────────
+
+    /// Build a filter from `scope_filter:` YAML (the real deserialise + validate
+    /// path), so the manifest predicate is constructed exactly as production.
+    fn manifest_filter(yaml: &str) -> ScopeFilter {
+        let spec: ScopeFilterSpec = serde_yaml_ng::from_str(yaml).expect("scope_filter parses");
+        ScopeFilter::from_spec("r", spec).expect("from_spec ok")
+    }
+
+    fn idx_with_manifest(paths: &[&str], key: &str, set: &[&str]) -> FileIndex {
+        let i = idx(paths);
+        let mut map = std::collections::HashMap::new();
+        map.insert(key.to_string(), set.iter().map(PathBuf::from).collect());
+        i.set_manifest_paths(map);
+        i
+    }
+
+    #[test]
+    fn exclude_manifest_paths_drops_files_in_set() {
+        let f = manifest_filter(
+            "exclude_manifest_paths:\n  source: package.json\n  extract: { json: \"$.bin.*\" }",
+        );
+        let key = f.manifest_predicates()[0].cache_key();
+        let i = idx_with_manifest(&["src/cli.ts", "src/lib.ts"], key, &["src/cli.ts"]);
+        assert!(
+            !f.matches(Path::new("src/cli.ts"), &i),
+            "in-set file dropped"
+        );
+        assert!(
+            f.matches(Path::new("src/lib.ts"), &i),
+            "out-of-set file kept"
+        );
+    }
+
+    #[test]
+    fn include_manifest_paths_keeps_only_files_in_set() {
+        let f = manifest_filter(
+            "include_manifest_paths:\n  source: Cargo.toml\n  extract: { toml: \"$.workspace.members[*]\" }",
+        );
+        let key = f.manifest_predicates()[0].cache_key();
+        let i = idx_with_manifest(
+            &["crates/a/lib.rs", "vendor/x.rs"],
+            key,
+            &["crates/a/lib.rs"],
+        );
+        assert!(
+            f.matches(Path::new("crates/a/lib.rs"), &i),
+            "in-set file kept"
+        );
+        assert!(
+            !f.matches(Path::new("vendor/x.rs"), &i),
+            "out-of-set file dropped"
+        );
+    }
+
+    #[test]
+    fn manifest_absent_include_scopes_nothing_exclude_full() {
+        // No cache entry (manifest unresolved) → include drops all, exclude keeps
+        // all — consistent with has_ancestor's silent behaviour.
+        let inc = manifest_filter(
+            "include_manifest_paths:\n  source: p.json\n  extract: { json: \"$.x[*]\" }",
+        );
+        let exc = manifest_filter(
+            "exclude_manifest_paths:\n  source: p.json\n  extract: { json: \"$.x[*]\" }",
+        );
+        let i = idx(&["a.rs"]); // no set_manifest_paths
+        assert!(
+            !inc.matches(Path::new("a.rs"), &i),
+            "include + absent → nothing"
+        );
+        assert!(
+            exc.matches(Path::new("a.rs"), &i),
+            "exclude + absent → full scope"
+        );
+    }
+
+    #[test]
+    fn manifest_and_composes_with_has_ancestor() {
+        let f = manifest_filter(
+            "has_ancestor: Cargo.toml\nexclude_manifest_paths:\n  source: Cargo.toml\n  extract: { toml: \"$.bin[*].path\" }",
+        );
+        let key = f.manifest_predicates()[0].cache_key().to_string();
+        let i = idx(&[
+            "crates/x/Cargo.toml",
+            "crates/x/a.rs",
+            "crates/x/b.rs",
+            "loose/c.rs",
+        ]);
+        let mut map = std::collections::HashMap::new();
+        map.insert(key, [PathBuf::from("crates/x/b.rs")].into_iter().collect());
+        i.set_manifest_paths(map);
+        assert!(
+            f.matches(Path::new("crates/x/a.rs"), &i),
+            "under manifest, not excluded"
+        );
+        assert!(
+            !f.matches(Path::new("crates/x/b.rs"), &i),
+            "excluded by manifest"
+        );
+        assert!(
+            !f.matches(Path::new("loose/c.rs"), &i),
+            "no ancestor manifest"
+        );
+    }
+
+    #[test]
+    fn resolve_set_extracts_maps_and_confines() {
+        let f = manifest_filter(
+            "exclude_manifest_paths:\n  source: package.json\n  extract: { json: \"$.bin.*\" }\n  derive_target: { from: '^dist/(.*)\\.js$', to: 'src/$1.ts' }",
+        );
+        let pred = &f.manifest_predicates()[0];
+        let text = r#"{ "bin": { "cli": "dist/cli.js", "helper": "dist/sub/helper.js" } }"#;
+        let set = pred.resolve_set(text);
+        assert!(
+            set.contains(Path::new("src/cli.ts")),
+            "mapped bin → src: {set:?}"
+        );
+        assert!(
+            set.contains(Path::new("src/sub/helper.ts")),
+            "nested mapped: {set:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_set_drops_non_matching_derive_target_entries() {
+        let f = manifest_filter(
+            "exclude_manifest_paths:\n  source: package.json\n  extract: { json: \"$.bin.*\" }\n  derive_target: { from: '^dist/(.*)\\.js$', to: 'src/$1.ts' }",
+        );
+        let text = r#"{ "bin": { "sh": "scripts/run.sh" } }"#;
+        assert!(
+            f.manifest_predicates()[0].resolve_set(text).is_empty(),
+            "an entry that doesn't match `from` is dropped"
+        );
+    }
+
+    #[test]
+    fn resolve_set_is_relative_to_manifest_dir() {
+        let f = manifest_filter(
+            "include_manifest_paths:\n  source: packages/foo/package.json\n  extract: { json: \"$.files[*]\" }",
+        );
+        let text = r#"{ "files": ["src/index.ts"] }"#;
+        let set = f.manifest_predicates()[0].resolve_set(text);
+        assert!(
+            set.contains(Path::new("packages/foo/src/index.ts")),
+            "declared path resolves under the manifest's own dir: {set:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_set_confines_escaping_declared_paths() {
+        let f = manifest_filter(
+            "exclude_manifest_paths:\n  source: packages/foo/package.json\n  extract: { json: \"$.files[*]\" }",
+        );
+        // `../../etc/x` escapes the repo root once resolved under packages/foo/.
+        let text = r#"{ "files": ["../../etc/x", "src/ok.ts"] }"#;
+        let set = f.manifest_predicates()[0].resolve_set(text);
+        assert!(set.contains(Path::new("packages/foo/src/ok.ts")));
+        assert!(
+            !set.iter().any(|p| p.starts_with("..")),
+            "root-escaping declared path dropped: {set:?}"
+        );
+    }
+
+    #[test]
+    fn from_spec_accepts_manifest_only() {
+        let f = manifest_filter(
+            "include_manifest_paths:\n  source: package.json\n  extract: { json: \"$.bin.*\" }",
+        );
+        assert_eq!(f.manifest_predicates().len(), 1);
+    }
+
+    #[test]
+    fn from_spec_rejects_source_escaping_root() {
+        let spec: ScopeFilterSpec = serde_yaml_ng::from_str(
+            "exclude_manifest_paths:\n  source: ../outside.json\n  extract: { json: \"$.x[*]\" }",
+        )
+        .unwrap();
+        let err = ScopeFilter::from_spec("r", spec).unwrap_err();
+        assert!(err.to_string().contains("repo-root-relative"), "msg: {err}");
+    }
+
+    #[test]
+    fn shared_config_produces_one_cache_key() {
+        // Two predicates with an identical (source, extract) config share a key,
+        // so the engine resolves the manifest once.
+        let a = manifest_filter(
+            "exclude_manifest_paths:\n  source: package.json\n  extract: { json: \"$.bin.*\" }",
+        );
+        let b = manifest_filter(
+            "exclude_manifest_paths:\n  source: package.json\n  extract: { json: \"$.bin.*\" }",
+        );
+        assert_eq!(
+            a.manifest_predicates()[0].cache_key(),
+            b.manifest_predicates()[0].cache_key()
+        );
     }
 }

--- a/crates/alint-core/src/scope_filter.rs
+++ b/crates/alint-core/src/scope_filter.rs
@@ -288,6 +288,18 @@ impl ManifestPredicate {
     }
 }
 
+/// One manifest predicate's resolved path set, for `alint explain` to surface
+/// what the manifest scope resolves to (the design's legibility mitigation).
+#[derive(Debug, Clone)]
+pub struct ResolvedManifestScope {
+    /// `true` for `include_manifest_paths`, `false` for `exclude_manifest_paths`.
+    pub include: bool,
+    /// The manifest source (repo-root-relative).
+    pub source: PathBuf,
+    /// The resolved, confined declared paths, sorted.
+    pub paths: Vec<PathBuf>,
+}
+
 impl ScopeFilter {
     /// Build from the deserialised spec, validating every
     /// `has_ancestor` entry. Returns `Error::rule_config` on
@@ -401,11 +413,15 @@ impl ScopeFilter {
         for pred in &self.manifest_predicates {
             // The manifest set is resolved once per run and cached on the index
             // (like `changed_since`); a missing entry (manifest absent /
-            // unresolved) is the empty set. `include` keeps only files whose
-            // path is IN the set; `exclude` drops files whose path is IN it.
+            // unresolved) is the empty set. Membership is component-wise prefix:
+            // a declared FILE (`bin` -> `src/cli.ts`) matches itself, and a
+            // declared DIRECTORY (`Cargo.toml` `workspace.members` -> `crates/a`)
+            // matches every file under it. `Path::starts_with` respects component
+            // boundaries, so `crates/a` does not match `crates/ab/x.rs`. `include`
+            // keeps files IN the set; `exclude` drops files IN it.
             let in_set = index
                 .manifest_paths(pred.cache_key())
-                .is_some_and(|set| set.contains(file));
+                .is_some_and(|set| set.iter().any(|declared| file.starts_with(declared)));
             let keep = match pred.sense {
                 ManifestSense::Include => in_set,
                 ManifestSense::Exclude => !in_set,
@@ -421,6 +437,27 @@ impl ScopeFilter {
     /// from every per-file rule to resolve each declared path set once per run.
     pub(crate) fn manifest_predicates(&self) -> &[ManifestPredicate] {
         &self.manifest_predicates
+    }
+
+    /// Resolve each manifest predicate's declared path set against `root`, for
+    /// display by `alint explain`. Reads each manifest (absent → empty set).
+    /// Not the hot path — the engine caches these on the [`FileIndex`] for
+    /// [`matches`](Self::matches).
+    #[must_use]
+    pub fn resolved_manifest_sets(&self, root: &Path) -> Vec<ResolvedManifestScope> {
+        self.manifest_predicates
+            .iter()
+            .map(|p| {
+                let text = std::fs::read_to_string(root.join(&p.source)).unwrap_or_default();
+                let mut paths: Vec<PathBuf> = p.resolve_set(&text).into_iter().collect();
+                paths.sort();
+                ResolvedManifestScope {
+                    include: p.sense == ManifestSense::Include,
+                    source: p.source.clone(),
+                    paths,
+                }
+            })
+            .collect()
     }
 
     /// The `has_ancestor` walk, factored out so [`matches`](Self::matches)
@@ -915,6 +952,34 @@ mod tests {
         assert!(
             !f.matches(Path::new("vendor/x.rs"), &i),
             "out-of-set file dropped"
+        );
+    }
+
+    #[test]
+    fn manifest_membership_is_directory_aware_prefix() {
+        // A declared DIRECTORY (`workspace.members` -> `crates/a`) matches files
+        // UNDER it; a shared-prefix sibling (`crates/ab`) does NOT match, because
+        // membership is component-wise, not string-prefix.
+        let f = manifest_filter(
+            "include_manifest_paths:\n  source: Cargo.toml\n  extract: { toml: \"$.workspace.members[*]\" }",
+        );
+        let key = f.manifest_predicates()[0].cache_key();
+        let i = idx_with_manifest(
+            &["crates/a/lib.rs", "crates/ab/x.rs", "vendor/y.rs"],
+            key,
+            &["crates/a"],
+        );
+        assert!(
+            f.matches(Path::new("crates/a/lib.rs"), &i),
+            "file under declared dir kept"
+        );
+        assert!(
+            !f.matches(Path::new("crates/ab/x.rs"), &i),
+            "shared-prefix sibling dir not matched (component boundary)"
+        );
+        assert!(
+            !f.matches(Path::new("vendor/y.rs"), &i),
+            "file outside members dropped"
         );
     }
 

--- a/crates/alint-core/src/scope_filter.rs
+++ b/crates/alint-core/src/scope_filter.rs
@@ -300,6 +300,33 @@ pub struct ResolvedManifestScope {
     pub paths: Vec<PathBuf>,
 }
 
+/// Read a manifest for `explain`'s resolved-set display, which (unlike the
+/// engine) has no `FileIndex` to read through: confine against a `source` that
+/// resolves — via a symlink — outside `root` (the canonical target must stay
+/// under the canonical root, ADR-0004), and cap the read at the analysis limit.
+/// Returns "" if the manifest is absent, escapes the root, or is too large; the
+/// predicate then shows the empty set.
+fn read_manifest_confined(root: &Path, rel: &Path) -> String {
+    let abs = root.join(rel);
+    let (Ok(croot), Ok(cabs)) = (root.canonicalize(), abs.canonicalize()) else {
+        return String::new();
+    };
+    if !cabs.starts_with(&croot) {
+        return String::new(); // a symlinked source that escapes the root
+    }
+    let Ok(meta) = std::fs::metadata(&cabs) else {
+        return String::new();
+    };
+    // Only a regular file is a manifest: a FIFO / device / socket would block or
+    // hang the read (the walker applies the same is_file filter for the engine).
+    if !meta.is_file() {
+        return String::new();
+    }
+    crate::walker::read_capped_or_skip(&cabs, meta.len())
+        .map(|b| String::from_utf8_lossy(&b).into_owned())
+        .unwrap_or_default()
+}
+
 impl ScopeFilter {
     /// Build from the deserialised spec, validating every
     /// `has_ancestor` entry. Returns `Error::rule_config` on
@@ -448,7 +475,7 @@ impl ScopeFilter {
         self.manifest_predicates
             .iter()
             .map(|p| {
-                let text = std::fs::read_to_string(root.join(&p.source)).unwrap_or_default();
+                let text = read_manifest_confined(root, &p.source);
                 let mut paths: Vec<PathBuf> = p.resolve_set(&text).into_iter().collect();
                 paths.sort();
                 ResolvedManifestScope {
@@ -1122,6 +1149,62 @@ mod tests {
         assert_eq!(
             a.manifest_predicates()[0].cache_key(),
             b.manifest_predicates()[0].cache_key()
+        );
+    }
+
+    #[test]
+    fn read_manifest_confined_reads_in_root_and_refuses_escape() {
+        let root_dir = tempfile::tempdir().unwrap();
+        let root = root_dir.path();
+        std::fs::write(root.join("m.json"), r#"{"x":1}"#).unwrap();
+        // A regular in-root manifest reads.
+        assert_eq!(
+            read_manifest_confined(root, Path::new("m.json")),
+            r#"{"x":1}"#
+        );
+        // Absent -> "".
+        assert!(read_manifest_confined(root, Path::new("missing.json")).is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_manifest_confined_refuses_escaping_symlink() {
+        let root_dir = tempfile::tempdir().unwrap();
+        let outside_dir = tempfile::tempdir().unwrap(); // a different tree, not under root
+        let root = root_dir.path();
+        std::fs::write(outside_dir.path().join("secret.json"), "SECRET").unwrap();
+        std::os::unix::fs::symlink(
+            outside_dir.path().join("secret.json"),
+            root.join("link.json"),
+        )
+        .unwrap();
+        // The symlink resolves outside root -> refused (empty), no out-of-tree read.
+        assert!(
+            read_manifest_confined(root, Path::new("link.json")).is_empty(),
+            "an escaping-symlink source must not be read"
+        );
+    }
+
+    #[test]
+    fn manifest_set_copies_onto_the_filtered_changed_index() {
+        // The `--changed` fix: the engine resolves manifests against the full
+        // index (where the manifest is reachable), then copies the resolved map
+        // onto the fresh filtered index that per-file `matches` reads. Guards
+        // that copy so an `include`/`exclude` predicate isn't silently empty
+        // under `--changed`.
+        let full = idx_with_manifest(&["a.rs"], "KEY", &["crates/a"]);
+        let filtered = idx(&["a.rs"]); // a fresh filtered index, empty cache
+        assert!(
+            filtered.manifest_paths("KEY").is_none(),
+            "filtered index starts with no manifest cache"
+        );
+        filtered.set_manifest_paths(full.manifest_paths_map().unwrap().clone());
+        assert!(
+            filtered
+                .manifest_paths("KEY")
+                .unwrap()
+                .contains(Path::new("crates/a")),
+            "the resolved set is visible on the filtered index after the copy"
         );
     }
 }

--- a/crates/alint-core/src/scope_filter.rs
+++ b/crates/alint-core/src/scope_filter.rs
@@ -134,7 +134,9 @@ pub struct ManifestPathSpec {
     pub derive_target: Option<ManifestDeriveTarget>,
     /// `include_manifest_paths:` only — warn when the extracted set is empty
     /// (default `true`). An empty include set silently no-ops the whole rule, a
-    /// footgun; set `false` for a rule that legitimately tolerates it.
+    /// footgun; set `false` for a rule that legitimately tolerates it. Ignored on
+    /// `exclude_manifest_paths:` — an empty exclude set is safe (full scope,
+    /// visible over-firing), so there is nothing to warn about.
     #[serde(default)]
     pub expect_nonempty: Option<bool>,
 }
@@ -202,6 +204,28 @@ impl ManifestPredicate {
     /// Build + validate from the config half: confine `source`, resolve the
     /// extractor, compile the `derive_target` regex, and compute the cache key.
     fn from_spec(rule_id: &str, spec: ManifestPathSpec, sense: ManifestSense) -> Result<Self> {
+        // The cache key NUL-delimits its components; a NUL byte in any of them
+        // would break its injectivity (a double-quoted `"a\0b"` YAML scalar
+        // decodes to a literal NUL). A NUL in a path / regex / template is
+        // meaningless anyway — reject it so the delimiter stays sound.
+        for (field, val) in [
+            ("source", spec.source.as_str()),
+            (
+                "derive_target.from",
+                spec.derive_target.as_ref().map_or("", |d| d.from.as_str()),
+            ),
+            (
+                "derive_target.to",
+                spec.derive_target.as_ref().map_or("", |d| d.to.as_str()),
+            ),
+        ] {
+            if val.contains('\u{0}') {
+                return Err(Error::rule_config(
+                    rule_id,
+                    format!("scope_filter manifest `{field}:` must not contain a NUL byte"),
+                ));
+            }
+        }
         let source = normalize_confined(Path::new(&spec.source)).ok_or_else(|| {
             Error::rule_config(
                 rule_id,
@@ -233,10 +257,10 @@ impl ManifestPredicate {
             .map(|(from, to)| format!("{}\u{0}{to}", from.as_str()))
             .unwrap_or_default();
         // `Extract`'s Debug is a stable, injective rendering of the resolved
-        // extractor. NUL (`\0`) delimits every component — it can't occur in a
-        // YAML scalar (`source`/`from`/`to`) — so the key is injective: two rules
-        // co-cache iff their `(source, extract, derive_target)` is identical.
-        // (A plain `=>` between `from`/`to` would let `{from:"a", to:"b=>c"}` and
+        // extractor. NUL (`\0`) delimits every component and is rejected above in
+        // `source`/`from`/`to`, so the key is injective: two rules co-cache iff
+        // their `(source, extract, derive_target)` is identical. (A plain `=>`
+        // between `from`/`to` would let `{from:"a", to:"b=>c"}` and
         // `{from:"a=>b", to:"c"}` forge one key and share a wrong set.)
         let cache_key = format!("{}\u{0}{extract:?}\u{0}{dt_key}", source.display());
         Ok(Self {
@@ -280,11 +304,20 @@ impl ManifestPredicate {
         raw.into_iter()
             .filter(|e| !is_non_literal(e))
             .filter_map(|entry| {
-                let mapped = match &self.derive_target {
-                    // A non-matching entry is not a mapped output — dropped,
-                    // matching file_graph's derive_target.
-                    Some((from, to)) => derive_target(from, to, &entry)?,
-                    None => PathBuf::from(entry),
+                // A non-matching derive_target entry is not a mapped output —
+                // dropped, matching file_graph's derive_target.
+                let mapped = if let Some((from, to)) = &self.derive_target {
+                    derive_target(from, to, &entry)?
+                } else {
+                    // Reject an entry that is vacuous or escaping on its own
+                    // (``, `.`, `x/..`, `../y`) BEFORE joining `base`, mirroring
+                    // the derive_target branch. Otherwise, for a nested manifest,
+                    // `base.join("")` == `base`, so a stray `.` / empty entry
+                    // would scope the manifest's WHOLE subtree — the silent
+                    // footgun the empty-set safety is meant to prevent (at the
+                    // repo root such entries already normalize to `None` below).
+                    normalize_confined(Path::new(&entry))?;
+                    PathBuf::from(entry)
                 };
                 normalize_confined(&base.join(mapped))
             })
@@ -310,7 +343,7 @@ pub struct ResolvedManifestScope {
 /// under the canonical root, ADR-0004), and cap the read at the analysis limit.
 /// Returns "" if the manifest is absent, escapes the root, or is too large; the
 /// predicate then shows the empty set.
-fn read_manifest_confined(root: &Path, rel: &Path) -> String {
+pub(crate) fn read_manifest_confined(root: &Path, rel: &Path) -> String {
     let abs = root.join(rel);
     let (Ok(croot), Ok(cabs)) = (root.canonicalize(), abs.canonicalize()) else {
         return String::new();
@@ -1173,6 +1206,43 @@ mod tests {
             b.manifest_predicates()[0].cache_key(),
             "distinct derive_targets must not forge one cache key"
         );
+    }
+
+    #[test]
+    fn from_spec_rejects_nul_in_derive_target() {
+        // A double-quoted YAML `"a\0b"` decodes to a literal NUL, which would
+        // break the NUL-delimited cache key's injectivity -> rejected at build.
+        let spec: ScopeFilterSpec = serde_yaml_ng::from_str(
+            "include_manifest_paths:\n  source: m.json\n  extract: { json: \"$.x[*]\" }\n  derive_target: { from: \"x\", to: \"a\\0b\" }",
+        )
+        .expect("scope_filter parses");
+        let err = ScopeFilter::from_spec("r", spec).unwrap_err();
+        assert!(
+            err.to_string().contains("NUL"),
+            "expected a NUL rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_set_drops_vacuous_nested_entry() {
+        // A nested manifest's `.` / `` / self-canceling entry must be dropped, not
+        // resolved to the manifest's own directory (`base.join(".")` == base),
+        // which would silently scope the manifest's whole subtree. A real child is
+        // still kept, resolved under the manifest dir.
+        let f = manifest_filter(
+            "include_manifest_paths:\n  source: pkg/tsconfig.json\n  extract: { json: \"$.include[*]\" }",
+        );
+        let set =
+            f.manifest_predicates()[0].resolve_set(r#"{"include": [".", "", "a/..", "src"]}"#);
+        assert!(
+            !set.contains(Path::new("pkg")),
+            "a vacuous entry must not scope the whole subtree: {set:?}"
+        );
+        assert!(
+            set.contains(Path::new("pkg/src")),
+            "a real child resolves under the manifest dir: {set:?}"
+        );
+        assert_eq!(set.len(), 1, "only the real child survives: {set:?}");
     }
 
     #[test]

--- a/crates/alint-core/src/scope_filter.rs
+++ b/crates/alint-core/src/scope_filter.rs
@@ -230,10 +230,14 @@ impl ManifestPredicate {
         };
         let dt_key = derive_target
             .as_ref()
-            .map(|(from, to)| format!("{}=>{to}", from.as_str()))
+            .map(|(from, to)| format!("{}\u{0}{to}", from.as_str()))
             .unwrap_or_default();
         // `Extract`'s Debug is a stable, injective rendering of the resolved
-        // extractor — enough to co-cache two rules with an identical config.
+        // extractor. NUL (`\0`) delimits every component — it can't occur in a
+        // YAML scalar (`source`/`from`/`to`) — so the key is injective: two rules
+        // co-cache iff their `(source, extract, derive_target)` is identical.
+        // (A plain `=>` between `from`/`to` would let `{from:"a", to:"b=>c"}` and
+        // `{from:"a=>b", to:"c"}` forge one key and share a wrong set.)
         let cache_key = format!("{}\u{0}{extract:?}\u{0}{dt_key}", source.display());
         Ok(Self {
             cache_key,
@@ -1153,6 +1157,25 @@ mod tests {
     }
 
     #[test]
+    fn distinct_derive_targets_do_not_share_a_cache_key() {
+        // Regression: the `derive_target` component of the cache key must be
+        // injective. A plain `=>` join let `{from:"a", to:"b=>c"}` and
+        // `{from:"a=>b", to:"c"}` forge one key (identical source+extract) and
+        // silently share a wrong resolved set. NUL-delimiting keeps them distinct.
+        let a = manifest_filter(
+            "include_manifest_paths:\n  source: package.json\n  extract: { json: \"$.bin.*\" }\n  derive_target: { from: \"a\", to: \"b=>c\" }",
+        );
+        let b = manifest_filter(
+            "include_manifest_paths:\n  source: package.json\n  extract: { json: \"$.bin.*\" }\n  derive_target: { from: \"a=>b\", to: \"c\" }",
+        );
+        assert_ne!(
+            a.manifest_predicates()[0].cache_key(),
+            b.manifest_predicates()[0].cache_key(),
+            "distinct derive_targets must not forge one cache key"
+        );
+    }
+
+    #[test]
     fn read_manifest_confined_reads_in_root_and_refuses_escape() {
         let root_dir = tempfile::tempdir().unwrap();
         let root = root_dir.path();
@@ -1205,6 +1228,35 @@ mod tests {
                 .unwrap()
                 .contains(Path::new("crates/a")),
             "the resolved set is visible on the filtered index after the copy"
+        );
+    }
+
+    #[test]
+    fn changed_since_diff_copies_onto_the_filtered_changed_index() {
+        // Sibling of the manifest copy: a `scope_filter.changed_since:` diff is
+        // resolved on the FULL index and must be copied onto the fresh `--changed`
+        // filtered index too, else a `changed_since` rule silently matches nothing
+        // under `--changed` (the diff cache would be unpopulated on the filtered
+        // index).
+        let full = idx(&["a.rs"]);
+        let mut m = std::collections::HashMap::new();
+        m.insert(
+            "REF".to_string(),
+            [PathBuf::from("a.rs")].into_iter().collect(),
+        );
+        full.set_changed_paths(m);
+        let filtered = idx(&["a.rs"]); // fresh filtered index, empty cache
+        assert!(
+            filtered.changed_paths("REF").is_none(),
+            "filtered index starts with no changed-paths cache"
+        );
+        filtered.set_changed_paths(full.changed_paths_map().unwrap().clone());
+        assert!(
+            filtered
+                .changed_paths("REF")
+                .unwrap()
+                .contains(Path::new("a.rs")),
+            "the changed_since diff is visible on the filtered index after the copy"
         );
     }
 }

--- a/crates/alint-core/src/structured_format.rs
+++ b/crates/alint-core/src/structured_format.rs
@@ -1,0 +1,384 @@
+//! Structured-document parsing shared by the structured-query rule
+//! family (`{json,yaml,toml,xml}_path_*`) and core-side predicates
+//! that need to read a config / manifest into a `serde_json::Value`
+//! tree.
+//!
+//! [`Format`] parses JSON / YAML / TOML / XML into one uniform
+//! `serde_json::Value` shape (YAML and TOML coerce through serde; XML
+//! maps via the xmltodict-style convention in `xml_to_value` — `@attr`
+//! / `#text` / repeated-element→array, leaf elements collapse to their
+//! text string, namespaces flatten to local names, every leaf is a
+//! string), so a single `JSONPath` engine only ever has to reason
+//! about one tree shape. XML design + open-question resolutions:
+//! `docs/design/v0.10/xml_path.md`.
+
+use serde_json::Value;
+
+/// Which YAML-flavoured parser to use on the target file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    Json,
+    Yaml,
+    Toml,
+    Xml,
+}
+
+impl Format {
+    pub fn parse(self, text: &str) -> std::result::Result<Value, String> {
+        match self {
+            // Try strict JSON first (the common, fast path — plain
+            // JSON is byte-for-byte unchanged). Only on failure retry
+            // tolerating JSONC: `//` + `/* */` comments and trailing
+            // commas, which the JS/TS ecosystem uses pervasively in
+            // `.json` files (tsconfig.json, `.vscode/*.json`). If the
+            // tolerant retry also fails, surface the *original* strict
+            // error so genuinely-broken JSON reports accurately.
+            Self::Json => serde_json::from_str(text).or_else(|strict_err| {
+                serde_json::from_str(&strip_jsonc(text)).map_err(|_| strict_err.to_string())
+            }),
+            Self::Yaml => {
+                // Bound flow-nesting before libyaml parses it super-linearly (a
+                // crafted `[[[…` file otherwise hangs the run) — the YAML analogue
+                // of the `xml_depth_within_limit` guard below. JSON (serde_json,
+                // 128-deep) and TOML (toml, 80-deep) carry their own limits.
+                if !crate::yaml_depth::flow_depth_within_limit(text) {
+                    return Err(format!(
+                        "YAML flow nesting exceeds the maximum supported depth ({})",
+                        crate::yaml_depth::MAX_YAML_FLOW_DEPTH
+                    ));
+                }
+                serde_yaml_ng::from_str(text).map_err(|e| e.to_string())
+            }
+            Self::Toml => toml::from_str(text).map_err(|e| e.to_string()),
+            Self::Xml => xml_to_value(text),
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Json => "JSON",
+            Self::Yaml => "YAML",
+            Self::Toml => "TOML",
+            Self::Xml => "XML",
+        }
+    }
+
+    /// Detect the format from a path's extension. Returns `None`
+    /// for unknown extensions; callers decide how to fall back
+    /// (require an explicit `format:` override, default to JSON,
+    /// emit a per-file violation, etc).
+    pub fn detect_from_path(path: &std::path::Path) -> Option<Self> {
+        match path.extension()?.to_str()? {
+            "json" => Some(Self::Json),
+            "yaml" | "yml" => Some(Self::Yaml),
+            "toml" => Some(Self::Toml),
+            "xml" | "csproj" | "props" | "targets" | "vbproj" | "fsproj" | "nuspec" => {
+                Some(Self::Xml)
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Make a JSONC document parseable as strict JSON: drop `//` and
+/// `/* … */` comments and trailing commas (a `,` immediately before a
+/// `]` / `}`). String-aware — markers inside `"…"` (with `\` escapes)
+/// are preserved, so a `"https://…"` URL or a `","` literal is
+/// untouched. Only invoked when strict parsing already failed, so
+/// plain JSON never pays for it.
+fn strip_jsonc(src: &str) -> String {
+    // Pass 1: remove comments.
+    let mut decommented = String::with_capacity(src.len());
+    let mut chars = src.chars().peekable();
+    let mut in_string = false;
+    while let Some(c) = chars.next() {
+        if in_string {
+            decommented.push(c);
+            if c == '\\' {
+                if let Some(n) = chars.next() {
+                    decommented.push(n);
+                }
+            } else if c == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match c {
+            '"' => {
+                in_string = true;
+                decommented.push(c);
+            }
+            '/' if chars.peek() == Some(&'/') => {
+                for n in chars.by_ref() {
+                    if n == '\n' {
+                        decommented.push('\n');
+                        break;
+                    }
+                }
+            }
+            '/' if chars.peek() == Some(&'*') => {
+                chars.next();
+                let mut prev = '\0';
+                for n in chars.by_ref() {
+                    if prev == '*' && n == '/' {
+                        break;
+                    }
+                    prev = n;
+                }
+            }
+            _ => decommented.push(c),
+        }
+    }
+    // Pass 2: drop trailing commas (`,` then whitespace then `]`/`}`).
+    let cs: Vec<char> = decommented.chars().collect();
+    let mut out = String::with_capacity(cs.len());
+    let mut in_string = false;
+    let mut i = 0;
+    while i < cs.len() {
+        let c = cs[i];
+        if in_string {
+            out.push(c);
+            if c == '\\' {
+                i += 1;
+                if i < cs.len() {
+                    out.push(cs[i]);
+                }
+            } else if c == '"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        if c == '"' {
+            in_string = true;
+            out.push(c);
+            i += 1;
+            continue;
+        }
+        if c == ',' {
+            let mut j = i + 1;
+            while j < cs.len() && cs[j].is_whitespace() {
+                j += 1;
+            }
+            if j < cs.len() && (cs[j] == ']' || cs[j] == '}') {
+                // Drop the comma; keep the intervening whitespace.
+                out.extend(&cs[i + 1..j]);
+                i = j;
+                continue;
+            }
+        }
+        out.push(c);
+        i += 1;
+    }
+    out
+}
+
+// ---------------------------------------------------------------
+// XML → serde_json::Value
+//
+// xmltodict-style convention so the JSONPath a user writes reads
+// like the XML they see. Full rationale + false-positive surface:
+// `docs/design/v0.10/xml_path.md`.
+// ---------------------------------------------------------------
+
+/// Maximum XML element-nesting depth `xml_to_value` will
+/// descend. Real config/manifest XML (`.csproj`, `pom.xml`, …)
+/// is a handful of levels deep; 256 is far beyond any real
+/// manifest yet far below the recursion depth that would
+/// overflow the stack. A document nested deeper is rejected as a
+/// parse error (one per-file violation via the existing
+/// parse-error path) rather than recursed into — a crafted or
+/// accidental deeply-nested file must never abort the run. The
+/// other formats' parsers carry their own internal recursion
+/// limits; this is the XML arm's equivalent.
+pub const MAX_XML_DEPTH: usize = 256;
+
+/// Conservatively bound the raw XML's element-nesting depth BEFORE
+/// `roxmltree::Document::parse` sees it. `Document::parse` descends recursively
+/// per element and overflows the stack — **aborting the whole process** — on
+/// deeply-nested input (tens of thousands of levels); the `element_to_value`
+/// [`MAX_XML_DEPTH`] guard is post-parse, so it only catches depths the parser
+/// already survived. A cheap linear pre-scan rejects an over-deep document here
+/// (as one ordinary per-file parse-error violation) so a crafted or accidental
+/// `<a><a>…` file can never abort the run. Comment / CDATA / PI / declaration
+/// regions are skipped so their contents don't count toward depth.
+fn xml_depth_within_limit(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut pos = 0usize;
+    let mut depth = 0usize;
+    while pos < bytes.len() {
+        if bytes[pos] != b'<' {
+            pos += 1;
+            continue;
+        }
+        let rest = &text[pos..];
+        if rest.starts_with("</") {
+            depth = depth.saturating_sub(1);
+            pos += 2;
+        } else if rest.starts_with("<!--") {
+            pos += rest.find("-->").map_or(rest.len(), |p| p + 3);
+        } else if rest.starts_with("<![CDATA[") {
+            pos += rest.find("]]>").map_or(rest.len(), |p| p + 3);
+        } else if rest.starts_with("<!") || rest.starts_with("<?") {
+            // DOCTYPE / PI / other declaration: skip to its terminating `>`.
+            pos += rest.find('>').map_or(rest.len(), |p| p + 1);
+        } else {
+            // `<tag …>` or `<tag/>`: find the closing `>` respecting quoted
+            // attribute values (a `>` inside `"…"`/`'…'` isn't the tag end).
+            let tag = rest.as_bytes();
+            let mut end = 1usize;
+            let mut quote: Option<u8> = None;
+            while end < tag.len() {
+                let ch = tag[end];
+                if let Some(q) = quote {
+                    if ch == q {
+                        quote = None;
+                    }
+                } else if ch == b'"' || ch == b'\'' {
+                    quote = Some(ch);
+                } else if ch == b'>' {
+                    break;
+                }
+                end += 1;
+            }
+            // Self-closing `<tag/>` opens and closes, so it adds no depth.
+            let self_closing = end >= 2 && tag[end - 1] == b'/';
+            if !self_closing {
+                depth += 1;
+                if depth > MAX_XML_DEPTH {
+                    return false;
+                }
+            }
+            pos += end + 1;
+        }
+    }
+    true
+}
+
+/// Parse XML into the same `serde_json::Value` tree the rest of
+/// the family queries. The document maps to
+/// `{ <root-element-name>: <root value> }` so the root element is
+/// the first `JSONPath` segment (`$.Project…`, `$.project…`).
+fn xml_to_value(text: &str) -> std::result::Result<Value, String> {
+    // Reject over-deep XML before `Document::parse` can overflow the stack.
+    if !xml_depth_within_limit(text) {
+        return Err(format!(
+            "XML nesting exceeds the maximum supported depth ({MAX_XML_DEPTH})"
+        ));
+    }
+    let doc = roxmltree::Document::parse(text).map_err(|e| e.to_string())?;
+    let root = doc.root_element();
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        root.tag_name().name().to_owned(),
+        element_to_value(root, 0)?,
+    );
+    Ok(Value::Object(obj))
+}
+
+/// One element → its `Value`. Attributes become `@name` keys;
+/// repeated child elements of the same (local) name become a JSON
+/// array in document order; loose text becomes `#text` when the
+/// element also has attributes/children, or *is* the value when
+/// the element is a pure leaf. Empty element → `null`. Namespaces
+/// are flattened to the local name (Open question 1 in the design
+/// doc). `depth` bounds recursion at `MAX_XML_DEPTH`: past the
+/// bound it returns `Err` (surfaced as one parse-error violation
+/// via the caller) instead of recursing into a stack abort.
+fn element_to_value(node: roxmltree::Node, depth: usize) -> std::result::Result<Value, String> {
+    if depth >= MAX_XML_DEPTH {
+        return Err(format!(
+            "XML nesting exceeds the maximum supported depth ({MAX_XML_DEPTH})"
+        ));
+    }
+    let mut obj = serde_json::Map::new();
+    for attr in node.attributes() {
+        obj.insert(
+            format!("@{}", attr.name()),
+            Value::String(attr.value().to_owned()),
+        );
+    }
+    let mut has_child_elem = false;
+    for child in node.children().filter(roxmltree::Node::is_element) {
+        has_child_elem = true;
+        let name = child.tag_name().name().to_owned();
+        let val = element_to_value(child, depth + 1)?;
+        match obj.get_mut(&name) {
+            Some(Value::Array(arr)) => arr.push(val),
+            Some(slot) => {
+                let prev = slot.take();
+                *slot = Value::Array(vec![prev, val]);
+            }
+            None => {
+                obj.insert(name, val);
+            }
+        }
+    }
+    let text: String = node
+        .children()
+        .filter(roxmltree::Node::is_text)
+        .filter_map(|n| n.text())
+        .collect();
+    let text = text.trim();
+    if obj.is_empty() && !has_child_elem {
+        return Ok(if text.is_empty() {
+            Value::Null
+        } else {
+            Value::String(text.to_owned())
+        });
+    }
+    if !text.is_empty() {
+        obj.insert("#text".to_owned(), Value::String(text.to_owned()));
+    }
+    Ok(Value::Object(obj))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─── JSONC tolerance ──────────────────────────────────────
+
+    #[test]
+    fn json_parse_tolerates_jsonc() {
+        // tsconfig.json-style: `//` + `/* */` comments and trailing
+        // commas. Strict parse fails, the tolerant retry succeeds.
+        let jsonc = "{\n  // line comment\n  \"a\": 1, /* block */\n  \"b\": [1, 2,],\n}\n";
+        let v = Format::Json.parse(jsonc).expect("JSONC should parse");
+        assert_eq!(v["a"], serde_json::json!(1));
+        assert_eq!(v["b"], serde_json::json!([1, 2]));
+    }
+
+    #[test]
+    fn json_parse_preserves_comment_markers_inside_strings() {
+        // `//` and `,` inside string values must NOT be stripped.
+        let s = "{ \"url\": \"https://x/y\", \"note\": \"a,b\" }";
+        let v = Format::Json.parse(s).expect("plain JSON");
+        assert_eq!(v["url"], serde_json::json!("https://x/y"));
+        assert_eq!(v["note"], serde_json::json!("a,b"));
+    }
+
+    #[test]
+    fn broken_json_keeps_the_strict_error() {
+        // A genuinely-malformed document (not JSONC) must still fail,
+        // and report the *strict* parser's message.
+        let err = Format::Json.parse("{ \"x\": 1, \"y\" }").unwrap_err();
+        assert!(err.contains("expected"), "strict error preserved: {err}");
+    }
+
+    #[test]
+    fn xml_depth_scan_does_not_count_comments_cdata_or_self_closing() {
+        // The pre-scan must not over-count: comment/CDATA contents and
+        // self-closing tags don't add nesting, so valid shallow docs pass.
+        assert!(xml_depth_within_limit(
+            "<r><!-- <a><a><a> --><c/><![CDATA[ <b><b> ]]><d attr=\"x>y\"/></r>"
+        ));
+        // A genuinely deep run is rejected.
+        let deep = format!("{}{}", "<a>".repeat(300), "</a>".repeat(300));
+        assert!(!xml_depth_within_limit(&deep));
+        // Real manifest depth is fine.
+        assert!(xml_depth_within_limit(
+            "<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>"
+        ));
+    }
+}

--- a/crates/alint-core/src/walker.rs
+++ b/crates/alint-core/src/walker.rs
@@ -263,6 +263,16 @@ impl FileIndex {
         let _ = self.changed_paths.set(map);
     }
 
+    /// The whole resolved `changed_since` diff map, if populated. Like
+    /// [`Self::manifest_paths_map`], the engine resolves diffs against the FULL
+    /// index and copies the result onto the pre-filtered `--changed` index (whose
+    /// own entries omit the ref-diff set), so a per-file `scope_filter.changed_since:`
+    /// still resolves under `--changed` instead of silently matching nothing.
+    #[must_use]
+    pub fn changed_paths_map(&self) -> Option<&HashMap<String, HashSet<std::path::PathBuf>>> {
+        self.changed_paths.get()
+    }
+
     /// Look up the cached manifest-derived path set for a predicate's cache key.
     /// `None` means the cache wasn't populated for this key (manifest absent /
     /// unresolved); the predicate treats it as the empty set.

--- a/crates/alint-core/src/walker.rs
+++ b/crates/alint-core/src/walker.rs
@@ -269,7 +269,9 @@ impl FileIndex {
     /// own entries omit the ref-diff set), so a per-file `scope_filter.changed_since:`
     /// still resolves under `--changed` instead of silently matching nothing.
     #[must_use]
-    pub fn changed_paths_map(&self) -> Option<&HashMap<String, HashSet<std::path::PathBuf>>> {
+    pub(crate) fn changed_paths_map(
+        &self,
+    ) -> Option<&HashMap<String, HashSet<std::path::PathBuf>>> {
         self.changed_paths.get()
     }
 
@@ -277,7 +279,7 @@ impl FileIndex {
     /// `None` means the cache wasn't populated for this key (manifest absent /
     /// unresolved); the predicate treats it as the empty set.
     #[must_use]
-    pub fn manifest_paths(&self, cache_key: &str) -> Option<&HashSet<std::path::PathBuf>> {
+    pub(crate) fn manifest_paths(&self, cache_key: &str) -> Option<&HashSet<std::path::PathBuf>> {
         self.manifest_paths.get()?.get(cache_key)
     }
 
@@ -301,7 +303,9 @@ impl FileIndex {
     /// still sees the set. The declared path set is independent of which files
     /// the run visits, so the same map is valid for both.
     #[must_use]
-    pub fn manifest_paths_map(&self) -> Option<&HashMap<String, HashSet<std::path::PathBuf>>> {
+    pub(crate) fn manifest_paths_map(
+        &self,
+    ) -> Option<&HashMap<String, HashSet<std::path::PathBuf>>> {
         self.manifest_paths.get()
     }
 

--- a/crates/alint-core/src/walker.rs
+++ b/crates/alint-core/src/walker.rs
@@ -175,6 +175,14 @@ pub struct FileIndex {
     /// predicate silently matches nothing). Read lock-free in the
     /// hot loop after `set`.
     changed_paths: OnceLock<HashMap<String, HashSet<std::path::PathBuf>>>,
+    /// Per-predicate manifest-derived path sets backing
+    /// `scope_filter.include_manifest_paths:` / `exclude_manifest_paths:`. Keyed
+    /// by each predicate's canonical `(source, extract, derive_target)` cache
+    /// key, so rules sharing a config share one resolved set. Populated once by
+    /// the engine before per-file dispatch (a missing key = empty set, so the
+    /// predicate contributes nothing). Read lock-free in the hot loop after
+    /// `set`.
+    manifest_paths: OnceLock<HashMap<String, HashSet<std::path::PathBuf>>>,
     /// Evaluated `facts:` values, cached so repeated [`Engine::run_for_file`]
     /// calls (the LSP per-keystroke path) don't re-scan the tree.
     /// ASSUMPTION: a given index is evaluated by one engine's fact set
@@ -205,6 +213,7 @@ impl FileIndex {
             path_set: OnceLock::new(),
             parent_to_children: OnceLock::new(),
             changed_paths: OnceLock::new(),
+            manifest_paths: OnceLock::new(),
             facts: OnceLock::new(),
         }
     }
@@ -252,6 +261,27 @@ impl FileIndex {
     /// one index across `run` + `fix` is safe.
     pub fn set_changed_paths(&self, map: HashMap<String, HashSet<std::path::PathBuf>>) {
         let _ = self.changed_paths.set(map);
+    }
+
+    /// Look up the cached manifest-derived path set for a predicate's cache key.
+    /// `None` means the cache wasn't populated for this key (manifest absent /
+    /// unresolved); the predicate treats it as the empty set.
+    #[must_use]
+    pub fn manifest_paths(&self, cache_key: &str) -> Option<&HashSet<std::path::PathBuf>> {
+        self.manifest_paths.get()?.get(cache_key)
+    }
+
+    /// `true` once the engine has populated the manifest-paths cache.
+    #[must_use]
+    pub fn manifest_paths_initialized(&self) -> bool {
+        self.manifest_paths.get().is_some()
+    }
+
+    /// Populate the manifest-paths cache (engine-only, once per run, before
+    /// parallel dispatch). A no-op if already set, so re-using one index across
+    /// `run` + `fix` is safe.
+    pub fn set_manifest_paths(&self, map: HashMap<String, HashSet<std::path::PathBuf>>) {
+        let _ = self.manifest_paths.set(map);
     }
 
     pub fn files(&self) -> impl Iterator<Item = &FileEntry> {

--- a/crates/alint-core/src/walker.rs
+++ b/crates/alint-core/src/walker.rs
@@ -284,6 +284,17 @@ impl FileIndex {
         let _ = self.manifest_paths.set(map);
     }
 
+    /// The whole resolved manifest-paths map, if populated. The engine resolves
+    /// manifests against the FULL index (so `find_file` reaches them) and copies
+    /// the result onto the pre-filtered `--changed` index (whose own entries omit
+    /// unchanged manifests), so per-file `matches` against the filtered index
+    /// still sees the set. The declared path set is independent of which files
+    /// the run visits, so the same map is valid for both.
+    #[must_use]
+    pub fn manifest_paths_map(&self) -> Option<&HashMap<String, HashSet<std::path::PathBuf>>> {
+        self.manifest_paths.get()
+    }
+
     pub fn files(&self) -> impl Iterator<Item = &FileEntry> {
         self.entries.iter().filter(|e| !e.is_dir)
     }

--- a/crates/alint-dsl/schemas/v1/config.json
+++ b/crates/alint-dsl/schemas/v1/config.json
@@ -954,7 +954,7 @@
           "type": "object"
         },
         "expect_nonempty": {
-          "description": "`include_manifest_paths` only: warn when the extracted set is empty (default true). An empty include set silently no-ops the whole rule; set false for a rule that legitimately tolerates it.",
+          "description": "`include_manifest_paths` only: warn when the extracted set is empty (default true). An empty include set silently no-ops the whole rule; set false for a rule that legitimately tolerates it. Ignored on `exclude_manifest_paths` (an empty exclude set is safe: full scope, visible over-firing).",
           "type": "boolean"
         },
         "extract": {

--- a/crates/alint-dsl/schemas/v1/config.json
+++ b/crates/alint-dsl/schemas/v1/config.json
@@ -929,6 +929,49 @@
       ],
       "type": "string"
     },
+    "manifest_path_set": {
+      "additionalProperties": false,
+      "description": "A manifest-derived path set (ADR-0010). The set is extracted from `source` once per run, optionally mapped by `derive_target`, resolved relative to the manifest's own directory, and confined to the repo root. `include_manifest_paths` keeps only files whose path is in the set; `exclude_manifest_paths` drops files whose path is in it. Manifest values gate which files the rule sees, never what it decides about a file (a content rule never reads the manifest).",
+      "properties": {
+        "derive_target": {
+          "additionalProperties": false,
+          "description": "Optional {from, to} regex mapping applied to each extracted path, e.g. mapping a package.json `bin` build output (dist/cli.js) back to its source (src/cli.ts). An entry that does not match `from` is dropped, as file_graph's derive_target drops a non-matching node.",
+          "properties": {
+            "from": {
+              "description": "Regex matched against each extracted path; $1-style capture groups substitute into `to`.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "to": {
+              "description": "The replacement template producing the mapped (source) path.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "from",
+            "to"
+          ],
+          "type": "object"
+        },
+        "expect_nonempty": {
+          "description": "`include_manifest_paths` only: warn when the extracted set is empty (default true). An empty include set silently no-ops the whole rule; set false for a rule that legitimately tolerates it.",
+          "type": "boolean"
+        },
+        "extract": {
+          "$ref": "#/$defs/extract_spec"
+        },
+        "source": {
+          "description": "The manifest file, always repo-root-confined (a manifest a rule scopes by lives in the repo; an escaping source is a build-time error). Its declared paths resolve relative to its own directory.",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "source",
+        "extract"
+      ],
+      "type": "object"
+    },
     "nested_rule": {
       "description": "A nested rule inside `require:`. Unlike top-level rules, `id` and `level` are synthesized from the parent; the user supplies only `kind` plus kind-specific options.",
       "properties": {
@@ -3669,14 +3712,27 @@
           "required": [
             "changed_since"
           ]
+        },
+        {
+          "required": [
+            "include_manifest_paths"
+          ]
+        },
+        {
+          "required": [
+            "exclude_manifest_paths"
+          ]
         }
       ],
-      "description": "Per-file rule scoping. `has_ancestor` (v0.9.6+) admits files whose ancestor chain contains a named manifest; `changed_since` (v0.11+) admits files in a `<ref>...HEAD` git diff. At least one must be set; setting both is an AND. Supported on per-file rules and on `dir_absent` (since v0.9.18). Cross-file rules (`pair`, `for_each_dir`, `file_exists`, etc.) reject `scope_filter:` at build time. Combine with the rule's existing `paths:` glob — all gates must match for the rule to fire.",
+      "description": "Per-file rule scoping. `has_ancestor` (v0.9.6+) admits files whose ancestor chain contains a named manifest; `changed_since` (v0.11+) admits files in a `<ref>...HEAD` git diff. At least one must be set; setting both is an AND. Supported on per-file rules and on `dir_absent` (since v0.9.18). Cross-file rules (`pair`, `for_each_dir`, `file_exists`, etc.) reject `scope_filter:` at build time. Combine with the rule's existing `paths:` glob — all gates must match for the rule to fire. `include_manifest_paths` / `exclude_manifest_paths` (v0.15+) admit or drop files by membership in a path set a manifest declares (ADR-0010).",
       "properties": {
         "changed_since": {
           "description": "Git ref; the rule only fires on files in the `<ref>...HEAD` diff (the same merge-base diff as `alint check --changed`). Right shape for grandfathering pre-existing files in a PR — e.g. require an SPDX header only on files the PR touched. Accepts the `{{env.X}}` interpolation (e.g. `changed_since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`). Outside a git repo the predicate matches nothing (silent); an unresolvable ref inside a repo is a hard error with a shallow-clone hint.",
           "minLength": 1,
           "type": "string"
+        },
+        "exclude_manifest_paths": {
+          "$ref": "#/$defs/manifest_path_set"
         },
         "has_ancestor": {
           "description": "Manifest filename (or list of filenames) whose presence in any ancestor directory of the linted file admits the rule. Each entry is a literal filename like `Cargo.toml` or `package.json` — no path separators, no glob metacharacters; the ancestor walk handles \"anywhere up the tree\" by traversing `Path::parent()` upward.",
@@ -3694,6 +3750,9 @@
               "type": "array"
             }
           ]
+        },
+        "include_manifest_paths": {
+          "$ref": "#/$defs/manifest_path_set"
         }
       },
       "type": "object"

--- a/crates/alint-dsl/src/nested.rs
+++ b/crates/alint-dsl/src/nested.rs
@@ -251,6 +251,33 @@ fn scope_rule(rule: &mut Mapping, prefix: &str, source: &str) -> Result<()> {
         }
     }
 
+    // A manifest predicate's `source:` is a path relative to this config's
+    // directory (like `paths:`), so rebase it under the nested prefix — else a
+    // nested rule would read the repo-root manifest, not its own package's, and
+    // silently mis-scope. `has_ancestor:` / `changed_since:` need no rebasing (a
+    // bare filename walked up the tree / a git ref). Not counted toward
+    // `any_scoped`: a per-file rule still needs its own `paths:` base glob.
+    if let Some(sf) = rule
+        .get_mut("scope_filter")
+        .and_then(serde_yaml_ng::Value::as_mapping_mut)
+    {
+        for key in ["include_manifest_paths", "exclude_manifest_paths"] {
+            if let Some(src) = sf
+                .get_mut(key)
+                .and_then(serde_yaml_ng::Value::as_mapping_mut)
+                .and_then(|mp| mp.get_mut("source"))
+                && let serde_yaml_ng::Value::String(s) = src
+            {
+                *s = scope_glob(s, prefix).map_err(|e| {
+                    Error::rule_config(
+                        &id_hint,
+                        format!("scoping `scope_filter.{key}.source` in {source}: {e}"),
+                    )
+                })?;
+            }
+        }
+    }
+
     if !any_scoped {
         return Err(Error::rule_config(
             &id_hint,

--- a/crates/alint-e2e/scenarios/check/changed/changed_keeps_dir_absent_on_full_tree.yml
+++ b/crates/alint-e2e/scenarios/check/changed/changed_keeps_dir_absent_on_full_tree.yml
@@ -1,0 +1,39 @@
+name: --changed keeps dir_absent (a directory rule) evaluating on the full tree
+tags: [check, check_changed, changed, dir_absent]
+
+# Complement to `changed_skips_existence_rule_when_scope_disjoint` (file_absent):
+# a forbidden `build/` dir was committed; the current diff only adds an untracked
+# `src/foo.rs`. Unlike a FILE pattern (`**/.env`, which intersects the diff when
+# the file changes), dir_absent's DIRECTORY pattern (`**/build`) can never appear
+# in a file-path changed-set — so it must NOT be `--changed`-skipped, or it would
+# never fire. dir_absent (like dir_exists) is `requires_full_index` with no
+# `path_scope`, so it always evaluates on the full tree and still flags the
+# standing forbidden dir. Regression guard: round-3 briefly gave dir_absent a
+# `path_scope`, which made `--changed` skip it and silently miss standing dirs.
+
+given:
+  tree:
+    README.md: "# demo\n"
+    build:
+      out.o: "x\n"
+    src:
+      foo.rs: "fn main() {}\n"
+  config: |
+    version: 1
+    rules:
+      - id: no-build
+        kind: dir_absent
+        paths: "**/build"
+        level: error
+  git:
+    init: true
+    add: [README.md, build/out.o]
+    commit: true
+
+when: [check, check_changed]
+
+expect:
+  - violations:
+      - {rule: no-build, level: error, path: "build"}
+  - violations:
+      - {rule: no-build, level: error, path: "build"}

--- a/crates/alint-e2e/scenarios/check/scope_filter/exclude_manifest_paths_bin_entrypoint.yml
+++ b/crates/alint-e2e/scenarios/check/scope_filter/exclude_manifest_paths_bin_entrypoint.yml
@@ -1,0 +1,37 @@
+name: exclude_manifest_paths exempts the package.json bin entrypoint via derive_target
+tags: [check, scope_filter, file_content_forbidden]
+
+# The motivating case (ADR-0010): package.json `bin` declares a build output
+# (dist/cli.js). `derive_target` maps it back to src/cli.ts, which
+# `exclude_manifest_paths` exempts from a no-console rule. src/lib.ts (not an
+# entrypoint the manifest declares) still fires. This exercises the whole path:
+# extract -> derive_target -> confine -> per-file exclusion.
+
+given:
+  tree:
+    package.json: |
+      { "bin": { "cli": "dist/cli.js" } }
+    src:
+      cli.ts: "console.log('entrypoint');\n"
+      lib.ts: "console.log('lib');\n"
+  config: |
+    version: 1
+    rules:
+      - id: no-console
+        kind: file_content_forbidden
+        paths: "src/**/*.ts"
+        pattern: 'console\.(log|debug|info)\('
+        level: error
+        scope_filter:
+          exclude_manifest_paths:
+            source: package.json
+            extract: { json: "$.bin.*" }
+            derive_target: { from: '^dist/(.*)\.js$', to: 'src/$1.ts' }
+
+when: [check]
+
+expect:
+  # src/cli.ts is the declared (mapped) entrypoint -> silently exempt.
+  # If the exclusion were a no-op, src/cli.ts would also fire and this fails.
+  - violations:
+      - {rule: no-console, level: error, path: src/lib.ts}

--- a/crates/alint-e2e/scenarios/check/scope_filter/include_manifest_paths_nested_config.yml
+++ b/crates/alint-e2e/scenarios/check/scope_filter/include_manifest_paths_nested_config.yml
@@ -1,0 +1,39 @@
+name: include_manifest_paths in a nested config reads the nested package's own manifest
+tags: [check, scope_filter, no_trailing_whitespace, nested]
+
+# A packages/foo/.alint.yml rule with `source: package.json` must resolve to
+# packages/foo/package.json (rebased to the nested dir), not the repo-root one,
+# and its declared paths resolve under that dir. Guards the nested-source rebase:
+# lib/a.ts (declared in src) fires; other/b.ts (not declared) is out of scope.
+
+given:
+  config: |
+    version: 1
+    nested_configs: true
+    rules: []
+  tree:
+    packages:
+      foo:
+        "package.json": |
+          { "src": ["lib"] }
+        ".alint.yml": |
+          version: 1
+          rules:
+            - id: nws
+              kind: no_trailing_whitespace
+              paths: "**/*.ts"
+              level: warning
+              scope_filter:
+                include_manifest_paths:
+                  source: package.json
+                  extract: { json: "$.src[*]" }
+        lib:
+          "a.ts": "const a = 1; \n"
+        other:
+          "b.ts": "const b = 1; \n"
+
+when: [check]
+
+expect:
+  - violations:
+      - {rule: nws, level: warning, path: packages/foo/lib/a.ts}

--- a/crates/alint-e2e/scenarios/check/scope_filter/include_manifest_paths_non_per_file_rule.yml
+++ b/crates/alint-e2e/scenarios/check/scope_filter/include_manifest_paths_non_per_file_rule.yml
@@ -1,0 +1,39 @@
+name: include_manifest_paths resolves for a non-per-file rule (filename_case)
+tags: [check, scope_filter, filename_case]
+
+# Regression (round-3 audit): manifest scope must resolve for rules dispatched in
+# the rule-major partition too, not only PerFileRule content rules. filename_case
+# applies its scope per file but isn't a PerFileRule, so the resolver used to miss
+# it (it exposed no path_scope) AND resolution ran after the rule-major loop --
+# both fixed. BadName.rs under the declared member fires; the non-member one is
+# out of scope. All four shipped scope_filter e2e scenarios used content rules,
+# which is why this class slipped.
+
+given:
+  config: |
+    version: 1
+    rules:
+      - id: names
+        kind: filename_case
+        case: snake
+        paths: "**/*.rs"
+        level: error
+        scope_filter:
+          include_manifest_paths:
+            source: Cargo.toml
+            extract: { toml: "$.workspace.members[*]" }
+  tree:
+    "Cargo.toml": |
+      [workspace]
+      members = ["crates/a"]
+    crates:
+      a:
+        "BadName.rs": "fn a() {}\n"
+    vendor:
+      "OtherBad.rs": "fn v() {}\n"
+
+when: [check]
+
+expect:
+  - violations:
+      - {rule: names, level: error, path: crates/a/BadName.rs}

--- a/crates/alint-e2e/scenarios/check/scope_filter/include_manifest_paths_workspace_members.yml
+++ b/crates/alint-e2e/scenarios/check/scope_filter/include_manifest_paths_workspace_members.yml
@@ -1,0 +1,36 @@
+name: include_manifest_paths scopes a rule to only the declared Cargo.toml workspace members
+tags: [check, scope_filter, no_trailing_whitespace]
+
+# Cargo.toml `workspace.members` declares DIRECTORIES (crates/a).
+# `include_manifest_paths` keeps only files UNDER a declared member:
+# crates/a/lib.rs (trailing space) fires; vendor/x.rs (trailing space but not a
+# member) is silently out of scope. Exercises directory-aware prefix membership.
+
+given:
+  tree:
+    Cargo.toml: |
+      [workspace]
+      members = ["crates/a"]
+    crates:
+      a:
+        lib.rs: "fn a() {} \n"
+    vendor:
+      x.rs: "fn x() {} \n"
+  config: |
+    version: 1
+    rules:
+      - id: nws
+        kind: no_trailing_whitespace
+        paths: "**/*.rs"
+        level: warning
+        scope_filter:
+          include_manifest_paths:
+            source: Cargo.toml
+            extract: { toml: "$.workspace.members[*]" }
+
+when: [check]
+
+expect:
+  # Only the file under the declared member fires; vendor/x.rs is out of scope.
+  - violations:
+      - {rule: nws, level: warning, path: crates/a/lib.rs}

--- a/crates/alint-e2e/scenarios/check/scope_filter/manifest_paths_absent_manifest_is_silent.yml
+++ b/crates/alint-e2e/scenarios/check/scope_filter/manifest_paths_absent_manifest_is_silent.yml
@@ -1,0 +1,31 @@
+name: exclude_manifest_paths with an absent manifest scopes nothing (rule runs full-scope)
+tags: [check, scope_filter, no_trailing_whitespace]
+
+# No package.json exists. `exclude_manifest_paths` resolves to the empty set, so
+# the exclusion drops nothing and the rule runs over its full `paths:` glob - the
+# has_ancestor-consistent silent degrade for a missing manifest, not an error.
+
+given:
+  tree:
+    src:
+      a.rs: "fn a() {} \n"
+      b.rs: "fn b() {} \n"
+  config: |
+    version: 1
+    rules:
+      - id: nws
+        kind: no_trailing_whitespace
+        paths: "src/**/*.rs"
+        level: warning
+        scope_filter:
+          exclude_manifest_paths:
+            source: package.json
+            extract: { json: "$.bin.*" }
+
+when: [check]
+
+expect:
+  # Both files fire: the absent manifest excludes nothing.
+  - violations:
+      - {rule: nws, level: warning, path: src/a.rs}
+      - {rule: nws, level: warning, path: src/b.rs}

--- a/crates/alint-e2e/scenarios/check/scope_filter/nested_manifest_dot_entry_does_not_scope_subtree.yml
+++ b/crates/alint-e2e/scenarios/check/scope_filter/nested_manifest_dot_entry_does_not_scope_subtree.yml
@@ -1,0 +1,38 @@
+name: a nested manifest '.' entry does not scope the whole subtree
+tags: [check, scope_filter, nested, file_content_forbidden]
+
+# Regression (round-3 audit): a nested-manifest entry that normalizes to nothing
+# on its own (`.`, ``, `x/..`) must be dropped, not resolved to the manifest's own
+# directory -- otherwise `base.join(".")` == base and the entry would scope the
+# manifest's WHOLE subtree. Here an exclude with `"."` must therefore resolve to
+# the EMPTY set (full scope), so the forbidden `console.` still fires.
+
+given:
+  config: |
+    version: 1
+    nested_configs: true
+    rules: []
+  tree:
+    pkg:
+      "tsconfig.json": |
+        { "include": ["."] }
+      ".alint.yml": |
+        version: 1
+        rules:
+          - id: forbid
+            kind: file_content_forbidden
+            paths: "**/*.ts"
+            pattern: "console\\."
+            level: error
+            scope_filter:
+              exclude_manifest_paths:
+                source: tsconfig.json
+                extract: { json: "$.include[*]" }
+      src:
+        "app.ts": "console.log(1)\n"
+
+when: [check]
+
+expect:
+  - violations:
+      - {rule: forbid, level: error, path: pkg/src/app.ts}

--- a/crates/alint-rules/src/cross_file.rs
+++ b/crates/alint-rules/src/cross_file.rs
@@ -37,10 +37,11 @@
 use std::collections::{BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 
-use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Scope, Violation};
+use alint_core::{
+    Context, Error, Extract, ExtractSpec, Level, Result, Rule, RuleSpec, Scope, Violation,
+    extract_values, is_non_literal,
+};
 use serde::Deserialize;
-
-use crate::extract::{Extract, ExtractSpec, extract_values, is_non_literal};
 
 /// The file whose extracted value(s) form the reference side of the relation:
 /// a single `{ file, extract }`, or (set relations only) `{ files: <glob>,
@@ -1371,7 +1372,7 @@ mod tests {
             Extract::Json("$.sdk.version".into()),
             Targets::List(vec![(
                 "Directory.Build.props".into(),
-                Some(Extract::Lines(crate::extract::LinesOpts::default())),
+                Some(Extract::Lines(alint_core::LinesOpts::default())),
             )]),
             Relation::Equals,
             Normalize::SemverMajor,
@@ -1422,7 +1423,7 @@ mod tests {
             Extract::Json("$.v".into()),
             Targets::List(vec![(
                 "protobuf_version.bzl".into(),
-                Some(Extract::Lines(crate::extract::LinesOpts::default())),
+                Some(Extract::Lines(alint_core::LinesOpts::default())),
             )]),
             Relation::Equals,
             Normalize::SemverMinor,
@@ -1901,7 +1902,7 @@ mod tests {
         let idx = index(&["manifest.txt", "src/a.rs", "src/b.rs"]);
         let r = resolves_rule(
             "manifest.txt",
-            Extract::Lines(crate::extract::LinesOpts::default()),
+            Extract::Lines(alint_core::LinesOpts::default()),
         );
         assert!(eval(&r, root, &idx).is_empty());
     }

--- a/crates/alint-rules/src/dir_absent.rs
+++ b/crates/alint-rules/src/dir_absent.rs
@@ -37,13 +37,14 @@ pub struct DirAbsentRule {
 }
 
 impl Rule for DirAbsentRule {
-    /// Expose the per-file scope so the engine resolves this rule's
-    /// `scope_filter` (manifest sets, `changed_since:`) before dispatch and
-    /// can `--changed`-skip it (see `Rule::path_scope`).
-    fn path_scope(&self) -> Option<&Scope> {
-        Some(&self.scope)
-    }
-
+    // Deliberately NO `path_scope` override (mirrors `dir_exists`): this is a
+    // directory rule (`requires_full_index = true`, scope matches dir paths), and
+    // a directory scope doesn't intersect a file-path-based `--changed` set, so
+    // exposing `path_scope` would let `skip_for_changed` wrongly skip a standing
+    // forbidden dir on every `--changed` run. `has_ancestor` still works (it
+    // resolves inside `evaluate`); manifest `scope_filter` is rejected loud by the
+    // engine's `ensure_manifest_scope_resolvable` guard rather than silently
+    // no-op'ing -- manifest-set scope isn't meaningful on a whole-tree dir rule.
     alint_core::rule_common_impl!();
     fn git_tracked_mode(&self) -> alint_core::GitTrackedMode {
         if self.git_tracked_only {

--- a/crates/alint-rules/src/dir_absent.rs
+++ b/crates/alint-rules/src/dir_absent.rs
@@ -37,6 +37,13 @@ pub struct DirAbsentRule {
 }
 
 impl Rule for DirAbsentRule {
+    /// Expose the per-file scope so the engine resolves this rule's
+    /// `scope_filter` (manifest sets, `changed_since:`) before dispatch and
+    /// can `--changed`-skip it (see `Rule::path_scope`).
+    fn path_scope(&self) -> Option<&Scope> {
+        Some(&self.scope)
+    }
+
     alint_core::rule_common_impl!();
     fn git_tracked_mode(&self) -> alint_core::GitTrackedMode {
         if self.git_tracked_only {

--- a/crates/alint-rules/src/executable_bit.rs
+++ b/crates/alint-rules/src/executable_bit.rs
@@ -37,6 +37,13 @@ pub struct ExecutableBitRule {
 }
 
 impl Rule for ExecutableBitRule {
+    /// Expose the per-file scope so the engine resolves this rule's
+    /// `scope_filter` (manifest sets, `changed_since:`) before dispatch and
+    /// can `--changed`-skip it (see `Rule::path_scope`).
+    fn path_scope(&self) -> Option<&Scope> {
+        Some(&self.scope)
+    }
+
     alint_core::rule_common_impl!();
 
     #[cfg(unix)]

--- a/crates/alint-rules/src/executable_has_shebang.rs
+++ b/crates/alint-rules/src/executable_has_shebang.rs
@@ -29,6 +29,13 @@ pub struct ExecutableHasShebangRule {
 }
 
 impl Rule for ExecutableHasShebangRule {
+    /// Expose the per-file scope so the engine resolves this rule's
+    /// `scope_filter` (manifest sets, `changed_since:`) before dispatch and
+    /// can `--changed`-skip it (see `Rule::path_scope`).
+    fn path_scope(&self) -> Option<&Scope> {
+        Some(&self.scope)
+    }
+
     alint_core::rule_common_impl!();
 
     #[cfg(unix)]

--- a/crates/alint-rules/src/file_graph.rs
+++ b/crates/alint-rules/src/file_graph.rs
@@ -53,11 +53,13 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::slice;
 
-use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Scope, Violation};
+use alint_core::{
+    Context, Error, Extract, ExtractSpec, Level, Result, Rule, RuleSpec, Scope, Violation,
+    extract_values, is_non_literal,
+};
 use regex::Regex;
 use serde::Deserialize;
 
-use crate::extract::{Extract, ExtractSpec, extract_values, is_non_literal};
 use crate::pair_hash::Algorithm;
 
 /// How a content-extracted reference string is turned into a path.
@@ -405,19 +407,22 @@ impl FileGraphRule {
     ) -> Vec<PathBuf> {
         if let EdgeSource::DeriveTarget { from, to } = &self.edges {
             let node_str = node.to_string_lossy();
-            let Some(caps) = from.captures(&node_str) else {
-                return Vec::new();
-            };
-            let mut derived = String::new();
-            caps.expand(to, &mut derived);
-            let Some(target) = crate::pathsafe::normalize_confined(Path::new(&derived)) else {
+            if let Some(target) = alint_core::derive_target(from, to, &node_str) {
+                return vec![target];
+            }
+            // `None` is either "the node doesn't match `from`" (no edge, silent)
+            // or "it matches but derives an out-of-repo target" (an escape).
+            // Re-check the match to tell them apart, and reconstruct the derived
+            // string only for the escape message — the path itself is never read.
+            if let Some(caps) = from.captures(&node_str) {
+                let mut derived = String::new();
+                caps.expand(to, &mut derived);
                 out.push(Self::node_violation(
                     node,
                     &format!("derives the out-of-repo target {derived:?} (escapes the repo root)"),
                 ));
-                return Vec::new();
-            };
-            return vec![target];
+            }
+            return Vec::new();
         }
         let EdgeSource::FromContent { extract, resolve } = &self.edges else {
             return Vec::new();

--- a/crates/alint-rules/src/file_max_size.rs
+++ b/crates/alint-rules/src/file_max_size.rs
@@ -23,6 +23,13 @@ pub struct FileMaxSizeRule {
 }
 
 impl Rule for FileMaxSizeRule {
+    /// Expose the per-file scope so the engine resolves this rule's
+    /// `scope_filter` (manifest sets, `changed_since:`) before dispatch and
+    /// can `--changed`-skip it (see `Rule::path_scope`).
+    fn path_scope(&self) -> Option<&Scope> {
+        Some(&self.scope)
+    }
+
     alint_core::rule_common_impl!();
 
     fn evaluate(&self, ctx: &Context<'_>) -> Result<Vec<Violation>> {

--- a/crates/alint-rules/src/file_min_size.rs
+++ b/crates/alint-rules/src/file_min_size.rs
@@ -34,6 +34,13 @@ pub struct FileMinSizeRule {
 }
 
 impl Rule for FileMinSizeRule {
+    /// Expose the per-file scope so the engine resolves this rule's
+    /// `scope_filter` (manifest sets, `changed_since:`) before dispatch and
+    /// can `--changed`-skip it (see `Rule::path_scope`).
+    fn path_scope(&self) -> Option<&Scope> {
+        Some(&self.scope)
+    }
+
     alint_core::rule_common_impl!();
 
     fn evaluate(&self, ctx: &Context<'_>) -> Result<Vec<Violation>> {

--- a/crates/alint-rules/src/filename_case.rs
+++ b/crates/alint-rules/src/filename_case.rs
@@ -30,6 +30,13 @@ pub struct FilenameCaseRule {
 }
 
 impl Rule for FilenameCaseRule {
+    /// Expose the per-file scope so the engine resolves this rule's
+    /// `scope_filter` (manifest sets, `changed_since:`) before dispatch and
+    /// can `--changed`-skip it (see `Rule::path_scope`).
+    fn path_scope(&self) -> Option<&Scope> {
+        Some(&self.scope)
+    }
+
     alint_core::rule_common_impl!();
 
     fn fixer(&self) -> Option<&dyn Fixer> {

--- a/crates/alint-rules/src/filename_regex.rs
+++ b/crates/alint-rules/src/filename_regex.rs
@@ -31,6 +31,13 @@ pub struct FilenameRegexRule {
 }
 
 impl Rule for FilenameRegexRule {
+    /// Expose the per-file scope so the engine resolves this rule's
+    /// `scope_filter` (manifest sets, `changed_since:`) before dispatch and
+    /// can `--changed`-skip it (see `Rule::path_scope`).
+    fn path_scope(&self) -> Option<&Scope> {
+        Some(&self.scope)
+    }
+
     alint_core::rule_common_impl!();
 
     fn evaluate(&self, ctx: &Context<'_>) -> Result<Vec<Violation>> {

--- a/crates/alint-rules/src/json_schema_passes.rs
+++ b/crates/alint-rules/src/json_schema_passes.rs
@@ -34,12 +34,10 @@
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
-use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Scope, Violation};
+use alint_core::{Context, Error, Format, Level, Result, Rule, RuleSpec, Scope, Violation};
 use jsonschema::Validator;
 use serde::Deserialize;
 use serde_json::Value;
-
-use crate::structured_path::Format;
 
 /// The `format:` override values for `json_schema_passes`. Distinct from
 /// `structured_path::Format` (which has `xml`, not `yml`): this validator targets

--- a/crates/alint-rules/src/json_schema_passes.rs
+++ b/crates/alint-rules/src/json_schema_passes.rs
@@ -89,6 +89,13 @@ pub struct JsonSchemaPassesRule {
 }
 
 impl Rule for JsonSchemaPassesRule {
+    /// Expose the per-file scope so the engine resolves this rule's
+    /// `scope_filter` (manifest sets, `changed_since:`) before dispatch and
+    /// can `--changed`-skip it (see `Rule::path_scope`).
+    fn path_scope(&self) -> Option<&Scope> {
+        Some(&self.scope)
+    }
+
     alint_core::rule_common_impl!();
 
     fn set_allow_out_of_root(&mut self, allow: bool) {

--- a/crates/alint-rules/src/lib.rs
+++ b/crates/alint-rules/src/lib.rs
@@ -77,7 +77,6 @@ pub mod dir_only_contains;
 pub mod every_matching_has;
 pub mod executable_bit;
 pub mod executable_has_shebang;
-mod extract;
 pub mod file_absent;
 pub mod file_content_forbidden;
 pub mod file_content_matches;

--- a/crates/alint-rules/src/max_directory_depth.rs
+++ b/crates/alint-rules/src/max_directory_depth.rs
@@ -31,6 +31,13 @@ pub struct MaxDirectoryDepthRule {
 }
 
 impl Rule for MaxDirectoryDepthRule {
+    /// Expose the per-file scope so the engine resolves this rule's
+    /// `scope_filter` (manifest sets, `changed_since:`) before dispatch and
+    /// can `--changed`-skip it (see `Rule::path_scope`).
+    fn path_scope(&self) -> Option<&Scope> {
+        Some(&self.scope)
+    }
+
     alint_core::rule_common_impl!();
 
     fn evaluate(&self, ctx: &Context<'_>) -> Result<Vec<Violation>> {

--- a/crates/alint-rules/src/max_files_per_directory.rs
+++ b/crates/alint-rules/src/max_files_per_directory.rs
@@ -33,6 +33,13 @@ pub struct MaxFilesPerDirectoryRule {
 }
 
 impl Rule for MaxFilesPerDirectoryRule {
+    /// Expose the per-file scope so the engine resolves this rule's
+    /// `scope_filter` (manifest sets, `changed_since:`) before dispatch and
+    /// can `--changed`-skip it (see `Rule::path_scope`).
+    fn path_scope(&self) -> Option<&Scope> {
+        Some(&self.scope)
+    }
+
     alint_core::rule_common_impl!();
 
     fn evaluate(&self, ctx: &Context<'_>) -> Result<Vec<Violation>> {

--- a/crates/alint-rules/src/no_case_conflicts.rs
+++ b/crates/alint-rules/src/no_case_conflicts.rs
@@ -20,6 +20,13 @@ pub struct NoCaseConflictsRule {
 }
 
 impl Rule for NoCaseConflictsRule {
+    /// Expose the per-file scope so the engine resolves this rule's
+    /// `scope_filter` (manifest sets, `changed_since:`) before dispatch and
+    /// can `--changed`-skip it (see `Rule::path_scope`).
+    fn path_scope(&self) -> Option<&Scope> {
+        Some(&self.scope)
+    }
+
     alint_core::rule_common_impl!();
 
     fn evaluate(&self, ctx: &Context<'_>) -> Result<Vec<Violation>> {

--- a/crates/alint-rules/src/no_empty_files.rs
+++ b/crates/alint-rules/src/no_empty_files.rs
@@ -19,6 +19,13 @@ pub struct NoEmptyFilesRule {
 }
 
 impl Rule for NoEmptyFilesRule {
+    /// Expose the per-file scope so the engine resolves this rule's
+    /// `scope_filter` (manifest sets, `changed_since:`) before dispatch and
+    /// can `--changed`-skip it (see `Rule::path_scope`).
+    fn path_scope(&self) -> Option<&Scope> {
+        Some(&self.scope)
+    }
+
     alint_core::rule_common_impl!();
 
     fn evaluate(&self, ctx: &Context<'_>) -> Result<Vec<Violation>> {

--- a/crates/alint-rules/src/no_illegal_windows_names.rs
+++ b/crates/alint-rules/src/no_illegal_windows_names.rs
@@ -26,6 +26,13 @@ pub struct NoIllegalWindowsNamesRule {
 }
 
 impl Rule for NoIllegalWindowsNamesRule {
+    /// Expose the per-file scope so the engine resolves this rule's
+    /// `scope_filter` (manifest sets, `changed_since:`) before dispatch and
+    /// can `--changed`-skip it (see `Rule::path_scope`).
+    fn path_scope(&self) -> Option<&Scope> {
+        Some(&self.scope)
+    }
+
     alint_core::rule_common_impl!();
 
     fn evaluate(&self, ctx: &Context<'_>) -> Result<Vec<Violation>> {

--- a/crates/alint-rules/src/no_symlinks.rs
+++ b/crates/alint-rules/src/no_symlinks.rs
@@ -22,6 +22,13 @@ pub struct NoSymlinksRule {
 }
 
 impl Rule for NoSymlinksRule {
+    /// Expose the per-file scope so the engine resolves this rule's
+    /// `scope_filter` (manifest sets, `changed_since:`) before dispatch and
+    /// can `--changed`-skip it (see `Rule::path_scope`).
+    fn path_scope(&self) -> Option<&Scope> {
+        Some(&self.scope)
+    }
+
     alint_core::rule_common_impl!();
 
     fn evaluate(&self, ctx: &Context<'_>) -> Result<Vec<Violation>> {

--- a/crates/alint-rules/src/pathsafe.rs
+++ b/crates/alint-rules/src/pathsafe.rs
@@ -3,11 +3,12 @@
 //! gate also defends against). Two layers, because a lexical check alone
 //! is not enough:
 //!
-//! - [`normalize_confined`] / [`confine`] are the *lexical* gate: pure, no
-//!   filesystem access, and the subject of the Kani proof below. They
-//!   reject absolute and `..`-escaping paths but are **symlink-blind** — a
-//!   lexically-confined `link/x` still resolves outside the tree if `link`
-//!   is an in-repo symlink pointing out of it.
+//! - [`normalize_confined`] (re-exported from `alint-core`, where the
+//!   lexical gate and its Kani proof now live) is the *lexical* gate:
+//!   pure, no filesystem access. It rejects absolute and `..`-escaping
+//!   paths but is **symlink-blind** — a lexically-confined `link/x` still
+//!   resolves outside the tree if `link` is an in-repo symlink pointing
+//!   out of it.
 //! - [`confine_read`] / [`resolved_within_root`] add the *filesystem*
 //!   gate: after joining under the root they follow symlinks and re-verify
 //!   containment. Every config-derived **read** must go through these, not
@@ -16,63 +17,14 @@
 //!
 //! Design: `docs/design/v0.12/path-confinement.md`.
 
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
-/// Normalise `p` lexically (collapsing `.` and `a/../b`) and return it
-/// **only if it stays within the repo root**.
-///
-/// Returns `None` when the path escapes the root:
-/// - an absolute component (`RootDir` / Windows `Prefix`) — because
-///   `root.join(absolute)` discards `root`, so reading it would touch
-///   an arbitrary host path;
-/// - a `..` that cannot pop a real component (caught *during* the
-///   walk, so `../../escape` and `a/../../x` are rejected, not merely
-///   inspected after the fact);
-/// - a result that collapses to empty (`.`, `a/..`) — the root itself
-///   is never a valid edge / target / reference.
-///
-/// A `Some(_)` result is guaranteed root-relative *lexically*: safe to
-/// look up in the (symlink-pruned) `FileIndex`. For a direct filesystem
-/// **read** it is **not** sufficient — `root.join(result)` still follows
-/// any in-repo symlink out of the tree — so reads must go through
-/// [`confine_read`] / [`resolved_within_root`], never this result alone.
-pub(crate) fn normalize_confined(p: &Path) -> Option<PathBuf> {
-    let mut out = PathBuf::new();
-    for comp in p.components() {
-        match comp {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                // A `..` that can't pop a real component escapes root.
-                if !out.pop() {
-                    return None;
-                }
-            }
-            Component::Normal(c) => out.push(c),
-            // Absolute (Unix root or Windows prefix) escapes by
-            // definition — never let it reach `root.join`.
-            Component::RootDir | Component::Prefix(_) => return None,
-        }
-    }
-    if out.as_os_str().is_empty() {
-        return None;
-    }
-    debug_assert!(
-        is_confined(&out),
-        "normalize_confined produced a non-confined path: {}",
-        out.display()
-    );
-    Some(out)
-}
-
-/// The confinement invariant every `Some(_)` from [`normalize_confined`]
-/// upholds: a non-empty, purely root-relative path — every component is
-/// `Normal` (no `..`, no `.`, no absolute `RootDir`/`Prefix`). Checked at
-/// runtime by the `debug_assert` above and exhaustively-for-bounded-inputs
-/// by the `confinement_invariant` property test. This is the security
-/// contract: a value satisfying it is safe to `root.join(..)`.
-fn is_confined(p: &Path) -> bool {
-    !p.as_os_str().is_empty() && p.components().all(|c| matches!(c, Component::Normal(_)))
-}
+// The lexical confinement primitive (`normalize_confined` + its private
+// `is_confined` helper) now lives in `alint-core`, along with its Kani
+// proof and property tests. Re-exported here so the crate-internal
+// `crate::pathsafe::normalize_confined` call sites and the filesystem-aware
+// layer below keep resolving unchanged.
+pub(crate) use alint_core::normalize_confined;
 
 /// The verdict for a config-derived *read* path, accounting for the
 /// rule's `allow_out_of_root` permission (see
@@ -173,127 +125,10 @@ pub(crate) fn confine_read(path: &Path, root: &Path, allow_escape: bool) -> Conf
     }
 }
 
-/// A bounded, verifiable model of the confinement policy — the only
-/// distinction the walk makes between path components, decoupled from
-/// `std::path::Component` (which carries an unbounded `OsStr`) so the
-/// policy is provable over fixed-size inputs. `normalize_confined` is the
-/// real, `PathBuf`-building implementation this abstracts; the
-/// `agrees_with_proven_model` property checks they never disagree.
-#[cfg(any(test, kani))]
-mod model {
-    use std::path::Component;
-
-    #[cfg_attr(kani, derive(kani::Arbitrary))]
-    #[derive(Clone, Copy)]
-    pub(super) enum Step {
-        Normal,
-        Parent,
-        Cur,
-        AbsRoot,
-    }
-
-    pub(super) fn step_of(c: &Component) -> Step {
-        match c {
-            Component::Normal(_) => Step::Normal,
-            Component::CurDir => Step::Cur,
-            Component::ParentDir => Step::Parent,
-            Component::RootDir | Component::Prefix(_) => Step::AbsRoot,
-        }
-    }
-
-    /// Fold component steps into the surviving root-relative depth, or
-    /// `None` on any escape (an absolute component, or a `..` that
-    /// underflows the root). `Some(depth)` requires `depth > 0` — the
-    /// root itself is never a valid confined path.
-    pub(super) fn confine_steps(steps: impl IntoIterator<Item = Step>) -> Option<usize> {
-        let mut depth = 0usize;
-        for s in steps {
-            match s {
-                Step::Normal => depth += 1,
-                Step::Cur => {}
-                Step::Parent => depth = depth.checked_sub(1)?,
-                Step::AbsRoot => return None,
-            }
-        }
-        (depth > 0).then_some(depth)
-    }
-}
-
-/// Kani bounded proof of the confinement policy. Run with `cargo kani`
-/// (not part of standard preflight — Kani is a separate, heavier
-/// toolchain). See `docs/design/formal-methods.md`.
-#[cfg(kani)]
-mod kani_proofs {
-    use super::model::{Step, confine_steps};
-
-    /// For every bounded component sequence, `confine_steps` implements
-    /// the confinement policy *exactly*: it escapes (`None`) on any
-    /// absolute component or on a `..` that underflows the root, and
-    /// otherwise yields the surviving depth `#Normal - #Parent` (with the
-    /// empty root, depth 0, rejected). The proof checks this against an
-    /// **independent counting formulation** of the spec — a different
-    /// algorithm shape from the early-return fold under test — so it
-    /// catches a real escape bug (e.g. a `..` that fails to pop), not just
-    /// the weaker side-conditions (`AbsRoot => None`, `depth <= #Normal`)
-    /// an earlier version proved. It also proves the `..` arithmetic never
-    /// underflows or panics.
-    #[kani::proof]
-    #[kani::unwind(7)]
-    fn confine_steps_is_sound() {
-        let steps: [Step; 6] = kani::any();
-        let result = confine_steps(steps);
-
-        // Independent spec: walk the whole sequence counting a running
-        // balance; the policy escapes iff any absolute component is
-        // present or the balance ever goes negative (a `..` underflowing
-        // the root). When no escape occurs, the depth is the final
-        // balance, and depth 0 (the bare root) is not a valid path.
-        let has_abs = steps.iter().any(|s| matches!(s, Step::AbsRoot));
-        let mut balance: i64 = 0;
-        let mut underflowed = false;
-        for s in &steps {
-            match s {
-                Step::Normal => balance += 1,
-                Step::Parent => {
-                    balance -= 1;
-                    if balance < 0 {
-                        underflowed = true;
-                    }
-                }
-                Step::Cur | Step::AbsRoot => {}
-            }
-        }
-        let expected = if has_abs || underflowed || balance <= 0 {
-            None
-        } else {
-            Some(balance as usize)
-        };
-
-        assert!(
-            result == expected,
-            "confine_steps must implement the confinement policy exactly"
-        );
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::normalize_confined;
-    use proptest::prelude::*;
-    use std::path::{Path, PathBuf};
-
-    fn confined(s: &str) -> Option<PathBuf> {
-        normalize_confined(Path::new(s))
-    }
-
-    #[test]
-    fn in_tree_paths_normalise_and_pass() {
-        assert_eq!(confined("a/b.rs"), Some(PathBuf::from("a/b.rs")));
-        assert_eq!(confined("./a/./b"), Some(PathBuf::from("a/b")));
-        assert_eq!(confined("a/x/../b"), Some(PathBuf::from("a/b")));
-        // pops back to root then descends — stays in-tree.
-        assert_eq!(confined("a/../b"), Some(PathBuf::from("b")));
-    }
+    use std::path::Path;
 
     #[cfg(unix)]
     #[test]
@@ -344,30 +179,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn absolute_paths_are_rejected() {
-        // root.join(absolute) would discard root — the read-oracle.
-        assert_eq!(confined("/etc/passwd"), None);
-        assert_eq!(confined("/tmp/secret.txt"), None);
-    }
-
-    #[test]
-    fn root_escaping_dotdot_is_rejected_including_cancellation() {
-        assert_eq!(confined("../x"), None);
-        // The double-dot-cancellation escape a first-component check
-        // misses: `../../escape` must NOT collapse to in-tree `escape`.
-        assert_eq!(confined("../../escape"), None);
-        assert_eq!(confined("a/../../x"), None);
-        assert_eq!(confined("a/b/../../../c"), None);
-    }
-
-    #[test]
-    fn empty_or_root_collapse_is_rejected() {
-        assert_eq!(confined(""), None);
-        assert_eq!(confined("."), None);
-        assert_eq!(confined("a/.."), None); // collapses to the root itself
-    }
-
     /// The `allow_out_of_root` decision surface -- the actual allow/deny
     /// gate. In-tree is always `In`; an escaping path is `Denied` without
     /// the permission and `AllowedEscape` with it.
@@ -392,70 +203,5 @@ mod tests {
             confine(Path::new("/etc/passwd"), true),
             Confined::AllowedEscape(_)
         ));
-    }
-
-    /// A path strategy that actually exercises the confinement logic: each
-    /// component is a short name, `..`, or `.`, joined by `/` and
-    /// optionally absolute. A flat character regex produces `..` in well
-    /// under 0.01% of cases, so it almost never hits the `..`-underflow
-    /// rejection (the headline cancellation attack); this makes escapes,
-    /// cancellation, and root underflow common, so the properties stress
-    /// the security-critical rejection paths, not just the in-tree case.
-    fn confinement_paths() -> impl Strategy<Value = String> {
-        let component = prop_oneof![
-            3 => "[a-z]{1,4}",
-            2 => Just("..".to_string()),
-            1 => Just(".".to_string()),
-        ];
-        (any::<bool>(), prop::collection::vec(component, 0..8)).prop_map(|(absolute, comps)| {
-            let body = comps.join("/");
-            if absolute { format!("/{body}") } else { body }
-        })
-    }
-
-    proptest! {
-        /// The security invariant, as a property: whatever path the
-        /// config author supplies, a `Some(_)` result is always
-        /// root-confined — every component `Normal`, never empty — so
-        /// `root.join(it)` can never escape the tree.
-        #[test]
-        fn confinement_invariant(s in confinement_paths()) {
-            if let Some(out) = normalize_confined(Path::new(&s)) {
-                prop_assert!(super::is_confined(&out));
-            }
-        }
-
-        /// Normalisation is idempotent: a confined path is a fixed point,
-        /// so re-normalising never changes it (a non-stable normaliser
-        /// would make `equals`/index lookups order-dependent).
-        #[test]
-        fn normalize_confined_is_idempotent(s in confinement_paths()) {
-            if let Some(out) = normalize_confined(Path::new(&s)) {
-                prop_assert_eq!(normalize_confined(&out), Some(out.clone()));
-            }
-        }
-
-        /// The real implementation agrees with the Kani-proven `model`:
-        /// it returns `Some` with N components exactly when the model
-        /// returns `Some(N)`. This ties the bounded proof to the actual
-        /// `PathBuf`-building code.
-        #[test]
-        fn agrees_with_proven_model(s in confinement_paths()) {
-            let p = Path::new(&s);
-            let model = super::model::confine_steps(p.components().map(|c| super::model::step_of(&c)));
-            let real = normalize_confined(p).map(|o| o.components().count());
-            prop_assert_eq!(real, model);
-        }
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn windows_prefix_and_unc_paths_are_rejected() {
-        // On Windows a drive-letter `Prefix` or a UNC `\\server\share`
-        // is absolute → escapes the root, same as a Unix `/etc`. (On
-        // Unix these parse as ordinary `Normal` components, so the test
-        // is Windows-only.)
-        assert_eq!(confined(r"C:\Windows\System32"), None);
-        assert_eq!(confined(r"\\server\share\x"), None);
     }
 }

--- a/crates/alint-rules/src/pathsafe.rs
+++ b/crates/alint-rules/src/pathsafe.rs
@@ -127,7 +127,6 @@ pub(crate) fn confine_read(path: &Path, root: &Path, allow_escape: bool) -> Conf
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_confined;
     use std::path::Path;
 
     #[cfg(unix)]
@@ -136,7 +135,7 @@ mod tests {
         // H1 regression: `normalize_confined` is symlink-blind, so a
         // lexically-confined path (`link/secret`) can read out of the tree
         // when `link` is an in-repo symlink. `confine_read` must catch it.
-        use super::{Confined, confine_read, resolved_within_root};
+        use super::{Confined, confine_read, normalize_confined, resolved_within_root};
         use std::os::unix::fs::symlink;
 
         let root = tempfile::tempdir().unwrap();

--- a/crates/alint-rules/src/registry_paths_resolve.rs
+++ b/crates/alint-rules/src/registry_paths_resolve.rs
@@ -25,11 +25,12 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use alint_core::{Context, Error, Level, Result, Rule, RuleSpec, Scope, Violation};
+use alint_core::{
+    Context, Error, Extract, ExtractSpec, Level, Result, Rule, RuleSpec, Scope, Violation,
+    extract_values, is_non_literal,
+};
 use regex::Regex;
 use serde::Deserialize;
-
-use crate::extract::{Extract, ExtractSpec, extract_values, is_non_literal};
 
 #[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
@@ -543,7 +544,7 @@ pub fn build(spec: &RuleSpec) -> Result<Box<dyn Rule>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extract::LinesOpts;
+    use alint_core::LinesOpts;
     use alint_core::{FileEntry, FileIndex};
 
     fn index(files: &[&str], dirs: &[&str]) -> FileIndex {

--- a/crates/alint-rules/src/shebang_has_executable.rs
+++ b/crates/alint-rules/src/shebang_has_executable.rs
@@ -29,6 +29,13 @@ pub struct ShebangHasExecutableRule {
 }
 
 impl Rule for ShebangHasExecutableRule {
+    /// Expose the per-file scope so the engine resolves this rule's
+    /// `scope_filter` (manifest sets, `changed_since:`) before dispatch and
+    /// can `--changed`-skip it (see `Rule::path_scope`).
+    fn path_scope(&self) -> Option<&Scope> {
+        Some(&self.scope)
+    }
+
     alint_core::rule_common_impl!();
 
     #[cfg(unix)]

--- a/crates/alint-rules/src/structured_path.rs
+++ b/crates/alint-rules/src/structured_path.rs
@@ -48,7 +48,7 @@
 use std::path::{Path, PathBuf};
 
 use alint_core::{
-    Context, Error, Level, PathsSpec, PerFileRule, Result, Rule, RuleSpec, Scope, Violation,
+    Context, Error, Format, Level, PathsSpec, PerFileRule, Result, Rule, RuleSpec, Scope, Violation,
 };
 use regex::Regex;
 use serde::Deserialize;
@@ -84,165 +84,6 @@ fn extract_literal_paths(spec: &PathsSpec) -> Option<Vec<PathBuf>> {
     } else {
         None
     }
-}
-
-/// Which YAML-flavoured parser to use on the target file.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Format {
-    Json,
-    Yaml,
-    Toml,
-    Xml,
-}
-
-impl Format {
-    pub(crate) fn parse(self, text: &str) -> std::result::Result<Value, String> {
-        match self {
-            // Try strict JSON first (the common, fast path — plain
-            // JSON is byte-for-byte unchanged). Only on failure retry
-            // tolerating JSONC: `//` + `/* */` comments and trailing
-            // commas, which the JS/TS ecosystem uses pervasively in
-            // `.json` files (tsconfig.json, `.vscode/*.json`). If the
-            // tolerant retry also fails, surface the *original* strict
-            // error so genuinely-broken JSON reports accurately.
-            Self::Json => serde_json::from_str(text).or_else(|strict_err| {
-                serde_json::from_str(&strip_jsonc(text)).map_err(|_| strict_err.to_string())
-            }),
-            Self::Yaml => {
-                // Bound flow-nesting before libyaml parses it super-linearly (a
-                // crafted `[[[…` file otherwise hangs the run) — the YAML analogue
-                // of the `xml_depth_within_limit` guard below. JSON (serde_json,
-                // 128-deep) and TOML (toml, 80-deep) carry their own limits.
-                if !alint_core::yaml_depth::flow_depth_within_limit(text) {
-                    return Err(format!(
-                        "YAML flow nesting exceeds the maximum supported depth ({})",
-                        alint_core::yaml_depth::MAX_YAML_FLOW_DEPTH
-                    ));
-                }
-                serde_yaml_ng::from_str(text).map_err(|e| e.to_string())
-            }
-            Self::Toml => toml::from_str(text).map_err(|e| e.to_string()),
-            Self::Xml => xml_to_value(text),
-        }
-    }
-
-    pub(crate) fn label(self) -> &'static str {
-        match self {
-            Self::Json => "JSON",
-            Self::Yaml => "YAML",
-            Self::Toml => "TOML",
-            Self::Xml => "XML",
-        }
-    }
-
-    /// Detect the format from a path's extension. Returns `None`
-    /// for unknown extensions; callers decide how to fall back
-    /// (require an explicit `format:` override, default to JSON,
-    /// emit a per-file violation, etc).
-    pub(crate) fn detect_from_path(path: &std::path::Path) -> Option<Self> {
-        match path.extension()?.to_str()? {
-            "json" => Some(Self::Json),
-            "yaml" | "yml" => Some(Self::Yaml),
-            "toml" => Some(Self::Toml),
-            "xml" | "csproj" | "props" | "targets" | "vbproj" | "fsproj" | "nuspec" => {
-                Some(Self::Xml)
-            }
-            _ => None,
-        }
-    }
-}
-
-/// Make a JSONC document parseable as strict JSON: drop `//` and
-/// `/* … */` comments and trailing commas (a `,` immediately before a
-/// `]` / `}`). String-aware — markers inside `"…"` (with `\` escapes)
-/// are preserved, so a `"https://…"` URL or a `","` literal is
-/// untouched. Only invoked when strict parsing already failed, so
-/// plain JSON never pays for it.
-fn strip_jsonc(src: &str) -> String {
-    // Pass 1: remove comments.
-    let mut decommented = String::with_capacity(src.len());
-    let mut chars = src.chars().peekable();
-    let mut in_string = false;
-    while let Some(c) = chars.next() {
-        if in_string {
-            decommented.push(c);
-            if c == '\\' {
-                if let Some(n) = chars.next() {
-                    decommented.push(n);
-                }
-            } else if c == '"' {
-                in_string = false;
-            }
-            continue;
-        }
-        match c {
-            '"' => {
-                in_string = true;
-                decommented.push(c);
-            }
-            '/' if chars.peek() == Some(&'/') => {
-                for n in chars.by_ref() {
-                    if n == '\n' {
-                        decommented.push('\n');
-                        break;
-                    }
-                }
-            }
-            '/' if chars.peek() == Some(&'*') => {
-                chars.next();
-                let mut prev = '\0';
-                for n in chars.by_ref() {
-                    if prev == '*' && n == '/' {
-                        break;
-                    }
-                    prev = n;
-                }
-            }
-            _ => decommented.push(c),
-        }
-    }
-    // Pass 2: drop trailing commas (`,` then whitespace then `]`/`}`).
-    let cs: Vec<char> = decommented.chars().collect();
-    let mut out = String::with_capacity(cs.len());
-    let mut in_string = false;
-    let mut i = 0;
-    while i < cs.len() {
-        let c = cs[i];
-        if in_string {
-            out.push(c);
-            if c == '\\' {
-                i += 1;
-                if i < cs.len() {
-                    out.push(cs[i]);
-                }
-            } else if c == '"' {
-                in_string = false;
-            }
-            i += 1;
-            continue;
-        }
-        if c == '"' {
-            in_string = true;
-            out.push(c);
-            i += 1;
-            continue;
-        }
-        if c == ',' {
-            let mut j = i + 1;
-            while j < cs.len() && cs[j].is_whitespace() {
-                j += 1;
-            }
-            if j < cs.len() && (cs[j] == ']' || cs[j] == '}') {
-                // Drop the comma; keep the intervening whitespace.
-                out.extend(&cs[i + 1..j]);
-                i = j;
-                continue;
-            }
-        }
-        out.push(c);
-        i += 1;
-    }
-    out
 }
 
 /// Comparison op — keeps the rule builders thin.
@@ -546,166 +387,6 @@ fn kind_name(v: &Value) -> &'static str {
 }
 
 // ---------------------------------------------------------------
-// XML → serde_json::Value
-//
-// xmltodict-style convention so the JSONPath a user writes reads
-// like the XML they see. Full rationale + false-positive surface:
-// `docs/design/v0.10/xml_path.md`.
-// ---------------------------------------------------------------
-
-/// Maximum XML element-nesting depth `xml_to_value` will
-/// descend. Real config/manifest XML (`.csproj`, `pom.xml`, …)
-/// is a handful of levels deep; 256 is far beyond any real
-/// manifest yet far below the recursion depth that would
-/// overflow the stack. A document nested deeper is rejected as a
-/// parse error (one per-file violation via the existing
-/// parse-error path) rather than recursed into — a crafted or
-/// accidental deeply-nested file must never abort the run. The
-/// other formats' parsers carry their own internal recursion
-/// limits; this is the XML arm's equivalent.
-const MAX_XML_DEPTH: usize = 256;
-
-/// Conservatively bound the raw XML's element-nesting depth BEFORE
-/// `roxmltree::Document::parse` sees it. `Document::parse` descends recursively
-/// per element and overflows the stack — **aborting the whole process** — on
-/// deeply-nested input (tens of thousands of levels); the `element_to_value`
-/// [`MAX_XML_DEPTH`] guard is post-parse, so it only catches depths the parser
-/// already survived. A cheap linear pre-scan rejects an over-deep document here
-/// (as one ordinary per-file parse-error violation) so a crafted or accidental
-/// `<a><a>…` file can never abort the run. Comment / CDATA / PI / declaration
-/// regions are skipped so their contents don't count toward depth.
-fn xml_depth_within_limit(text: &str) -> bool {
-    let bytes = text.as_bytes();
-    let mut pos = 0usize;
-    let mut depth = 0usize;
-    while pos < bytes.len() {
-        if bytes[pos] != b'<' {
-            pos += 1;
-            continue;
-        }
-        let rest = &text[pos..];
-        if rest.starts_with("</") {
-            depth = depth.saturating_sub(1);
-            pos += 2;
-        } else if rest.starts_with("<!--") {
-            pos += rest.find("-->").map_or(rest.len(), |p| p + 3);
-        } else if rest.starts_with("<![CDATA[") {
-            pos += rest.find("]]>").map_or(rest.len(), |p| p + 3);
-        } else if rest.starts_with("<!") || rest.starts_with("<?") {
-            // DOCTYPE / PI / other declaration: skip to its terminating `>`.
-            pos += rest.find('>').map_or(rest.len(), |p| p + 1);
-        } else {
-            // `<tag …>` or `<tag/>`: find the closing `>` respecting quoted
-            // attribute values (a `>` inside `"…"`/`'…'` isn't the tag end).
-            let tag = rest.as_bytes();
-            let mut end = 1usize;
-            let mut quote: Option<u8> = None;
-            while end < tag.len() {
-                let ch = tag[end];
-                if let Some(q) = quote {
-                    if ch == q {
-                        quote = None;
-                    }
-                } else if ch == b'"' || ch == b'\'' {
-                    quote = Some(ch);
-                } else if ch == b'>' {
-                    break;
-                }
-                end += 1;
-            }
-            // Self-closing `<tag/>` opens and closes, so it adds no depth.
-            let self_closing = end >= 2 && tag[end - 1] == b'/';
-            if !self_closing {
-                depth += 1;
-                if depth > MAX_XML_DEPTH {
-                    return false;
-                }
-            }
-            pos += end + 1;
-        }
-    }
-    true
-}
-
-/// Parse XML into the same `serde_json::Value` tree the rest of
-/// the family queries. The document maps to
-/// `{ <root-element-name>: <root value> }` so the root element is
-/// the first `JSONPath` segment (`$.Project…`, `$.project…`).
-fn xml_to_value(text: &str) -> std::result::Result<Value, String> {
-    // Reject over-deep XML before `Document::parse` can overflow the stack.
-    if !xml_depth_within_limit(text) {
-        return Err(format!(
-            "XML nesting exceeds the maximum supported depth ({MAX_XML_DEPTH})"
-        ));
-    }
-    let doc = roxmltree::Document::parse(text).map_err(|e| e.to_string())?;
-    let root = doc.root_element();
-    let mut obj = serde_json::Map::new();
-    obj.insert(
-        root.tag_name().name().to_owned(),
-        element_to_value(root, 0)?,
-    );
-    Ok(Value::Object(obj))
-}
-
-/// One element → its `Value`. Attributes become `@name` keys;
-/// repeated child elements of the same (local) name become a JSON
-/// array in document order; loose text becomes `#text` when the
-/// element also has attributes/children, or *is* the value when
-/// the element is a pure leaf. Empty element → `null`. Namespaces
-/// are flattened to the local name (Open question 1 in the design
-/// doc). `depth` bounds recursion at `MAX_XML_DEPTH`: past the
-/// bound it returns `Err` (surfaced as one parse-error violation
-/// via the caller) instead of recursing into a stack abort.
-fn element_to_value(node: roxmltree::Node, depth: usize) -> std::result::Result<Value, String> {
-    if depth >= MAX_XML_DEPTH {
-        return Err(format!(
-            "XML nesting exceeds the maximum supported depth ({MAX_XML_DEPTH})"
-        ));
-    }
-    let mut obj = serde_json::Map::new();
-    for attr in node.attributes() {
-        obj.insert(
-            format!("@{}", attr.name()),
-            Value::String(attr.value().to_owned()),
-        );
-    }
-    let mut has_child_elem = false;
-    for child in node.children().filter(roxmltree::Node::is_element) {
-        has_child_elem = true;
-        let name = child.tag_name().name().to_owned();
-        let val = element_to_value(child, depth + 1)?;
-        match obj.get_mut(&name) {
-            Some(Value::Array(arr)) => arr.push(val),
-            Some(slot) => {
-                let prev = slot.take();
-                *slot = Value::Array(vec![prev, val]);
-            }
-            None => {
-                obj.insert(name, val);
-            }
-        }
-    }
-    let text: String = node
-        .children()
-        .filter(roxmltree::Node::is_text)
-        .filter_map(|n| n.text())
-        .collect();
-    let text = text.trim();
-    if obj.is_empty() && !has_child_elem {
-        return Ok(if text.is_empty() {
-            Value::Null
-        } else {
-            Value::String(text.to_owned())
-        });
-    }
-    if !text.is_empty() {
-        obj.insert("#text".to_owned(), Value::String(text.to_owned()));
-    }
-    Ok(Value::Object(obj))
-}
-
-// ---------------------------------------------------------------
 // Builders
 //
 // Eight thin wrappers per (Format, Op) combination. Each consumes
@@ -821,35 +502,6 @@ mod tests {
         assert!(rendered.ends_with('…'), "expected truncation: {rendered}");
         // A short non-ASCII value is returned whole (quoted JSON rendering).
         assert_eq!(short_render(&Value::String("café".to_string())), "\"café\"");
-    }
-
-    // ─── JSONC tolerance ──────────────────────────────────────
-
-    #[test]
-    fn json_parse_tolerates_jsonc() {
-        // tsconfig.json-style: `//` + `/* */` comments and trailing
-        // commas. Strict parse fails, the tolerant retry succeeds.
-        let jsonc = "{\n  // line comment\n  \"a\": 1, /* block */\n  \"b\": [1, 2,],\n}\n";
-        let v = Format::Json.parse(jsonc).expect("JSONC should parse");
-        assert_eq!(v["a"], serde_json::json!(1));
-        assert_eq!(v["b"], serde_json::json!([1, 2]));
-    }
-
-    #[test]
-    fn json_parse_preserves_comment_markers_inside_strings() {
-        // `//` and `,` inside string values must NOT be stripped.
-        let s = "{ \"url\": \"https://x/y\", \"note\": \"a,b\" }";
-        let v = Format::Json.parse(s).expect("plain JSON");
-        assert_eq!(v["url"], serde_json::json!("https://x/y"));
-        assert_eq!(v["note"], serde_json::json!("a,b"));
-    }
-
-    #[test]
-    fn broken_json_keeps_the_strict_error() {
-        // A genuinely-malformed document (not JSONC) must still fail,
-        // and report the *strict* parser's message.
-        let err = Format::Json.parse("{ \"x\": 1, \"y\" }").unwrap_err();
-        assert!(err.contains("expected"), "strict error preserved: {err}");
     }
 
     // ─── build-path errors ────────────────────────────────────
@@ -1223,7 +875,7 @@ mod tests {
         // whole process. The `MAX_XML_DEPTH` guard must instead
         // yield exactly one ordinary parse-error violation for
         // the file (no panic, no abort, per-file contained).
-        let depth = MAX_XML_DEPTH + 50;
+        let depth = alint_core::MAX_XML_DEPTH + 50;
         let xml = format!("{}deep{}", "<a>".repeat(depth), "</a>".repeat(depth));
         let spec = spec_yaml(
             "id: t\n\
@@ -1300,22 +952,6 @@ mod tests {
             "the flow-depth guard message should mention depth: {}",
             v[0].message
         );
-    }
-
-    #[test]
-    fn xml_depth_scan_does_not_count_comments_cdata_or_self_closing() {
-        // The pre-scan must not over-count: comment/CDATA contents and
-        // self-closing tags don't add nesting, so valid shallow docs pass.
-        assert!(xml_depth_within_limit(
-            "<r><!-- <a><a><a> --><c/><![CDATA[ <b><b> ]]><d attr=\"x>y\"/></r>"
-        ));
-        // A genuinely deep run is rejected.
-        let deep = format!("{}{}", "<a>".repeat(300), "</a>".repeat(300));
-        assert!(!xml_depth_within_limit(&deep));
-        // Real manifest depth is fine.
-        assert!(xml_depth_within_limit(
-            "<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>"
-        ));
     }
 
     #[test]

--- a/crates/alint/src/main.rs
+++ b/crates/alint/src/main.rs
@@ -137,7 +137,14 @@ fn url_encode(s: &str) -> String {
 fn init_tracing() {
     use tracing_subscriber::{EnvFilter, fmt};
     let filter = EnvFilter::try_from_env("ALINT_LOG").unwrap_or_else(|_| EnvFilter::new("warn"));
-    let _ = fmt().with_env_filter(filter).with_target(false).try_init();
+    // Diagnostics go to stderr, never stdout: a `warn!` (e.g. an empty
+    // `include_manifest_paths` set) must not corrupt `--format json`/SARIF, which
+    // machine consumers read from stdout. `fmt()`'s default writer is stdout.
+    let _ = fmt()
+        .with_env_filter(filter)
+        .with_target(false)
+        .with_writer(std::io::stderr)
+        .try_init();
 }
 
 fn run(mut cli: Cli) -> Result<ExitCode> {

--- a/crates/alint/src/main.rs
+++ b/crates/alint/src/main.rs
@@ -1268,6 +1268,55 @@ fn fact_value_json(v: &alint_core::FactValue) -> serde_json::Value {
     }
 }
 
+/// Render the `scope_filter:` block for `alint explain` (human format): the
+/// `has_ancestor` / `changed_since` gates, and for the manifest predicates the
+/// paths they resolve to (ADR-0010's legibility mitigation). No-op if unset.
+fn write_scope_filter_explain(
+    out: &mut impl std::io::Write,
+    entry: &alint_core::RuleEntry,
+) -> Result<()> {
+    use alint_output::style;
+    let dim = style::DIM;
+    // scope_filter narrows `paths:` further; you can't read the glob and know the
+    // scope, so surface each gate — and for the manifest predicates, the paths
+    // they actually resolve to (ADR-0010's legibility mitigation).
+    if let Some(sf) = entry.scope_filter() {
+        writeln!(out, "{dim}scope_filter:{dim:#}")?;
+        if let Some(ha) = &sf.has_ancestor {
+            writeln!(out, "  {dim}has_ancestor: {dim:#} {}", ha.join(", "))?;
+        }
+        if let Some(cs) = &sf.changed_since {
+            writeln!(out, "  {dim}changed_since:{dim:#} {cs}")?;
+        }
+        if (sf.include_manifest_paths.is_some() || sf.exclude_manifest_paths.is_some())
+            && let Ok(filter) = alint_core::ScopeFilter::from_spec(entry.rule.id(), sf.clone())
+        {
+            for res in filter.resolved_manifest_sets(Path::new(".")) {
+                let key = if res.include {
+                    "include_manifest_paths"
+                } else {
+                    "exclude_manifest_paths"
+                };
+                let paths = if res.paths.is_empty() {
+                    "(no paths resolved)".to_string()
+                } else {
+                    res.paths
+                        .iter()
+                        .map(|p| p.display().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                };
+                writeln!(
+                    out,
+                    "  {dim}{key}:{dim:#} {} -> {paths}",
+                    res.source.display()
+                )?;
+            }
+        }
+    }
+    Ok(())
+}
+
 fn cmd_explain(rule_id: &str, cli: &Cli) -> Result<ExitCode> {
     use alint_core::Level;
     use alint_output::style;
@@ -1331,6 +1380,7 @@ fn cmd_explain(rule_id: &str, cli: &Cli) -> Result<ExitCode> {
     if let Some(paths) = entry.paths() {
         writeln!(out, "{dim}paths:     {dim:#} {}", paths.render_scope())?;
     }
+    write_scope_filter_explain(&mut out, entry)?;
     // Kind-specific options (pattern, max_lines, ...): the first inline after
     // the `options:` label, the rest indented under the value column. A
     // spec-less entry has no options, so the flattened iterator is empty.
@@ -1404,6 +1454,32 @@ fn explain_json(entry: &alint_core::RuleEntry) -> Result<ExitCode> {
         }
         _ => serde_json::Value::Null,
     };
+    // scope_filter: the configured gates plus, for the manifest predicates, the
+    // paths they resolve to (relative to the CWD, like the human block).
+    let scope_filter = entry.scope_filter().map(|sf| {
+        let manifest_scopes: Vec<_> =
+            alint_core::ScopeFilter::from_spec(entry.rule.id(), sf.clone())
+                .map(|f| f.resolved_manifest_sets(Path::new(".")))
+                .unwrap_or_default()
+                .into_iter()
+                .map(|r| {
+                    serde_json::json!({
+                        "predicate": if r.include {
+                            "include_manifest_paths"
+                        } else {
+                            "exclude_manifest_paths"
+                        },
+                        "source": r.source,
+                        "paths": r.paths,
+                    })
+                })
+                .collect();
+        serde_json::json!({
+            "has_ancestor": sf.has_ancestor,
+            "changed_since": sf.changed_since,
+            "manifest_scopes": manifest_scopes,
+        })
+    });
     let doc = serde_json::json!({
         "schema_version": 1,
         "kind": "rule",
@@ -1421,6 +1497,7 @@ fn explain_json(entry: &alint_core::RuleEntry) -> Result<ExitCode> {
         }),
         "level": entry.rule.level().as_str(),
         "paths": paths,
+        "scope_filter": scope_filter,
         "options": options,
         "message": entry.message().filter(|m| !m.trim().is_empty()),
         "policy_url": entry.rule.policy_url(),

--- a/docs/adr/0010-manifest-derived-rule-scope.md
+++ b/docs/adr/0010-manifest-derived-rule-scope.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-08-06
 decision-makers: asamarts
 ---
@@ -8,11 +8,15 @@ decision-makers: asamarts
 
 ## Status
 
-Proposed. (One of: Proposed | Accepted | Rejected | Deprecated | Superseded by ADR-NNNN.)
+Accepted. (One of: Proposed | Accepted | Rejected | Deprecated | Superseded by ADR-NNNN.)
 
-Proposed pending the companion design doc (`docs/design/v0.15/manifest-derived-scope.md`)
-and its implementation phases. The boundary this ADR draws is settled; the mechanism
-details (predicate shape, source-versus-output handling) are the design doc's to resolve.
+Accepted 2026-08-13 for the v0.15 cut. The companion design doc
+(`docs/design/v0.15/manifest-derived-scope.md`) resolved the mechanism details left open
+here: a narrow `scope_filter` predicate pair, `include_manifest_paths` /
+`exclude_manifest_paths` (not a top-level `path_sets:` block), with `derive_target`
+output-to-source mapping shipping in the same release so the motivating `package.json`
+`bin` case works on arrival rather than as a fast-follow. The boundary this ADR draws is
+unchanged.
 
 ## Context
 

--- a/docs/adr/0010-manifest-derived-rule-scope.md
+++ b/docs/adr/0010-manifest-derived-rule-scope.md
@@ -79,7 +79,13 @@ predicates). Concretely, we will:
   path-confinement gate (ADR-0004).
 
 The one-line invariant: **manifest VALUES may gate WHICH files a rule sees, never WHAT the
-rule decides about a file.**
+rule decides about a file.** Precisely: a manifest value parametrizes the *domain* of files a
+rule is evaluated over — exactly as a static `paths:` glob does — and never crosses into the
+per-file decision function (`evaluate_file`), a message template, a violation's fields, a
+fix, or a `when:` expression. (A rule with a constant per-file verdict, e.g. "flag every
+in-scope file", still has its whole finding set shaped by the domain; that is the same
+domain-level effect a `paths.exclude` glob already has, and is the accepted "legibility
+erodes" consequence below — not a verdict leak.)
 
 The mechanism details deliberately left to the design doc — the exact predicate names,
 whether to ship a narrow `scope_filter` variant or a general named `path_sets:` block, and

--- a/docs/design/v0.15/manifest-derived-scope.md
+++ b/docs/design/v0.15/manifest-derived-scope.md
@@ -210,7 +210,11 @@ the decision taken on each:
    (an escaping `source` is a build-time error). A manifest a rule scopes by lives in the repo,
    so v1 does not honor `allow_out_of_root:` for the manifest read: the policy is a load-time
    per-rule resolution not reachable from `ScopeFilter::from_spec`, and an out-of-root manifest
-   source is not a real use case. Revisit only if one appears.
+   source is not a real use case. Revisit only if one appears. The `source:` is read
+   directly and confined by canonicalisation (as `registry_paths_resolve` / `file_graph`
+   read their sources), NOT through the walked file index — so a `.gitignore`'d or `ignore:`'d
+   manifest is still read (`.gitignore` governs lint *targets*, not a referenced config
+   source), and `alint explain` shows the same resolved set the engine uses.
 7. **Relationship to `has_sibling`.** RESOLVED: `has_sibling` is NOT bundled into v0.15 (a
    separate scope generalisation). The manifest-path predicate is named and shaped as a
    `scope_filter` membership predicate so `has_sibling` joins the same family later without a

--- a/docs/design/v0.15/manifest-derived-scope.md
+++ b/docs/design/v0.15/manifest-derived-scope.md
@@ -203,9 +203,11 @@ the decision taken on each:
 5. **Manifest-absent default.** RESOLVED: the predicate contributes nothing, consistent with
    `has_ancestor`. `exclude_manifest_paths` → full-scope; `include_manifest_paths` → scopes
    nothing and warns (same footgun as the empty set).
-6. **`allow_out_of_root` and confinement.** RESOLVED: honored. `source:` is repo-root-confined
-   under ADR-0004 by default; a rule that sets the existing `allow_out_of_root:` escape lifts
-   the confinement for its manifest read too — no new knob.
+6. **`allow_out_of_root` and confinement.** RESOLVED: `source:` is ALWAYS repo-root-confined
+   (an escaping `source` is a build-time error). A manifest a rule scopes by lives in the repo,
+   so v1 does not honor `allow_out_of_root:` for the manifest read: the policy is a load-time
+   per-rule resolution not reachable from `ScopeFilter::from_spec`, and an out-of-root manifest
+   source is not a real use case. Revisit only if one appears.
 7. **Relationship to `has_sibling`.** RESOLVED: `has_sibling` is NOT bundled into v0.15 (a
    separate scope generalisation). The manifest-path predicate is named and shaped as a
    `scope_filter` membership predicate so `has_sibling` joins the same family later without a

--- a/docs/design/v0.15/manifest-derived-scope.md
+++ b/docs/design/v0.15/manifest-derived-scope.md
@@ -1,6 +1,6 @@
 # Manifest-derived rule scope — narrowing a per-file rule by a manifest's declared paths
 
-Status: Draft. (Draft | Implemented in <commit> | Superseded by <doc>.)
+Status: Draft — spec resolved 2026-08-13 (see §7), implementing for v0.15. (Draft | Implemented in <commit> | Superseded by <doc>.)
 Decisions: [ADR-0010](../../adr/0010-manifest-derived-rule-scope.md) (manifest-derived rule scope stays on the scope_filter seam)
 Demand evidence: the "repo-shape vs manifest" reply drafted in the alint.org marketing tree (`marketing/reddit/drafts/2026-08-reply-repo-shape-vs-manifest.md`); the in-tree `paths.exclude` drift in [`../v0.12/asf_bundle_overfire.md`](../v0.12/asf_bundle_overfire.md).
 
@@ -178,24 +178,35 @@ Mandatory section. What fires wrongly, and the mitigations.
   standard S-scenarios (should be negligible).
 - Every registered predicate needs both a firing and a silent e2e scenario (constitution 8).
 
-## 7. Open questions
+## 7. Resolved decisions
 
-Lead with the crux; resolve each inline with an editorial note when the work lands.
+Resolved 2026-08-13 for the v0.15 cut (ADR-0010 Accepted). The original open questions and
+the decision taken on each:
 
-1. **Source-versus-output — the crux.** Does v1 require source-declaring manifests and ship
-   `derive_target` as a fast-follow, or land both together? Recommendation: v1 =
-   source-declaring (the clean, honest sweet spot), `derive_target` mapping as an immediate
-   follow-up, so the headline `bin` case is documented as "needs the mapper" rather than
-   half-working.
-2. **Shape.** Narrow `scope_filter` predicate (favored: fits the roadmap ScopeFilter
-   generalisation, minimal surface) vs a general named `path_sets:` block (more reusable, new
-   top-level concept). Pick one before schema work.
-3. **Include and exclude.** Two predicates (`include_manifest_paths` /
-   `exclude_manifest_paths`) or one with a `mode:`? Naming should sit with `has_ancestor` and
-   the roadmap's mooted `has_sibling`.
-4. **Empty-set default**: silent no-op vs warn vs `expect_nonempty`.
-5. **Manifest-absent default**: scope-nothing (sibling-consistent) vs warn/error.
-6. **`allow_out_of_root` and confinement** interplay for an external manifest `source:`.
-7. **Relationship to the roadmap's `has_sibling`** idea (ROADMAP, ScopeFilter generalisation
-   line): coordinate so the two land as one coherent generalisation, not two overlapping
-   predicates.
+1. **Source-versus-output — the crux.** RESOLVED: land both together. `derive_target` ships
+   in v0.15 (reusing `file_graph`'s mapper), so the headline `package.json` `bin` case works
+   on arrival — mapping `dist/cli.js` back to `src/cli.ts` — rather than being documented as
+   "needs the mapper." Source-declaring manifests (`Cargo.toml` `workspace.members`,
+   `tsconfig` references, `go.work`, PSR-4 autoload) work without the mapper; build-output
+   manifests opt into it.
+2. **Shape.** RESOLVED: a narrow `scope_filter` predicate, not a top-level `path_sets:` block.
+   It fits the ScopeFilter generalisation and keeps the schema surface minimal. A set reused
+   by many rules is repeated per rule — the accepted cost of not adding a top-level concept;
+   `path_sets:` stays a possible future addition if reuse pressure grows.
+3. **Include and exclude.** RESOLVED: two predicates, `include_manifest_paths` /
+   `exclude_manifest_paths`, not one with a `mode:`. This sits with `has_ancestor` (also a
+   predicate, not a mode) and the roadmap's mooted `has_sibling`.
+4. **Empty-set default.** RESOLVED: `exclude_manifest_paths` with an empty set excludes
+   nothing (the rule runs full-scope — safe), logged at debug. `include_manifest_paths` with
+   an empty set would silently no-op the rule (a "silent cap" the constitution forbids), so it
+   WARNS by default; `expect_nonempty: false` opts out for a rule that tolerates an empty set.
+5. **Manifest-absent default.** RESOLVED: the predicate contributes nothing, consistent with
+   `has_ancestor`. `exclude_manifest_paths` → full-scope; `include_manifest_paths` → scopes
+   nothing and warns (same footgun as the empty set).
+6. **`allow_out_of_root` and confinement.** RESOLVED: honored. `source:` is repo-root-confined
+   under ADR-0004 by default; a rule that sets the existing `allow_out_of_root:` escape lifts
+   the confinement for its manifest read too — no new knob.
+7. **Relationship to `has_sibling`.** RESOLVED: `has_sibling` is NOT bundled into v0.15 (a
+   separate scope generalisation). The manifest-path predicate is named and shaped as a
+   `scope_filter` membership predicate so `has_sibling` joins the same family later without a
+   rework.

--- a/docs/design/v0.15/manifest-derived-scope.md
+++ b/docs/design/v0.15/manifest-derived-scope.md
@@ -197,9 +197,12 @@ the decision taken on each:
    `exclude_manifest_paths`, not one with a `mode:`. This sits with `has_ancestor` (also a
    predicate, not a mode) and the roadmap's mooted `has_sibling`.
 4. **Empty-set default.** RESOLVED: `exclude_manifest_paths` with an empty set excludes
-   nothing (the rule runs full-scope — safe), logged at debug. `include_manifest_paths` with
-   an empty set would silently no-op the rule (a "silent cap" the constitution forbids), so it
-   WARNS by default; `expect_nonempty: false` opts out for a rule that tolerates an empty set.
+   nothing, so the rule runs full-scope — safe, and the resulting over-firing is *visible*
+   (more violations, not fewer), so no warning is needed. `include_manifest_paths` with an
+   empty set would silently no-op the rule (silent under-firing — a "silent cap" the
+   constitution forbids), so it WARNS by default; `expect_nonempty: false` opts out for a rule
+   that tolerates an empty set. (An absent, unreadable, or root-escaping manifest resolves to
+   the empty set through the same paths.)
 5. **Manifest-absent default.** RESOLVED: the predicate contributes nothing, consistent with
    `has_ancestor`. `exclude_manifest_paths` → full-scope; `include_manifest_paths` → scopes
    nothing and warns (same footgun as the empty set).

--- a/docs/site/configuration/index.md
+++ b/docs/site/configuration/index.md
@@ -161,7 +161,7 @@ Common per-rule fields:
 - **`level`** *(required)*: `error`, `warning`, `info`, or `off`. `off` disables the rule entirely.
 - **`paths`**: glob, list of globs, or `{include, exclude}` pair. Required for most kinds.
 - **`when`**: bounded expression gating the rule on facts / vars.
-- **`scope_filter`**: closest-ancestor manifest scoping for per-file rules (see below). Cross-file rules reject this field at build time.
+- **`scope_filter`**: extra per-file scoping — by ancestor manifest presence, git diff, or membership in a manifest-declared path set (see below). Cross-file rules reject this field at build time.
 - **`fix`**: fix-op declaration (e.g. `file_trim_trailing_whitespace: {}`).
 - **`message`**: override the rule's display message.
 - **`policy_url`**: link surfaced when the rule fires.
@@ -196,7 +196,45 @@ rules:
     level: error
 ```
 
-It accepts the `{{env.X}}` interpolation, resolves the diff once per run, matches nothing outside a git repo (silent), and hard-errors on an unresolvable ref with a shallow-clone hint. `has_ancestor:` and `changed_since:` AND-compose when both are set; at least one must be present.
+It accepts the `{{env.X}}` interpolation, resolves the diff once per run, matches nothing outside a git repo (silent), and hard-errors on an unresolvable ref with a shallow-clone hint. The `scope_filter:` predicates AND-compose when more than one is set; at least one of `has_ancestor:`, `changed_since:`, `include_manifest_paths:`, or `exclude_manifest_paths:` must be present.
+
+`include_manifest_paths:` / `exclude_manifest_paths:` (v0.15+) scope a per-file rule by membership in a path set a **manifest** declares, so the manifest that owns the truth and the rule that depends on it stay in one place instead of a hand-maintained `paths.exclude` that drifts. `exclude_manifest_paths:` drops files in the set; `include_manifest_paths:` keeps only files in it.
+
+Exempt the `package.json` `bin` entrypoints from a `no-console` rule — even though `bin` names the *build output* (`dist/cli.js`), `derive_target:` maps it back to source:
+
+```yaml
+rules:
+  - id: no-stray-console
+    kind: file_content_forbidden
+    paths: "src/**/*.ts"
+    pattern: 'console\.(log|debug|info)\('
+    scope_filter:
+      exclude_manifest_paths:
+        source: package.json              # the manifest (always repo-root-confined)
+        extract: { json: "$.bin.*" }      # the shared extract one-of
+        derive_target:                    # optional: map declared output -> source
+          from: '^dist/(.*)\.js$'
+          to:   'src/$1.ts'
+    level: error
+```
+
+Or scope a rule to only the source directories a workspace manifest declares:
+
+```yaml
+rules:
+  - id: rust-hygiene
+    kind: no_trailing_whitespace
+    paths: "**/*.rs"
+    scope_filter:
+      include_manifest_paths:
+        source: Cargo.toml
+        extract: { toml: "$.workspace.members[*]" }
+    level: warning
+```
+
+Each predicate takes a **`source:`** (the manifest file, always repo-root-confined; its declared paths resolve relative to its own directory), an **`extract:`** (the shared `{ json | toml | yaml: <JSONPath> }` / `{ lines }` / `{ regex }` extractor `registry_paths_resolve` and `file_graph` also use; non-literal entries are dropped), an optional **`derive_target: { from, to }`** regex mapping applied to each extracted path (a path that does not match `from` is dropped), and, for `include_manifest_paths:` only, **`expect_nonempty:`** (default `true`) to warn when the set is empty — an empty include set would otherwise silently no-op the whole rule.
+
+Membership is **directory-aware**: a declared file matches itself; a declared directory (a workspace member) matches every file under it, respecting component boundaries (`crates/a` does not match `crates/ab`). The set is extracted once per run and cached, like `changed_since:`. A manifest that is absent or unreadable contributes nothing — the rule runs full-scope for `exclude`, matches nothing for `include`. A manifest **value** gates *which* files a rule sees, never *what* it decides about a file: content rules never read the manifest, extraction is pure-parse (no spawn, safe inside an `extends:`'d ruleset), and `alint explain <rule>` prints the resolved set.
 
 Cross-file rules (`pair`, `for_each_dir`, `file_exists`, etc.) reject `scope_filter:` at build time with a pointer to the `for_each_dir + when_iter:` pattern. Rule-major rules like `filename_case` silently ignore the field; gate them via the rule's `paths:` glob instead.
 

--- a/schemas/v1/config.json
+++ b/schemas/v1/config.json
@@ -954,7 +954,7 @@
           "type": "object"
         },
         "expect_nonempty": {
-          "description": "`include_manifest_paths` only: warn when the extracted set is empty (default true). An empty include set silently no-ops the whole rule; set false for a rule that legitimately tolerates it.",
+          "description": "`include_manifest_paths` only: warn when the extracted set is empty (default true). An empty include set silently no-ops the whole rule; set false for a rule that legitimately tolerates it. Ignored on `exclude_manifest_paths` (an empty exclude set is safe: full scope, visible over-firing).",
           "type": "boolean"
         },
         "extract": {

--- a/schemas/v1/config.json
+++ b/schemas/v1/config.json
@@ -929,6 +929,49 @@
       ],
       "type": "string"
     },
+    "manifest_path_set": {
+      "additionalProperties": false,
+      "description": "A manifest-derived path set (ADR-0010). The set is extracted from `source` once per run, optionally mapped by `derive_target`, resolved relative to the manifest's own directory, and confined to the repo root. `include_manifest_paths` keeps only files whose path is in the set; `exclude_manifest_paths` drops files whose path is in it. Manifest values gate which files the rule sees, never what it decides about a file (a content rule never reads the manifest).",
+      "properties": {
+        "derive_target": {
+          "additionalProperties": false,
+          "description": "Optional {from, to} regex mapping applied to each extracted path, e.g. mapping a package.json `bin` build output (dist/cli.js) back to its source (src/cli.ts). An entry that does not match `from` is dropped, as file_graph's derive_target drops a non-matching node.",
+          "properties": {
+            "from": {
+              "description": "Regex matched against each extracted path; $1-style capture groups substitute into `to`.",
+              "minLength": 1,
+              "type": "string"
+            },
+            "to": {
+              "description": "The replacement template producing the mapped (source) path.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "from",
+            "to"
+          ],
+          "type": "object"
+        },
+        "expect_nonempty": {
+          "description": "`include_manifest_paths` only: warn when the extracted set is empty (default true). An empty include set silently no-ops the whole rule; set false for a rule that legitimately tolerates it.",
+          "type": "boolean"
+        },
+        "extract": {
+          "$ref": "#/$defs/extract_spec"
+        },
+        "source": {
+          "description": "The manifest file, always repo-root-confined (a manifest a rule scopes by lives in the repo; an escaping source is a build-time error). Its declared paths resolve relative to its own directory.",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "source",
+        "extract"
+      ],
+      "type": "object"
+    },
     "nested_rule": {
       "description": "A nested rule inside `require:`. Unlike top-level rules, `id` and `level` are synthesized from the parent; the user supplies only `kind` plus kind-specific options.",
       "properties": {
@@ -3669,14 +3712,27 @@
           "required": [
             "changed_since"
           ]
+        },
+        {
+          "required": [
+            "include_manifest_paths"
+          ]
+        },
+        {
+          "required": [
+            "exclude_manifest_paths"
+          ]
         }
       ],
-      "description": "Per-file rule scoping. `has_ancestor` (v0.9.6+) admits files whose ancestor chain contains a named manifest; `changed_since` (v0.11+) admits files in a `<ref>...HEAD` git diff. At least one must be set; setting both is an AND. Supported on per-file rules and on `dir_absent` (since v0.9.18). Cross-file rules (`pair`, `for_each_dir`, `file_exists`, etc.) reject `scope_filter:` at build time. Combine with the rule's existing `paths:` glob — all gates must match for the rule to fire.",
+      "description": "Per-file rule scoping. `has_ancestor` (v0.9.6+) admits files whose ancestor chain contains a named manifest; `changed_since` (v0.11+) admits files in a `<ref>...HEAD` git diff. At least one must be set; setting both is an AND. Supported on per-file rules and on `dir_absent` (since v0.9.18). Cross-file rules (`pair`, `for_each_dir`, `file_exists`, etc.) reject `scope_filter:` at build time. Combine with the rule's existing `paths:` glob — all gates must match for the rule to fire. `include_manifest_paths` / `exclude_manifest_paths` (v0.15+) admit or drop files by membership in a path set a manifest declares (ADR-0010).",
       "properties": {
         "changed_since": {
           "description": "Git ref; the rule only fires on files in the `<ref>...HEAD` diff (the same merge-base diff as `alint check --changed`). Right shape for grandfathering pre-existing files in a PR — e.g. require an SPDX header only on files the PR touched. Accepts the `{{env.X}}` interpolation (e.g. `changed_since: \"{{env.ALINT_BASE_SHA | default('origin/main')}}\"`). Outside a git repo the predicate matches nothing (silent); an unresolvable ref inside a repo is a hard error with a shallow-clone hint.",
           "minLength": 1,
           "type": "string"
+        },
+        "exclude_manifest_paths": {
+          "$ref": "#/$defs/manifest_path_set"
         },
         "has_ancestor": {
           "description": "Manifest filename (or list of filenames) whose presence in any ancestor directory of the linted file admits the rule. Each entry is a literal filename like `Cargo.toml` or `package.json` — no path separators, no glob metacharacters; the ancestor walk handles \"anywhere up the tree\" by traversing `Path::parent()` upward.",
@@ -3694,6 +3750,9 @@
               "type": "array"
             }
           ]
+        },
+        "include_manifest_paths": {
+          "$ref": "#/$defs/manifest_path_set"
         }
       },
       "type": "object"


### PR DESCRIPTION
## What

Adds **manifest-derived rule scope** (ADR-0010) — a v0.15 `scope_filter` feature: scope a per-file rule by membership in a path set a **manifest** declares, instead of a hand-maintained `paths.exclude` that drifts from the manifest that owns the truth.

The motivating case (exempt the `package.json` `bin` entrypoint from a `no-console` rule), working end to end:

```yaml
- id: no-stray-console
  kind: file_content_forbidden
  paths: "src/**/*.ts"
  pattern: 'console\.(log|debug|info)\('
  scope_filter:
    exclude_manifest_paths:
      source: package.json
      extract: { json: "$.bin.*" }          # -> "dist/cli.js"
      derive_target: { from: '^dist/(.*)\.js$', to: 'src/$1.ts' }  # -> src/cli.ts
```

`src/cli.ts` (the mapped entrypoint) is exempt; `src/lib.ts` still fires.

## The boundary (ADR-0010)

A manifest **value** gates *which files a rule sees*, never *what it decides about a file*. Content rules never read the manifest; extraction is pure-parse (no spawn), so the predicate is safe inside an `extends:`'d ruleset.

## Phased (one commit each)

1. **Spec of record** — ADR-0010 Accepted; the design doc's 7 open questions resolved.
2. **Hoist** — `Format` + the extract one-of + `derive_target` + `normalize_confined` promoted from `alint-rules` into `alint-core` (behavior-preserving; the predicate lives in core `scope_filter`, which couldn't reach them across the one-way crate edge). All 72 test binaries + schema stayed green through the move.
3. **Predicate core** — `include_manifest_paths:` / `exclude_manifest_paths:` on `ScopeFilterSpec`; a `manifest_paths` `OnceLock` on `FileIndex` (mirrors `changed_paths`); the engine's `resolve_manifest_paths` pass (dedup by cache key, read once, extract → `derive_target` → confine relative to the manifest's dir) wired at `run`/`run_for_file`/`fix`; `ScopeFilter::matches` AND-composes membership. **Directory-aware** (component-wise): a declared file matches itself, a declared `workspace.members` directory matches files under it, `crates/a` ≠ `crates/ab`.
4. **`explain`** — a `scope_filter:` block (human + JSON) surfaces the gates and, for the manifest predicates, the paths they actually resolve to.
5. **e2e + docs** — three scenarios (exclude+`derive_target`, include+directory-prefix, absent-manifest silent-degrade); config reference; CHANGELOG.

## Resolutions of note

- **`derive_target` ships in v0.15** (not deferred), so the headline `bin` case works on arrival.
- **`source` is always repo-root-confined** (an escaping source is a build-time error) — a manifest a rule scopes by lives in the repo, so v1 doesn't thread `allow_out_of_root` for it.
- **Absent/unreadable manifest → empty set** (exclude → full-scope, include → nothing, consistent with `has_ancestor`); an empty **include** set warns (`expect_nonempty: false` opts out).

## Testing / perf

- 13 `scope_filter` unit tests (membership, absent-manifest, AND-composition, `resolve_set` extraction + mapping + confinement + manifest-relative resolution + root-escape rejection + directory-prefix), 3 e2e scenarios, `explain` verified live.
- Zero-cost for rules without a manifest predicate: `matches` iterates an empty vec and `resolve_manifest_paths` returns early — the change is additive and inactive for the existing bench scenarios, so no regression is expected (the deterministic perf gate covers it).

Closes the ASF-bundle `paths.exclude` drift recorded in `docs/design/v0.12/asf_bundle_overfire.md`.
