### PR TITLE
ci(release): sign + attest release artifacts and image (P1-b)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,8 +201,10 @@ jobs:
     needs: [build, supply-chain]
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # create the GitHub Release
-      actions: write    # dispatch docs-bundle.yml (workflow_dispatch) below
+      contents: write       # create the GitHub Release
+      actions: write        # dispatch docs-bundle.yml (workflow_dispatch) below
+      id-token: write       # keyless OIDC for cosign + build-provenance attestation
+      attestations: write   # write the build-provenance + SBOM attestations
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -232,6 +234,37 @@ jobs:
           echo "=== SHA256SUMS ==="
           cat SHA256SUMS
 
+      - name: install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: cosign sign SHA256SUMS (keyless)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd release-artifacts
+          # One keyless signature over the whole manifest covers every asset it
+          # lists (tarballs, installer, SBOM, license bundle). The bundle carries
+          # the signature + Fulcio cert + Rekor entry, so consumers verify offline:
+          #   cosign verify-blob --bundle SHA256SUMS.cosign.bundle \
+          #     --certificate-identity-regexp '^https://github.com/asamarts/alint/' \
+          #     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+          #     SHA256SUMS
+          cosign sign-blob --yes --bundle SHA256SUMS.cosign.bundle SHA256SUMS
+
+      - name: attest build provenance for every release asset
+        # subject-checksums reads SHA256SUMS and attests each listed file's digest,
+        # so `gh attestation verify <tarball> --repo asamarts/alint` works for the
+        # tarballs, installer, SBOM, and license bundle in one attestation.
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-checksums: release-artifacts/SHA256SUMS
+
+      - name: attest the CycloneDX SBOM against the tarballs
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: "release-artifacts/alint-*.tar.gz"
+          sbom-path: release-artifacts/alint.cdx.json
+
       - name: create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -243,12 +276,13 @@ jobs:
           cd release-artifacts
           # install.sh + the supply-chain bundle (THIRD-PARTY-LICENSES.html,
           # alint.cdx.json) were staged / downloaded above and are already
-          # recorded in SHA256SUMS by the aggregate step.
+          # recorded in SHA256SUMS by the aggregate step. SHA256SUMS.cosign.bundle
+          # is the keyless signature over SHA256SUMS produced just above.
           gh release create "$TAG" \
             --repo "$REPO" \
             --title "alint $TAG" \
             --generate-notes \
-            install.sh SHA256SUMS \
+            install.sh SHA256SUMS SHA256SUMS.cosign.bundle \
             THIRD-PARTY-LICENSES.html alint.cdx.json \
             alint-*.tar.gz alint-*.tar.gz.sha256
 
@@ -290,6 +324,11 @@ jobs:
     # which the Dockerfile COPYs into the image; listed explicitly for clarity.
     needs: [build, supply-chain]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read        # checkout
+      packages: write       # push the image + its registry attestation to ghcr
+      id-token: write       # keyless OIDC for cosign + build-provenance attestation
+      attestations: write   # write the image build-provenance attestation
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -370,6 +409,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: build + push multi-arch image
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -382,6 +422,31 @@ jobs:
             org.opencontainers.image.version=${{ github.ref_name }}
             org.opencontainers.image.licenses=Apache-2.0 OR MIT
             org.opencontainers.image.description=Language-agnostic linter for repository structure
+
+      - name: attest build provenance for the image
+        # subject-digest is the multi-arch manifest-list digest; push-to-registry
+        # stores the attestation alongside the image in ghcr, so a consumer can
+        # `gh attestation verify oci://ghcr.io/asamarts/alint:<tag> --repo asamarts/alint`.
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ steps.tags.outputs.image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: cosign sign the image (keyless)
+        env:
+          IMAGE: ${{ steps.tags.outputs.image }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          # Sign by immutable digest (not tag). Verify with:
+          #   cosign verify ghcr.io/asamarts/alint@<digest> \
+          #     --certificate-identity-regexp '^https://github.com/asamarts/alint/' \
+          #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+          cosign sign --yes "${IMAGE}@${DIGEST}"
 
   publish-crates:
     name: publish to crates.io
@@ -435,10 +500,11 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: stamp package version from tag + publish
         env:
-          # PAT auth (NPM_TOKEN). npm Trusted Publishing (OIDC) is
-          # deferred: npmjs.com's UI to enable a trusted publisher is
-          # currently broken (same blocker hit at v0.10.0). crates.io
-          # already runs keyless via OIDC; revisit npm when the UI ships.
+          # PAT auth (NPM_TOKEN). npm OIDC Trusted Publishing is now GA, but npm
+          # provenance is only meaningful once the package ships native bytes via
+          # the optionalDependencies migration (ADR-0015 / P2) -- the current
+          # postinstall-download shim has nothing to attest. Until that lands this
+          # stays on the PAT; the migration switches to keyless `--provenance`.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           TAG: ${{ github.ref_name }}
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,11 @@ jobs:
 
       - name: install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin cosign too (the action's default floats). v3.0.6 writes the
+          # new-format Sigstore bundle, so consumers verify with cosign v3+
+          # (or `gh attestation verify`, which needs no cosign at all).
+          cosign-release: "v3.0.6"
 
       - name: cosign sign SHA256SUMS (keyless)
         shell: bash
@@ -246,20 +251,25 @@ jobs:
           # lists (tarballs, installer, SBOM, license bundle). The bundle carries
           # the signature + Fulcio cert + Rekor entry, so consumers verify offline:
           #   cosign verify-blob --bundle SHA256SUMS.cosign.bundle \
-          #     --certificate-identity-regexp '^https://github.com/asamarts/alint/' \
+          #     --certificate-identity-regexp '^https://github\.com/asamarts/alint/\.github/workflows/release\.yml@refs/tags/v' \
           #     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
           #     SHA256SUMS
           cosign sign-blob --yes --bundle SHA256SUMS.cosign.bundle SHA256SUMS
 
-      - name: attest build provenance for every release asset
+      - name: attest build provenance for every asset in SHA256SUMS
         # subject-checksums reads SHA256SUMS and attests each listed file's digest,
         # so `gh attestation verify <tarball> --repo asamarts/alint` works for the
-        # tarballs, installer, SBOM, and license bundle in one attestation.
+        # tarballs, installer, SBOM, and license bundle in one attestation. (Not
+        # SHA256SUMS itself, the .cosign.bundle, or the .sha256 sidecars.)
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-checksums: release-artifacts/SHA256SUMS
 
       - name: attest the CycloneDX SBOM against the tarballs
+        # attest-sbom is deprecated in favour of actions/attest with an SBOM
+        # predicate, but is SHA-pinned here so it keeps working; it still wraps
+        # actions/attest and handles the CycloneDX predicate for us. Migrate when
+        # convenient.
         uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
         with:
           subject-path: "release-artifacts/alint-*.tar.gz"
@@ -435,6 +445,11 @@ jobs:
 
       - name: install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin cosign too (the action's default floats). v3.0.6 writes the
+          # new-format Sigstore bundle, so consumers verify with cosign v3+
+          # (or `gh attestation verify`, which needs no cosign at all).
+          cosign-release: "v3.0.6"
 
       - name: cosign sign the image (keyless)
         env:
@@ -444,7 +459,7 @@ jobs:
           set -euo pipefail
           # Sign by immutable digest (not tag). Verify with:
           #   cosign verify ghcr.io/asamarts/alint@<digest> \
-          #     --certificate-identity-regexp '^https://github.com/asamarts/alint/' \
+          #     --certificate-identity-regexp '^https://github\.com/asamarts/alint/\.github/workflows/release\.yml@refs/tags/v' \
           #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
           cosign sign --yes "${IMAGE}@${DIGEST}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 
-- `SHA256SUMS` now covers `install.sh` and the supply-chain artifacts, so a later
-  cosign signature over the manifest will protect the installer and the
-  attribution bundle, not only the tarballs (`MP-L8`).
+- Releases are now signed and carry build provenance (P1-b of the
+  supply-chain-hardening arc): `SHA256SUMS` is cosign-signed keyless
+  (`SHA256SUMS.cosign.bundle`), every release asset gets a GitHub build-provenance
+  attestation (verifiable with `gh attestation verify`), the CycloneDX SBOM is
+  attested, and the container image is both attested (pushed to the registry) and
+  cosign-signed by digest. All keyless via Sigstore / GitHub OIDC, so there is no
+  signing secret to manage. See [SECURITY.md](SECURITY.md) for the verification
+  commands.
+- `SHA256SUMS` covers `install.sh` and the supply-chain artifacts, so the cosign
+  signature over the manifest protects the installer and the attribution bundle,
+  not only the tarballs (`MP-L8`).
 
 ## [0.15.0] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Releases are now signed and carry build provenance (P1-b of the
   supply-chain-hardening arc): `SHA256SUMS` is cosign-signed keyless
-  (`SHA256SUMS.cosign.bundle`), every release asset gets a GitHub build-provenance
-  attestation (verifiable with `gh attestation verify`), the CycloneDX SBOM is
-  attested, and the container image is both attested (pushed to the registry) and
-  cosign-signed by digest. All keyless via Sigstore / GitHub OIDC, so there is no
-  signing secret to manage. See [SECURITY.md](SECURITY.md) for the verification
-  commands.
+  (`SHA256SUMS.cosign.bundle`), every asset recorded in `SHA256SUMS` (tarballs,
+  installer, SBOM, license bundle) gets a GitHub build-provenance attestation
+  (verifiable with `gh attestation verify`), the CycloneDX SBOM is attested, and
+  the container image is both attested (pushed to the registry) and cosign-signed
+  by digest. All keyless via Sigstore / GitHub OIDC, so there is no signing secret
+  to manage. Verify with cosign v3+ or `gh attestation verify`; see
+  [SECURITY.md](SECURITY.md) for the commands.
 - `SHA256SUMS` covers `install.sh` and the supply-chain artifacts, so the cosign
   signature over the manifest protects the installer and the attribution bundle,
   not only the tarballs (`MP-L8`).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -141,10 +141,12 @@ checklist so the release-gated pieces land and nothing drifts:
 | **`bench-record.yml`** | tag push only | **Self-hosted full publish-grade `xtask bench-scale` matrix (S1-S14 × {1k, 10k, 100k, 1m} × {full, changed}) at `--warmup 3 --runs 10`. Opens a PR adding the new per-version macro/results dir + criterion micro snapshot.** | **~3.5 hr** |
 
 Signing and attestation (the `release`/`docker` cosign + `attest-build-provenance`
-/ `attest-sbom` steps) are **keyless** via Sigstore + GitHub OIDC: they need only
-`id-token: write` + `attestations: write` job permissions, no stored secret, so
-there is nothing here to rotate or that can expire mid-release. Consumer-side
-verification commands live in [SECURITY.md](SECURITY.md#verifying-release-artifacts).
+/ `attest-sbom` steps) are **keyless** via Sigstore + GitHub OIDC: they add
+`id-token: write` + `attestations: write` job permissions (the image path also
+uses the `docker` job's existing `packages: write` to store its signature and
+attestation in ghcr), no stored secret, so there is nothing here to rotate or that
+can expire mid-release. Consumer-side verification commands live in
+[SECURITY.md](SECURITY.md#verifying-release-artifacts).
 
 ## Adding a new published crate
 
@@ -175,6 +177,14 @@ never re-tag** (crates.io / npm / ghcr are permanent, and a new tag would collid
   (fail-closed, not a partial release). Fix the generator and
   `gh run rerun <id> --failed`; ci.yml runs the same script pre-merge (the
   `supply-chain` job), so a release-time failure should be rare.
+- **A signing / attestation failure** (`MP-H1`). The `release` job's cosign + attest
+  steps run *before* `create GitHub Release` and depend on public-good Sigstore
+  (Fulcio + Rekor) plus the GitHub attestations API. A transient Sigstore outage, or
+  a cosign / attest-action error, fails the release job before the Release exists,
+  while `docker` and `publish-crates` (both `needs: build`) may already have
+  published to ghcr / crates.io. Re-run the release job: the cosign + attest steps are
+  idempotent and precede Release creation, so a clean re-run re-signs and then creates
+  the Release. Never re-tag.
 - **Expiring credentials** (`MP-M2`). Four channels carry secrets that can expire: the
   npm PAT (`NPM_TOKEN`), VS Code + Open VSX (`VSCE_PAT` / `OVSX_PAT`), JetBrains (the
   marketplace token + signing cert/key), and the Homebrew tap SSH deploy key. On a

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -135,10 +135,16 @@ checklist so the release-gated pieces land and nothing drifts:
 | Workflow | Triggered by | What it does | Time |
 |---|---|---|---|
 | `ci.yml` | tag + main pushes | fmt + clippy + test + doc + dogfood, plus audit, deny, build, bench-smoke, examples, shell-tests, editors, and the advisory perf-gate. Self-hosted Linux. | ~5 min |
-| `release.yml` | tag push only | preflight gate → cross-platform build matrix → GitHub Release → ghcr.io Docker → npm → Homebrew tap → crates.io → VS Code Marketplace + Open VSX → JetBrains Marketplace. | ~15-25 min |
+| `release.yml` | tag push only | preflight gate → supply-chain (SBOM + license bundle) → cross-platform build matrix → GitHub Release (cosign-signed `SHA256SUMS` + build-provenance + SBOM attestations) → ghcr.io Docker (attested + cosign-signed by digest) → npm → Homebrew tap → crates.io → VS Code Marketplace + Open VSX → JetBrains Marketplace. | ~15-25 min |
 | `docs-bundle.yml` | tag + main pushes | `xtask docs-export` → push refreshed bundle to `docs-bundle` branch → Cloudflare deploy hook → alint.org rebuilds. The sibling `check-pins.yml` workflow in the alint.org repo (PR + push + daily cron) asserts alint.org's three install-pin sites reference the latest tag from this release; fires automatically. | ~3-5 min |
 | `bench-docker.yml` | tag pushes | Build + push `ghcr.io/asamarts/alint-bench:<tag>` (the reproducible competitive-bench environment). | ~5 min |
 | **`bench-record.yml`** | tag push only | **Self-hosted full publish-grade `xtask bench-scale` matrix (S1-S14 × {1k, 10k, 100k, 1m} × {full, changed}) at `--warmup 3 --runs 10`. Opens a PR adding the new per-version macro/results dir + criterion micro snapshot.** | **~3.5 hr** |
+
+Signing and attestation (the `release`/`docker` cosign + `attest-build-provenance`
+/ `attest-sbom` steps) are **keyless** via Sigstore + GitHub OIDC: they need only
+`id-token: write` + `attestations: write` job permissions, no stored secret, so
+there is nothing here to rotate or that can expire mid-release. Consumer-side
+verification commands live in [SECURITY.md](SECURITY.md#verifying-release-artifacts).
 
 ## Adding a new published crate
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,47 @@ minors. Published versions are **removed only on a confirmed defect, never
 proactively**: crates.io versions can only be yanked (never deleted), and we do not
 unpublish npm releases, so pinned builds keep working. There is no separate LTS line.
 
+## Verifying release artifacts
+
+Releases are signed and carry build provenance, so you can confirm a download was
+built by this repo's CI from this repo's source before you run it. This defends
+against tampered mirrors and typosquats. It does not by itself defend a
+compromised publishing account (that account is the root of trust), so the org is
+hardened with 2FA and minimal token scopes alongside these steps. Signing and
+attestation are keyless (Sigstore / GitHub OIDC): there is no long-lived signing
+key to leak, and every signature is logged in the public Rekor transparency log.
+
+**Build provenance, any release asset** (tarballs, installer, SBOM, license
+bundle), with the GitHub CLI:
+
+```
+gh attestation verify alint-<version>-<target>.tar.gz --repo asamarts/alint
+gh attestation verify oci://ghcr.io/asamarts/alint:<version> --repo asamarts/alint
+```
+
+**Signature over the checksum manifest**, no GitHub CLI needed. `SHA256SUMS` is
+cosign-signed; the signature travels as `SHA256SUMS.cosign.bundle`. Verify the
+manifest, then check any downloaded asset against it:
+
+```
+cosign verify-blob --bundle SHA256SUMS.cosign.bundle \
+  --certificate-identity-regexp '^https://github.com/asamarts/alint/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  SHA256SUMS
+sha256sum --check --ignore-missing SHA256SUMS
+```
+
+**Container image signature**, verified by digest:
+
+```
+cosign verify ghcr.io/asamarts/alint:<version> \
+  --certificate-identity-regexp '^https://github.com/asamarts/alint/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Provenance and signatures are attached to every release from the version that
+introduced them onward; a release that predates it has none to verify.
+
 ## Reporting a vulnerability
 
 **Do not file a public GitHub issue for security vulnerabilities.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,14 +16,18 @@ unpublish npm releases, so pinned builds keep working. There is no separate LTS 
 
 Releases are signed and carry build provenance, so you can confirm a download was
 built by this repo's CI from this repo's source before you run it. This defends
-against tampered mirrors and typosquats. It does not by itself defend a
+against tampered mirrors and tampered downloads. It does not by itself defend a
 compromised publishing account (that account is the root of trust), so the org is
 hardened with 2FA and minimal token scopes alongside these steps. Signing and
 attestation are keyless (Sigstore / GitHub OIDC): there is no long-lived signing
 key to leak, and every signature is logged in the public Rekor transparency log.
 
-**Build provenance, any release asset** (tarballs, installer, SBOM, license
-bundle), with the GitHub CLI:
+The `gh` commands need an authenticated GitHub CLI (`gh auth login`, or a
+`GH_TOKEN`); the `cosign` commands need cosign v3+ (the signatures use the
+new-format Sigstore bundle) but no GitHub account.
+
+**Build provenance** (GitHub CLI). Each tarball, the installer, the SBOM, the
+license bundle, and the container image are attested:
 
 ```
 gh attestation verify alint-<version>-<target>.tar.gz --repo asamarts/alint
@@ -36,17 +40,17 @@ manifest, then check any downloaded asset against it:
 
 ```
 cosign verify-blob --bundle SHA256SUMS.cosign.bundle \
-  --certificate-identity-regexp '^https://github.com/asamarts/alint/' \
+  --certificate-identity-regexp '^https://github\.com/asamarts/alint/\.github/workflows/release\.yml@refs/tags/v' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   SHA256SUMS
-sha256sum --check --ignore-missing SHA256SUMS
+sha256sum --check --ignore-missing SHA256SUMS   # macOS: shasum -a 256 --check --ignore-missing SHA256SUMS
 ```
 
-**Container image signature**, verified by digest:
+**Container image signature.** cosign resolves the tag to the digest it signed:
 
 ```
 cosign verify ghcr.io/asamarts/alint:<version> \
-  --certificate-identity-regexp '^https://github.com/asamarts/alint/' \
+  --certificate-identity-regexp '^https://github\.com/asamarts/alint/\.github/workflows/release\.yml@refs/tags/v' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
 


### PR DESCRIPTION
**P1-b of the supply-chain-hardening arc** (`docs/design/distribution.md` §6.1/6.2; ADR-0015): keyless signing + build provenance for every release artifact. Builds on P1-a's SBOM + third-party bundle. **No new secret** -- all keyless via Sigstore + GitHub OIDC.

## What it adds

**Release assets** (in the `release` job):
- `cosign sign-blob` the aggregate `SHA256SUMS` keyless -> `SHA256SUMS.cosign.bundle`, attached to the Release. One signature covers every asset the manifest lists.
- `actions/attest-build-provenance` via `subject-checksums: SHA256SUMS` -> a GitHub build-provenance attestation for the tarballs, installer, SBOM, and license bundle in **one** call.
- `actions/attest-sbom` binds `alint.cdx.json` to the tarballs.

**Container image** (in the `docker` job):
- `attest-build-provenance` for the manifest-list digest with `push-to-registry: true` (attestation stored in ghcr).
- `cosign sign` the image keyless by immutable digest.
- Permissions tightened to least-privilege: `contents: read` + `packages: write` + `id-token: write` + `attestations: write` (was inheriting `contents: write`).

**Pins:** `attest-build-provenance` v4.2.2, `attest-sbom` v4.1.0, `cosign-installer` v4.1.2 (all SHA-pinned).

## Consumer verification (documented in SECURITY.md)

```
gh attestation verify alint-<version>-<target>.tar.gz --repo asamarts/alint
gh attestation verify oci://ghcr.io/asamarts/alint:<version> --repo asamarts/alint
cosign verify-blob --bundle SHA256SUMS.cosign.bundle \
  --certificate-identity-regexp '^https://github.com/asamarts/alint/' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com SHA256SUMS
```

## Deferred (user decision)

**cargo-auditable** -> focused follow-up. It is undocumented with `cross` (the aarch64-musl target) and unverifiable locally; the attested CycloneDX SBOM already provides the dependency inventory for every target, so nothing is lost on the security surface meanwhile.

## Also

Corrected the stale npm-OIDC comment (OIDC is GA; provenance waits on the P2 native-bytes migration). Docs: SECURITY.md "Verifying release artifacts", CHANGELOG Security, RELEASING.md keyless-signing note.

## Testing reality

The crypto (attestation + cosign) needs the Actions OIDC token, so **true E2E verification runs only on the next release tag**. This branch is validated by: `actionlint` (0 new findings) + yaml parse; `cosign` v2.4.1 + `gh` 2.97.0 confirm every documented flag (`sign-blob`/`sign --yes --bundle`, `verify-blob` identity/issuer, `gh attestation verify`); the three action pins resolved; SECURITY.md/RELEASING.md em-dash-clean; dogfood green. Release-day checklist: `gh attestation verify` + `cosign verify` against a real tarball and the ghcr image.