### PR TITLE
P0: distribution-hardening — CI pins, Zed version-gate, install-page rewrite (ADR-0015)

### DIFF
--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -91,7 +91,7 @@ jobs:
           # recognize. Convention: track the previous minor
           # (i.e. when HEAD is 0.X+1, this sits at v0.X) so
           # the test catches CLI/.alint.yml drift one release out.
-          version: v0.12.0
+          version: v0.14.0
 
   action-config-single:
     name: config input (single path)

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The image runs as the distroless `nonroot` user (UID 65532); host files must be 
 docker run --rm -u $(id -u):$(id -g) -v "$PWD:/repo" ghcr.io/asamarts/alint:latest fix
 ```
 
-Also published: the `:<major>.<minor>` rolling channel and the raw git tag (`:v0.15.0`).
+Also published: the bare semver (`:0.15.0`), the `:<major>.<minor>` rolling channel, and the raw git tag (`:v0.15.0`).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Working `.alint.yml` configs for 30 OSS repos (single-language workspaces, polyg
 ## 60-second quickstart
 
 ```sh
-# Install (Linux + macOS + Windows tarballs):
+# Install (Linux + macOS; Windows via npm/cargo):
 curl -sSL https://alint.org/install.sh | bash
 
 # Initialise a config in the current repo (uses bundled oss-baseline + auto-detected ecosystem rulesets):
@@ -94,13 +94,13 @@ Scope is the filesystem shape and contents of a repository, not the semantics of
 
 ## Install
 
-### install.sh (Linux + macOS + Windows tarballs)
+### install.sh (Linux + macOS)
 
 ```bash
 curl -sSL https://alint.org/install.sh | bash
 ```
 
-Detects platform (Linux / macOS, x86_64 / aarch64), downloads the matching tarball, verifies the SHA-256, and installs to `$INSTALL_DIR` (default `~/.local/bin`). Windows users download the Windows tarball from the [Releases page](https://github.com/asamarts/alint/releases).
+Detects platform (Linux / macOS, x86_64 / aarch64), downloads the matching tarball, verifies the SHA-256, and installs to `$INSTALL_DIR` (default `~/.local/bin`). This shell path does not cover Windows; on Windows use `npm install -g @asamarts/alint`, `cargo install alint`, or download the Windows tarball from the [Releases page](https://github.com/asamarts/alint/releases).
 
 ### Homebrew (macOS + Linuxbrew)
 
@@ -158,7 +158,7 @@ The image runs as the distroless `nonroot` user (UID 65532); host files must be 
 docker run --rm -u $(id -u):$(id -g) -v "$PWD:/repo" ghcr.io/asamarts/alint:latest fix
 ```
 
-Also published: `:<major>.<minor>` (e.g. `:0.13`) and the raw git tag (`:v0.15.0`).
+Also published: the `:<major>.<minor>` rolling channel and the raw git tag (`:v0.15.0`).
 
 ## Usage
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -192,8 +192,8 @@ See [`docs/development/release-credentials.md`](docs/development/release-credent
 for the full credential inventory, the secret-storage convention, and
 the OIDC (keyless) publishing setup for crates.io + npm.
 
-**One-time prerequisites (NOT yet done; do before the first editor
-release):**
+**One-time prerequisites (completed before the first editor release;
+retained here as the setup record):**
 
 1. Create the **VS Code Marketplace publisher** `asamarts` (Azure
    DevOps) and an **Open VSX** namespace; generate `VSCE_PAT` / `OVSX_PAT`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -154,6 +154,26 @@ is permanent; see Yanking). The publish script is idempotent, so the
 recovery is: add the publisher, then `gh run rerun <id> --failed`
 (never re-tag). `alint-lsp` hit this on v0.11.1.
 
+## Recovering a partial release
+
+The publish jobs run *after* the GitHub Release exists (`needs: release`), so a
+mid-release failure leaves a split-brain state (binaries and some channels published,
+others stale). Recovery is always **rotate or fix, then re-run the failed job, never
+re-tag** (crates.io / npm / ghcr are permanent, and a new tag would collide):
+
+- **Expiring credentials** (`MP-M2`). Four channels carry secrets that can expire: the
+  npm PAT (`NPM_TOKEN`), VS Code + Open VSX (`VSCE_PAT` / `OVSX_PAT`), JetBrains (the
+  marketplace token + signing cert/key), and the Homebrew tap SSH deploy key. On a
+  401/403 from any, rotate the secret (inventory + storage in
+  [`release-credentials.md`](docs/development/release-credentials.md)), then
+  `gh run rerun <id> --failed`. (npm OIDC trusted publishing is now GA and will retire
+  the `NPM_TOKEN` PAT once the package migrates to per-platform sub-packages.)
+- **A build-matrix flake blocking crates.io** (`MP-M1`). `publish-crates` deliberately
+  `needs: build` (a cross-platform compile gate before the irreversible publish), so a
+  flaky windows or aarch64 leg can block it. Re-run once the leg heals with
+  `gh run rerun <id> --failed`; the publish script is idempotent, so already-published
+  crates are skipped.
+
 ## Editor extensions / IDE plugins
 
 The six editor integrations live under `editors/`. Two distribution

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,14 @@ alint is a build-time / CI-time tool that runs against repository contents.
 Vulnerabilities can affect supply-chain integrity for everyone who uses it,
 so reports are taken seriously and handled privately until a fix ships.
 
+## Supported versions
+
+alint is pre-1.0 and ships from a single line of development. Only the **latest
+released minor** is supported: fixes land in a new release, not as backports to older
+minors. Published versions are immutable (crates.io and npm are never deleted) and are
+**yanked or deprecated only on a confirmed defect**, never proactively removed, so
+pinned builds keep working. There is no separate LTS line.
+
 ## Reporting a vulnerability
 
 **Do not file a public GitHub issue for security vulnerabilities.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,9 +8,9 @@ so reports are taken seriously and handled privately until a fix ships.
 
 alint is pre-1.0 and ships from a single line of development. Only the **latest
 released minor** is supported: fixes land in a new release, not as backports to older
-minors. Published versions are immutable (crates.io and npm are never deleted) and are
-**yanked or deprecated only on a confirmed defect**, never proactively removed, so
-pinned builds keep working. There is no separate LTS line.
+minors. Published versions are **removed only on a confirmed defect, never
+proactively**: crates.io versions can only be yanked (never deleted), and we do not
+unpublish npm releases, so pinned builds keep working. There is no separate LTS line.
 
 ## Reporting a vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,6 +56,7 @@ In scope:
 - The Docker image (`ghcr.io/asamarts/alint`)
 - The Homebrew formula (`asamarts/homebrew-alint`)
 - The npm package (`@asamarts/alint`)
+- The `install.sh` release installer (served from `alint.org/install.sh`)
 - The `xtask` build/release tooling
 
 Out of scope (report directly to upstream):

--- a/ci/scripts/bump-version.sh
+++ b/ci/scripts/bump-version.sh
@@ -130,6 +130,13 @@ for zf in editors/zed/extension.toml editors/zed/Cargo.toml; do
   [[ -f "$zf" ]] && sed -i -E "s/^(version = )\"${CUR_ESCAPED}\"/\1\"${NEW}\"/" "$zf"
 done
 
+# 2d. npm README version example (@asamarts/alint@X.Y.Z + "alint vX.Y.Z").
+#     Illustrative, and outside the SCOPE pin-regex (which ignores @-prefixed
+#     pins), so keep it current here or it rots (it had gone 10 minors stale).
+if [[ -f npm/README.md ]]; then
+  sed -i -E "s#(@asamarts/alint@|alint v)${CUR_ESCAPED}#\1${NEW}#g" npm/README.md
+fi
+
 # 3. CHANGELOG stub at top so the release date is captured.
 #    The new entry is "TBD" — the author fills in what changed.
 #    We do NOT touch any existing `## [...]` entries (history).

--- a/ci/scripts/bump-version.sh
+++ b/ci/scripts/bump-version.sh
@@ -131,8 +131,8 @@ for zf in editors/zed/extension.toml editors/zed/Cargo.toml; do
 done
 
 # 2d. npm README version example (@asamarts/alint@X.Y.Z + "alint vX.Y.Z").
-#     Illustrative, and outside the SCOPE pin-regex (which ignores @-prefixed
-#     pins), so keep it current here or it rots (it had gone 10 minors stale).
+#     Illustrative, and not in the SCOPE files (its @-prefixed pin wouldn't match the
+#     SCOPE regex anyway), so keep it current here or it rots (it had gone 10 minors stale).
 if [[ -f npm/README.md ]]; then
   sed -i -E "s#(@asamarts/alint@|alint v)${CUR_ESCAPED}#\1${NEW}#g" npm/README.md
 fi

--- a/ci/scripts/bump-version.sh
+++ b/ci/scripts/bump-version.sh
@@ -121,6 +121,15 @@ if [[ -f npm/package.json ]]; then
   sed -i -E "s/^([[:space:]]*\"version\":[[:space:]]+)\"${CUR_ESCAPED}\"/\1\"${NEW}\"/" npm/package.json
 fi
 
+# 2c. Zed extension version. Unlike VS Code/JetBrains (which release.yml
+#     version-stamps from the tag at publish, so their committed value may
+#     lag intentionally), the Zed registry builds the extension from source
+#     at the committed version — so the committed value is what ships and
+#     must track the workspace version. check-version-pins.sh enforces it.
+for zf in editors/zed/extension.toml editors/zed/Cargo.toml; do
+  [[ -f "$zf" ]] && sed -i -E "s/^(version = )\"${CUR_ESCAPED}\"/\1\"${NEW}\"/" "$zf"
+done
+
 # 3. CHANGELOG stub at top so the release date is captured.
 #    The new entry is "TBD" — the author fills in what changed.
 #    We do NOT touch any existing `## [...]` entries (history).

--- a/ci/scripts/check-version-pins.sh
+++ b/ci/scripts/check-version-pins.sh
@@ -117,7 +117,9 @@ done
 
 if [[ "$failed" -ne 0 ]]; then
   echo "" >&2
-  echo "Fix: bash ci/scripts/bump-version.sh $WORKSPACE_VER" >&2
+  echo "Fix: after a version bump, run 'bash ci/scripts/bump-version.sh <new-version>'." >&2
+  echo "     If the workspace is already at $WORKSPACE_VER, hand-edit the flagged file(s)" >&2
+  echo "     to match (bump-version.sh no-ops when current == target)." >&2
   exit 1
 fi
 

--- a/ci/scripts/check-version-pins.sh
+++ b/ci/scripts/check-version-pins.sh
@@ -101,10 +101,24 @@ if [[ -f npm/package.json ]]; then
   fi
 fi
 
+# Zed extension manifests: the registry builds from source at the committed
+# version (no publish-time stamp), so the committed value ships and must match
+# the workspace. (VS Code/JetBrains are version-stamped at publish, so their
+# committed versions are intentionally allowed to lag and are NOT gated here.)
+for zf in editors/zed/extension.toml editors/zed/Cargo.toml; do
+  if [[ -f "$zf" ]]; then
+    ZED_VER=$(awk -F'"' '/^version = / { print $2; exit }' "$zf")
+    if [[ "$ZED_VER" != "$WORKSPACE_VER" ]]; then
+      echo "[version-pin] $zf: version $ZED_VER != workspace $WORKSPACE_VER" >&2
+      failed=1
+    fi
+  fi
+done
+
 if [[ "$failed" -ne 0 ]]; then
   echo "" >&2
   echo "Fix: bash ci/scripts/bump-version.sh $WORKSPACE_VER" >&2
   exit 1
 fi
 
-echo "[version-pin] OK — all ${#SCOPE[@]} install-snippet files + npm/package.json pin to $WORKSPACE_VER"
+echo "[version-pin] OK — all ${#SCOPE[@]} install-snippet files + npm/package.json + Zed manifests pin to $WORKSPACE_VER"

--- a/ci/scripts/release-binary.sh
+++ b/ci/scripts/release-binary.sh
@@ -34,7 +34,7 @@ BUILD_CMD="cargo"
 if [[ "$USE_CROSS" == "true" ]]; then
   if ! command -v cross >/dev/null 2>&1; then
     echo "==> Installing cross"
-    cargo install --locked cross --version 0.2.5
+    cargo install --locked cross --version '=0.2.5'
   fi
   BUILD_CMD="cross"
 fi

--- a/ci/scripts/release-binary.sh
+++ b/ci/scripts/release-binary.sh
@@ -34,7 +34,7 @@ BUILD_CMD="cargo"
 if [[ "$USE_CROSS" == "true" ]]; then
   if ! command -v cross >/dev/null 2>&1; then
     echo "==> Installing cross"
-    cargo install --locked cross
+    cargo install --locked cross --version 0.2.5
   fi
   BUILD_CMD="cross"
 fi

--- a/docs/design/distribution.md
+++ b/docs/design/distribution.md
@@ -192,7 +192,7 @@ live citations.
 |---|:--:|---|---|---|
 | **MP-H1** | HIGH | No signing / SLSA provenance / SBOM / attestation on any binary artifact; `.sha256` proves transit only. | grep across `.github/`, `install.sh`, `Dockerfile`, `npm/`; v0.15.0 assets carry none; `release.yml:305-317` docker sets no attestation | §6 / P1 |
 | **MP-H2** | HIGH | Official GitHub Action silently fails on Windows runners (composite → install.sh hard-exits) though a win-x64 binary exists. | `action.yml:56-130` (`bash "$install_sh"` at `:129`), `install.sh:32-38` | Windows path in the Action / P2; doc note / P0 |
-| **MP-M1** | MED | Build matrix needlessly gates the irreversible crates.io publish (and docker). A flaky win/aarch64 leg blocks a publish needing zero binaries. | `release.yml:104` (`fail-fast:false`), `:329` (`publish-crates needs: build`) | `publish-crates` → `needs: preflight` / P0 (effect next tag) |
+| **MP-M1** | NOTE | The crates.io publish is coupled to the full build matrix (`publish-crates: needs: build`), so a flaky win/aarch64 leg can block it. **Considered and kept** (decision 2026-08-16): `release.yml:321-328` deliberately uses the matrix as a *cross-platform compile gate* before the irreversible publish (preflight is ubuntu-only), and shipping win/aarch64-broken source to immutable crates.io is the worse harm. A build-blocked publish is recovered by re-running the idempotent `publish-crates` job. | `release.yml:329` + `:321-328` (rationale) | keep as-is; document the re-run recovery in RELEASING.md / P0 (doc only) |
 | **MP-M2** | MED | Four secret-bearing channels, each a split-brain single point of failure, all run after the Release exists. Three are expiring tokens; the Homebrew SSH key is long-lived (compromise, not expiry). | `NPM_TOKEN release.yml:375`; `VSCE_PAT/OVSX_PAT :475-476`; the four JetBrains secrets `:525-528`; `HOMEBREW_TAP_DEPLOY_KEY :420` | migrate npm to OIDC (now GA) / P2; rotation runbook / P0, extended to the P2-added AUR SSH key + WinGet PAT |
 | **MP-M3** | MED | npm declares `win32/arm64` (os×cpu) it cannot serve; hard postinstall error instead of clean `EBADPLATFORM`. | `npm/package.json:31-32`, `npm/install.js:52-58` | fix declaration / P0; add win-arm64 build+package / P2 |
 | **MP-M4** | MED | Air-gapped/enterprise install is impossible from the primary paths: `install.sh` hardcodes `api.github.com` + `github.com` and its `ALINT_REPO` overrides only the repo path, not the host; `npm/install.js`'s repo is a hardcoded const with no env override. | `install.sh:18,48,60`, `npm/install.js:26` | install.sh base-URL override + npm made mirrorable by the optionalDeps migration + mirror docs / §7.2, P0 docs + P2 code |
@@ -569,9 +569,10 @@ benign, no action).
   homebrew form, `D-L1` anchor, `D-L2` docker tags, `D-L3` npm example, `D-L4`
   homepage cargo, `D-L6` RELEASING note, `D-L7` manual-download OS caveat, `D-L8`
   uninstall line, `D-L9` `SECURITY.md` "Supported Versions", `D-L10` `security.txt`. Pin gate: `VP-M1` add
-  editor manifests. Pipeline: `MP-M1` decouple `publish-crates`, `MP-M3` fix the npm
+  editor manifests. Pipeline: `MP-M3` fix the npm
   win-arm64 declaration, `MP-L1` document `ALINT_VERSION`, `MP-L2` bump the selftest
-  pin, `MP-L3` pin `cross`, `MP-M2` write the token-rotation runbook. Doc note for
+  pin, `MP-L3` pin `cross`, `MP-M2` write the token-rotation runbook (and `MP-M1`'s
+  publish-crates re-run recovery note). Doc note for
   `MP-H2` (Action is Linux/macOS-only today) and the `MP-M4` enterprise-mirror paths
   that already work (image retag, cargo source-replacement). **Document** cargo-
   binstall (`G2`), podman (fully-qualified), the fetchers + `cargo install --git`, and

--- a/docs/design/distribution.md
+++ b/docs/design/distribution.md
@@ -34,9 +34,7 @@ accretion rather than to a plan. Three problems:
 
 3. **Small correctness debt.** A copy-paste-broken `brew install` command on the
    marketing site, npm advertised on a page that omits it, a Zed extension pinned
-   two minors stale and invisible to the version-pin gate, and a release pipeline
-   that couples the irreversible crates.io publish to an unrelated build-matrix
-   leg.
+   two minors stale and invisible to the version-pin gate.
 
 **Strategic frame (the insight that should drive the plan).** A mature
 single-binary Rust CLI does *not* own every channel. ripgrep is the proof:
@@ -617,8 +615,9 @@ benign, no action).
 - **P0:** the version-pin gate is green across *all* editor manifests; `cargo
   binstall alint --dry-run` resolves the release; the canonical install page lists
   every live channel including npm, a real Windows path, an uninstall line, and the
-  manual-download caveat; `SECURITY.md` has a "Supported Versions" section;
-  `publish-crates` no longer `needs: build`.
+  manual-download caveat; `SECURITY.md` has a "Supported Versions" section; and
+  RELEASING.md documents the partial-release recovery runbook (`MP-M2` credential
+  rotation + `MP-M1` publish-crates re-run).
 - **P1:** `gh attestation verify` and `cosign verify-blob` succeed against a released
   tarball and the ghcr image; an SBOM + a `THIRD-PARTY-LICENSES` bundle are attached and
   attested; `SHA256SUMS` covers `install.sh`; and the `MP-M5` post-publish smoke job

--- a/docs/site/about/index.md
+++ b/docs/site/about/index.md
@@ -34,6 +34,8 @@ Scope is the filesystem shape and contents of a repository, not the semantics of
 - **Rust API docs**: [docs.rs/alint](https://docs.rs/alint), [docs.rs/alint-core](https://docs.rs/alint-core)
 - **Container**: [ghcr.io/asamarts/alint](https://ghcr.io/asamarts/alint)
 - **Homebrew**: [asamarts/homebrew-alint](https://github.com/asamarts/homebrew-alint)
+- **npm**: [@asamarts/alint](https://www.npmjs.com/package/@asamarts/alint)
+- **GitHub Action**: [asamarts/alint@v0](../integrations/github-actions/)
 
 ## License
 

--- a/docs/site/about/index.md
+++ b/docs/site/about/index.md
@@ -35,7 +35,7 @@ Scope is the filesystem shape and contents of a repository, not the semantics of
 - **Container**: [ghcr.io/asamarts/alint](https://ghcr.io/asamarts/alint)
 - **Homebrew**: [asamarts/homebrew-alint](https://github.com/asamarts/homebrew-alint)
 - **npm**: [@asamarts/alint](https://www.npmjs.com/package/@asamarts/alint)
-- **GitHub Action**: [asamarts/alint@v0](../integrations/github-actions/)
+- **GitHub Action**: [asamarts/alint](../integrations/github-actions/)
 
 ## License
 

--- a/docs/site/getting-started/installation.md
+++ b/docs/site/getting-started/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Install alint via Homebrew, install.sh, Docker, cargo, or from source.
+description: Install alint via Homebrew, install.sh, npm, cargo (or cargo-binstall), Docker/Podman, or from source.
 sidebar:
   order: 1
 ---
@@ -18,17 +18,51 @@ brew install alint
 
 The recommended path on macOS and Linux. The [asamarts/homebrew-alint](https://github.com/asamarts/homebrew-alint) tap is auto-updated on every release; the formula resolves the matching pre-built tarball for your platform, verifies its SHA-256, and installs to the Homebrew cellar.
 
-## install.sh (Linux + macOS + Windows tarballs)
+## install.sh (Linux + macOS)
 
 ```bash
 curl -sSL https://alint.org/install.sh | bash
 ```
 
-Detects platform (Linux / macOS, x86_64 / aarch64), downloads the matching tarball from GitHub Releases, verifies its SHA-256, and installs to `$INSTALL_DIR` (default `~/.local/bin`). Windows users download the Windows tarball from the [Releases page](https://github.com/asamarts/alint/releases) directly.
+Detects platform (Linux / macOS, x86_64 / aarch64), downloads the matching tarball from GitHub Releases, verifies its SHA-256, and installs to `$INSTALL_DIR` (default `~/.local/bin`). This path is shell-based, so it does not cover Windows; Windows users have [npm](#npm), [cargo](#cargo), or the manual tarball (see [Windows](#windows)).
+
+Pin a specific version (and skip the "latest release" GitHub API lookup, which can rate-limit on shared CI egress IPs):
+
+```bash
+ALINT_VERSION=v0.15.0 curl -sSL https://alint.org/install.sh | bash
+```
 
 Supply-chain note: the installer verifies the SHA-256 of the release tarball it downloads, but the script itself is fetched from the `main` branch (`alint.org/install.sh` redirects there). To pin the installer too, point `curl` at a release tag instead of `main` (for example `https://raw.githubusercontent.com/asamarts/alint/v0.15.0/install.sh`), or download it from the [Releases page](https://github.com/asamarts/alint/releases) and review it before running.
 
-## Docker
+## npm
+
+```bash
+npm install -g @asamarts/alint    # or: pnpm add -g @asamarts/alint
+```
+
+The [`@asamarts/alint`](https://www.npmjs.com/package/@asamarts/alint) package is a thin wrapper: on install it downloads the platform-matched native binary from GitHub Releases and verifies its SHA-256. Handy in Node/JS projects and CI that already have npm. Zero-install works too:
+
+```bash
+npx @asamarts/alint check
+```
+
+Supports Linux (x64/arm64), macOS (x64/arm64), and Windows (x64). The install runs a postinstall script, so it needs network access at install time and does not work under `npm install --ignore-scripts` or Bun's `bunx` (a future release moves to per-platform packages to lift those limits).
+
+## cargo
+
+```bash
+cargo install alint
+```
+
+Builds from source against the current stable Rust toolchain (requires rustc 1.85+ and `cargo` on `$PATH`). To install a **pre-built** binary instead of compiling, use [cargo-binstall](https://github.com/cargo-bins/cargo-binstall):
+
+```bash
+cargo binstall alint
+```
+
+`cargo binstall` fetches the same release tarball the other channels use (verifying its checksum) rather than building from source, so it is much faster on CI and low-powered machines.
+
+## Docker / Podman
 
 A distroless multi-arch image (`linux/amd64`, `linux/arm64`) is published to ghcr.io on each release:
 
@@ -40,21 +74,37 @@ docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:latest
 docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.15.0 check
 ```
 
+The image is OCI-standard, so **Podman runs it unchanged** — just use the fully-qualified name (Podman does not assume a default registry):
+
+```bash
+podman run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:latest check
+```
+
 The image runs as the distroless `nonroot` user (UID 65532); host files must be world-readable. To apply fixes and preserve host ownership, pass `-u`:
 
 ```bash
 docker run --rm -u $(id -u):$(id -g) -v "$PWD:/repo" ghcr.io/asamarts/alint:latest fix
 ```
 
-Also published: `:<major>.<minor>` (e.g. `:0.10`) and the raw git tag (`:v0.15.0`).
+Also published: the `:<major>.<minor>` rolling channel and the raw git tag (`:v0.15.0`).
 
-## crates.io
+## Windows
 
-```bash
-cargo install alint
-```
+The `install.sh` one-liner is shell-based and does not cover Windows. On Windows, use:
 
-Builds from source against the current stable Rust toolchain. Requires `cargo` already on `$PATH`.
+- **npm:** `npm install -g @asamarts/alint` (see [npm](#npm)) — the simplest path;
+- **cargo:** `cargo install alint` or `cargo binstall alint` (see [cargo](#cargo));
+- **manual:** download `alint-v0.15.0-x86_64-pc-windows-msvc.tar.gz` from the [Releases page](https://github.com/asamarts/alint/releases), extract, and put `alint.exe` on your `PATH`.
+
+Note on manually-downloaded binaries: a tarball downloaded through a **browser** carries a "mark of the web", so the first run can trip Windows SmartScreen ("More info → Run anyway") or, on macOS, Gatekeeper quarantine — clear it with `xattr -d com.apple.quarantine ./alint`. Binaries fetched by `curl`/npm/cargo/Homebrew/Docker carry no such mark and run without prompts.
+
+## Enterprise mirror / offline install
+
+Air-gapped setups can install without direct github.com access:
+
+- **Docker:** re-tag and push the image into your internal registry, then pull from there.
+- **npm:** once a future release ships per-platform packages, point `.npmrc` `registry=` at your internal mirror; today the postinstall wrapper fetches from github.com.
+- **cargo:** use a [source replacement](https://doc.rust-lang.org/cargo/reference/source-replacement.html) mirror for the from-source build.
 
 ## From source
 
@@ -74,3 +124,7 @@ alint --version
 ```
 
 Should print `alint <version>` matching the channel you installed from.
+
+## Uninstall
+
+alint's footprint is a single binary and no managed config, cache, or data directory. Remove it with whatever installed it: `brew uninstall alint`, `npm uninstall -g @asamarts/alint`, `cargo uninstall alint`, or for `install.sh`, delete the binary (`rm ~/.local/bin/alint`).

--- a/docs/site/getting-started/installation.md
+++ b/docs/site/getting-started/installation.md
@@ -86,7 +86,7 @@ The image runs as the distroless `nonroot` user (UID 65532); host files must be 
 docker run --rm -u $(id -u):$(id -g) -v "$PWD:/repo" ghcr.io/asamarts/alint:latest fix
 ```
 
-Also published: the `:<major>.<minor>` rolling channel and the raw git tag (`:v0.15.0`).
+Also published: the bare semver (`:0.15.0`), the `:<major>.<minor>` rolling channel, and the raw git tag (`:v0.15.0`).
 
 ## Windows
 

--- a/docs/site/getting-started/installation.md
+++ b/docs/site/getting-started/installation.md
@@ -37,7 +37,7 @@ Supply-chain note: the installer verifies the SHA-256 of the release tarball it 
 ## npm
 
 ```bash
-npm install -g @asamarts/alint    # or: pnpm add -g @asamarts/alint
+npm install -g @asamarts/alint
 ```
 
 The [`@asamarts/alint`](https://www.npmjs.com/package/@asamarts/alint) package is a thin wrapper: on install it downloads the platform-matched native binary from GitHub Releases and verifies its SHA-256. Handy in Node/JS projects and CI that already have npm. Zero-install works too:
@@ -46,7 +46,7 @@ The [`@asamarts/alint`](https://www.npmjs.com/package/@asamarts/alint) package i
 npx @asamarts/alint check
 ```
 
-Supports Linux (x64/arm64), macOS (x64/arm64), and Windows (x64). The install runs a postinstall script, so it needs network access at install time and does not work under `npm install --ignore-scripts` or Bun's `bunx` (a future release moves to per-platform packages to lift those limits).
+Supports Linux (x64/arm64), macOS (x64/arm64), and Windows (x64). The install runs a postinstall script, so it needs network access at install time and does not work under `npm install --ignore-scripts`, Bun's `bunx`, or **pnpm 10+** (which blocks dependency build scripts by default — run `pnpm approve-builds @asamarts/alint` to allow it). A future release moves to per-platform packages to lift those limits.
 
 ## cargo
 
@@ -60,7 +60,7 @@ Builds from source against the current stable Rust toolchain (requires rustc 1.8
 cargo binstall alint
 ```
 
-`cargo binstall` fetches the same release tarball the other channels use (verifying its checksum) rather than building from source, so it is much faster on CI and low-powered machines.
+`cargo binstall` attempts to fetch a pre-built release tarball (verifying its checksum) instead of compiling, falling back to a source build if it cannot resolve one — much faster on CI and low-powered machines when the pre-built path is taken.
 
 ## Docker / Podman
 
@@ -127,4 +127,4 @@ Should print `alint <version>` matching the channel you installed from.
 
 ## Uninstall
 
-alint's footprint is a single binary and no managed config, cache, or data directory. Remove it with whatever installed it: `brew uninstall alint`, `npm uninstall -g @asamarts/alint`, `cargo uninstall alint`, or for `install.sh`, delete the binary (`rm ~/.local/bin/alint`).
+alint's footprint is the binary itself (no managed config or data directory), plus — only if you used remote `extends:` rulesets — a cache under your platform cache dir (`~/.cache/alint/` on Linux). Remove the binary with whatever installed it: `brew uninstall alint`, `npm uninstall -g @asamarts/alint`, `cargo uninstall alint`, or for `install.sh`, `rm ~/.local/bin/alint`; delete the cache dir too if you used remote rulesets.

--- a/docs/site/integrations/github-actions.md
+++ b/docs/site/integrations/github-actions.md
@@ -7,6 +7,8 @@ sidebar:
 
 The official Action wraps the `install.sh` flow plus alint invocation into one step.
 
+**Runs on Linux and macOS runners only.** The Action wraps `install.sh` (shell-based), so on `windows-latest` it fails with `unsupported platform`. For Windows CI, install alint in a prior `run:` step (`npm install -g @asamarts/alint` or `cargo install alint`) and invoke `alint` directly.
+
 <likec4-view view-id="ciActionFlow"></likec4-view>
 
 ## Inline PR annotations (default)

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alint-zed"
-version = "0.13.0"
+version = "0.15.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0 OR MIT"

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "alint"
 name = "alint"
-version = "0.13.0"
+version = "0.15.0"
 schema_version = 1
 authors = ["alint contributors"]
 description = "Repository-structure linting (alint) in Zed via the alint language server."

--- a/npm/README.md
+++ b/npm/README.md
@@ -23,7 +23,7 @@ alint check
 ```
 
 The npm package version tracks alint releases exactly: `npm install
-@asamarts/alint@0.5.11` downloads alint v0.5.11.
+@asamarts/alint@0.15.0` downloads alint v0.15.0.
 
 ## Supported platforms
 
@@ -34,7 +34,7 @@ The npm package version tracks alint releases exactly: `npm install
 | Windows | x64                  |
 
 For unsupported platforms, install via `cargo install alint`,
-[Homebrew](https://github.com/asamarts/alint#homebrew), or by
+[Homebrew](https://github.com/asamarts/alint#homebrew-macos--linuxbrew), or by
 downloading the tarball directly from
 [GitHub Releases](https://github.com/asamarts/alint/releases).
 


### PR DESCRIPTION
First P0 batch from the distribution plan ([`docs/design/distribution.md`](docs/design/distribution.md) §9, ADR-0015 Accepted). Mechanical correctness + near-free wins; nothing changes rule semantics or `.alint.yml`.

## CI / pipeline / pin gate
- **MP-L2** action-selftest pin `v0.12.0 → v0.14.0` (previous minor, per its own convention).
- **MP-L3** pin `cross` at `=0.2.5` (exact; 0.2.5 is the current latest, so no behavior change today).
- **VP-M1** the Zed extension version is what actually ships (built from source by the Zed registry, unlike the publish-stamped VS Code/JetBrains). Synced `0.13.0 → 0.15.0` and **wired into `bump-version.sh` + `check-version-pins.sh`** (Zed only). *E2E-verified: a patch bump bumps Zed in lockstep, and the gate catches drift.*
- **MP-M1** — **decision: KEEP `publish-crates: needs: build`** (a deliberate cross-platform compile gate before the irreversible crates.io publish, `release.yml:321-328`). Downgraded to a considered-and-kept NOTE in the design doc.

## Docs
- **D-H2 / D-M1 / D-L2 / D-L7 / D-L8 / MP-L1 / MP-M4 / G2** — comprehensive install-page rewrite: add the npm section (was advertised but absent), reframe Windows out of the install.sh heading + add a Windows section, de-hardcode the docker channel, document `ALINT_VERSION`, cargo-binstall, Podman, zero-install, a manual-download (mark-of-the-web / Gatekeeper) caveat, uninstall, and an enterprise-mirror section.
- **D-M1 / D-L2** README brought into line with the install page (Windows framing + docker tag).
- **D-L9** SECURITY.md "Supported versions"; **D-L6** RELEASING stale-note fix; **D-L1/D-L3** npm README anchor + version example (now auto-bumped); **D-L5** about-page npm + Action links.

## Adversarial audits (this branch was self-audited twice)
- The CI/pin-gate increment: fixed npm-README re-rot durability, the pin-gate hint, a SECURITY.md npm-unpublish overclaim, and the exact cross pin.
- The install-page increment: fixed a pnpm-10 broken-install recommendation, an unguaranteed cargo-binstall claim, and a false "no managed cache" uninstall claim.

Verified throughout: dogfood clean, pin gate passes (now covering Zed), em-dash-clean root files, `cargo metadata --locked` clean.

## Still to add (small, next)
`MP-M2` token-rotation runbook + the `MP-M1` re-run recovery note in RELEASING.md, and the `MP-H2` Action-on-Windows note in the github-actions integration doc. Separately, the **alint.org** fixes (`D-H1` broken `brew install alint`, `D-L4` homepage cargo, `D-L10` security.txt) land in that repo.

**Note:** the install-page frontmatter `description` now names npm/binstall/podman — the alint.org head-parity baseline will need a refresh when the docs bundle syncs.