### PR TITLE
ci: add post-publish install smoke (MP-M5)

### DIFF
--- a/.github/workflows/post-publish-smoke.yml
+++ b/.github/workflows/post-publish-smoke.yml
@@ -1,0 +1,86 @@
+name: Post-publish smoke
+
+# MP-M5: advisory post-publish install smoke. Installs alint from each live
+# distribution channel and asserts `alint --version` matches the released tag, so
+# a broken or stale publish (a channel serving the wrong version, a propagation
+# gap, a de-listed package) is caught by CI rather than by a user. This is NOT a
+# release gate -- it runs AFTER publishing (dispatched by release.yml) and on a
+# weekly cron; a red run is a signal to investigate, it blocks nothing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to smoke (e.g. v0.16.0); blank = latest release"
+        required: false
+        default: ""
+  schedule:
+    # Weekly (Mon 06:00 UTC): catch a channel that breaks AFTER release day.
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: post-publish-smoke-${{ github.event.inputs.tag || 'latest' }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: resolve tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.r.outputs.tag }}
+    steps:
+      - id: r
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_TAG}" ]; then
+            tag="${INPUT_TAG}"
+          else
+            tag="$(gh release view --repo "$REPO" --json tagName --jq '.tagName')"
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "smoking release tag: ${tag}"
+
+  smoke:
+    name: smoke ${{ matrix.channel }}
+    needs: resolve
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Advisory: one channel failing must not cancel the others -- each is an
+      # independent signal about that channel.
+      fail-fast: false
+      matrix:
+        include:
+          - { channel: install.sh, os: ubuntu-latest }
+          - { channel: docker, os: ubuntu-latest }
+          - { channel: npm, os: ubuntu-latest }
+          - { channel: cargo-binstall, os: ubuntu-latest }
+          - { channel: cargo, os: ubuntu-latest }
+          - { channel: homebrew, os: macos-latest }
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: set up Node (npm channel)
+        if: matrix.channel == 'npm'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "20"
+
+      - name: set up Rust (cargo + cargo-binstall channels)
+        if: matrix.channel == 'cargo' || matrix.channel == 'cargo-binstall'
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+
+      - name: install cargo-binstall (cargo-binstall channel)
+        if: matrix.channel == 'cargo-binstall'
+        uses: cargo-bins/cargo-binstall@e00d2c94cc0067b77737821097a62d91c0301baa # v1.21.1
+
+      - name: smoke ${{ matrix.channel }}
+        run: ci/scripts/smoke-channel.sh "${{ matrix.channel }}" "${{ needs.resolve.outputs.tag }}"

--- a/.github/workflows/post-publish-smoke.yml
+++ b/.github/workflows/post-publish-smoke.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.r.outputs.tag }}
+      is_latest: ${{ steps.r.outputs.is_latest }}
     steps:
       - id: r
         env:
@@ -39,13 +40,20 @@ jobs:
           INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
           set -euo pipefail
+          latest="$(gh release view --repo "$REPO" --json tagName --jq '.tagName')"
           if [ -n "${INPUT_TAG}" ]; then
             tag="${INPUT_TAG}"
           else
-            tag="$(gh release view --repo "$REPO" --json tagName --jq '.tagName')"
+            tag="${latest}"
           fi
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "smoking release tag: ${tag}"
+          # is_latest gates the floating-pointer + homebrew checks: those only make
+          # sense when the smoked tag is what `latest` / `:latest` / the tap serve.
+          if [ "${tag}" = "${latest}" ]; then is_latest=1; else is_latest=0; fi
+          {
+            echo "tag=${tag}"
+            echo "is_latest=${is_latest}"
+          } >> "$GITHUB_OUTPUT"
+          echo "smoking release tag: ${tag} (is_latest=${is_latest}, latest=${latest})"
 
   smoke:
     name: smoke ${{ matrix.channel }}
@@ -82,5 +90,19 @@ jobs:
         if: matrix.channel == 'cargo-binstall'
         uses: cargo-bins/cargo-binstall@e00d2c94cc0067b77737821097a62d91c0301baa # v1.21.1
 
+      - name: install cosign (so the install.sh leg exercises its verify path)
+        # With cosign v3 present, install.sh's opt-in verification actually runs
+        # against the release's real signed assets -- so a SAN-regexp drift, a
+        # renamed .cosign.bundle, or a broken verify surfaces here, not in a user's
+        # install. (On an unsigned release it just skips, as install.sh is designed.)
+        if: matrix.channel == 'install.sh'
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: "v3.0.6"
+
       - name: smoke ${{ matrix.channel }}
+        env:
+          # 1 when the smoked tag is the latest release: enables the floating
+          # (`latest` / `:latest` / homebrew) pointer checks in the script.
+          SMOKE_FLOATING: ${{ needs.resolve.outputs.is_latest }}
         run: ci/scripts/smoke-channel.sh "${{ matrix.channel }}" "${{ needs.resolve.outputs.tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -697,6 +697,10 @@ jobs:
     # cover. workflow_dispatch is the documented anti-recursion exception (same
     # pattern as the docs-bundle dispatch), so the token-triggered run fires.
     needs: [release, docker, publish-crates, publish-npm, homebrew]
+    # Fire even if a publisher failed (partial publish) -- the smoke then reds on
+    # exactly the un-published channel instead of the monitor going dark. Only a
+    # cancelled run skips it.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       actions: write   # workflow_dispatch the smoke workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -686,3 +686,24 @@ jobs:
           # Use the pinned wrapper (./gradlew) so release matches what CI
           # validates, not the setup-action's provisioned Gradle.
           ./gradlew -PpluginVersion="$ver" publishPlugin
+
+  post-publish-smoke:
+    name: dispatch post-publish smoke
+    # Advisory (MP-M5): once every CLI channel has published, fire the
+    # post-publish-smoke workflow to install alint from each and assert the
+    # version. `needs` the CLI-channel publishers so it runs only after they
+    # succeed; a broken publish surfaces as a red smoke run, not a user report.
+    # Not gated by editor channels (vscode/jetbrains), which the smoke doesn't
+    # cover. workflow_dispatch is the documented anti-recursion exception (same
+    # pattern as the docs-bundle dispatch), so the token-triggered run fires.
+    needs: [release, docker, publish-crates, publish-npm, homebrew]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write   # workflow_dispatch the smoke workflow
+    steps:
+      - name: dispatch post-publish-smoke.yml
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: gh workflow run post-publish-smoke.yml --repo "$REPO" --ref main -f tag="$TAG"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -139,6 +139,7 @@ checklist so the release-gated pieces land and nothing drifts:
 | `docs-bundle.yml` | tag + main pushes | `xtask docs-export` → push refreshed bundle to `docs-bundle` branch → Cloudflare deploy hook → alint.org rebuilds. The sibling `check-pins.yml` workflow in the alint.org repo (PR + push + daily cron) asserts alint.org's three install-pin sites reference the latest tag from this release; fires automatically. | ~3-5 min |
 | `bench-docker.yml` | tag pushes | Build + push `ghcr.io/asamarts/alint-bench:<tag>` (the reproducible competitive-bench environment). | ~5 min |
 | **`bench-record.yml`** | tag push only | **Self-hosted full publish-grade `xtask bench-scale` matrix (S1-S14 × {1k, 10k, 100k, 1m} × {full, changed}) at `--warmup 3 --runs 10`. Opens a PR adding the new per-version macro/results dir + criterion micro snapshot.** | **~3.5 hr** |
+| `post-publish-smoke.yml` | dispatched by `release.yml` after the CLI channels publish (+ weekly cron) | Install alint from each CLI channel (install.sh, cargo, cargo-binstall, npm, docker, homebrew) and assert `alint --version` matches the tag. Advisory (`MP-M5`): a red run flags a broken/stale publish, blocks nothing. | ~5-10 min |
 
 Signing and attestation (the `release`/`docker` cosign + `attest-build-provenance`
 / `attest-sbom` steps) are **keyless** via Sigstore + GitHub OIDC: they add

--- a/ci/scripts/smoke-channel.sh
+++ b/ci/scripts/smoke-channel.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Post-publish install smoke (MP-M5): install alint from ONE distribution channel
+# and assert `alint --version` reports the expected version. Advisory -- run after
+# a release (or on demand) so a broken/stale publish is caught by CI, not a user.
+# Each channel retries to ride out registry / CDN propagation lag.
+#
+# Usage: ci/scripts/smoke-channel.sh <channel> <tag>
+#   channel: install.sh | cargo | cargo-binstall | npm | docker | homebrew
+#   tag:     the release tag, e.g. v0.16.0
+#
+# Env overrides: DOCKER (default: docker; set to podman locally),
+#                RETRY_MAX (default 6), RETRY_SLEEP seconds (default 30).
+
+CHANNEL="${1:?channel required (install.sh|cargo|cargo-binstall|npm|docker|homebrew)}"
+TAG="${2:?tag required (e.g. v0.16.0)}"
+VER="${TAG#v}"                        # 0.16.0
+IMAGE="ghcr.io/asamarts/alint"
+DOCKER="${DOCKER:-docker}"
+RETRY_MAX="${RETRY_MAX:-6}"
+RETRY_SLEEP="${RETRY_SLEEP:-30}"
+
+# Retry a command until it succeeds, to absorb post-publish propagation lag.
+retry() {
+  local n=1
+  until "$@"; do
+    if [ "$n" -ge "$RETRY_MAX" ]; then
+      echo "  [smoke] '$*' still failing after ${RETRY_MAX} attempts" >&2
+      return 1
+    fi
+    echo "  [smoke] attempt ${n}/${RETRY_MAX} failed; sleeping ${RETRY_SLEEP}s (propagation lag?)" >&2
+    sleep "$RETRY_SLEEP"
+    n=$((n + 1))
+  done
+}
+
+# Run the given `alint --version` command and assert field 2 equals $VER exactly.
+# `alint --version` prints "alint <ver> (<hash>, built <date>)".
+assert_version() {
+  local out got
+  out="$("$@" 2>&1)"
+  echo "  [smoke] ${CHANNEL}: ${out}"
+  got="$(printf '%s\n' "$out" | awk 'NR==1 {print $2; exit}')"
+  if [ "$got" != "$VER" ]; then
+    echo "  [smoke] FAIL: ${CHANNEL} served version '${got}', expected '${VER}'" >&2
+    return 1
+  fi
+  echo "  [smoke] OK: ${CHANNEL} serves alint ${VER}"
+}
+
+echo "==> smoke: channel=${CHANNEL} tag=${TAG} ver=${VER}"
+case "$CHANNEL" in
+  install.sh)
+    retry bash -c "curl -fsSL https://alint.org/install.sh | ALINT_VERSION='${TAG}' bash"
+    export PATH="${HOME}/.local/bin:${PATH}"       # install.sh's default INSTALL_DIR
+    assert_version alint --version
+    ;;
+  cargo)
+    # Mirror the documented `cargo install alint`; --force makes a retry idempotent.
+    retry cargo install alint --version "${VER}" --force
+    assert_version alint --version
+    ;;
+  cargo-binstall)
+    retry cargo binstall --no-confirm "alint@${VER}"
+    assert_version alint --version
+    ;;
+  npm)
+    retry npm install -g "@asamarts/alint@${VER}"
+    assert_version alint --version
+    ;;
+  docker)
+    retry "$DOCKER" pull "${IMAGE}:${VER}"
+    assert_version "$DOCKER" run --rm "${IMAGE}:${VER}" --version
+    ;;
+  homebrew)
+    # Homebrew serves only the latest formula, so this is meaningful only when
+    # smoking the newest release (the post-publish case), not an older tag.
+    brew tap asamarts/alint 2>/dev/null || true
+    retry brew install alint
+    assert_version alint --version
+    ;;
+  *)
+    echo "  [smoke] unknown channel: ${CHANNEL}" >&2
+    exit 2
+    ;;
+esac

--- a/ci/scripts/smoke-channel.sh
+++ b/ci/scripts/smoke-channel.sh
@@ -39,17 +39,36 @@ retry() {
 # `alint --version` prints "alint <ver> (<hash>, built <date>)".
 assert_version() {
   local out got
-  out="$("$@" 2>&1)"
+  if ! out="$("$@" 2>&1)"; then
+    echo "  [smoke] FAIL: ${CHANNEL} command '$*' exited non-zero: ${out}" >&2
+    return 1
+  fi
   echo "  [smoke] ${CHANNEL}: ${out}"
-  got="$(printf '%s\n' "$out" | awk 'NR==1 {print $2; exit}')"
+  # Match the `alint <ver>` line wherever it is -- a channel may emit a warning
+  # line first, so keying on field 2 of a merged-stderr line 1 is fragile.
+  got="$(printf '%s\n' "$out" | awk '/^alint [0-9]/ { print $2; exit }')"
   if [ "$got" != "$VER" ]; then
-    echo "  [smoke] FAIL: ${CHANNEL} served version '${got}', expected '${VER}'" >&2
+    echo "  [smoke] FAIL: ${CHANNEL} served version '${got:-<none>}', expected '${VER}'" >&2
     return 1
   fi
   echo "  [smoke] OK: ${CHANNEL} serves alint ${VER}"
 }
 
-echo "==> smoke: channel=${CHANNEL} tag=${TAG} ver=${VER}"
+# When smoking the LATEST release (SMOKE_FLOATING=1, set by the workflow when the
+# resolved tag == the latest release), also confirm a channel's FLOATING pointer
+# (its unversioned / :latest install) resolves to VER, so a stale npm dist-tag or
+# docker :latest is caught, not just the pinned install. No-op otherwise.
+check_floating() {
+  [[ "${SMOKE_FLOATING:-}" == "1" ]] || return 0
+  local got="$1"
+  if [ "$got" != "$VER" ]; then
+    echo "  [smoke] FAIL: ${CHANNEL} 'latest' pointer serves '${got:-<none>}', expected '${VER}'" >&2
+    return 1
+  fi
+  echo "  [smoke] OK: ${CHANNEL} latest pointer -> ${VER}"
+}
+
+echo "==> smoke: channel=${CHANNEL} tag=${TAG} ver=${VER} floating=${SMOKE_FLOATING:-0}"
 case "$CHANNEL" in
   install.sh)
     retry bash -c "curl -fsSL https://alint.org/install.sh | ALINT_VERSION='${TAG}' bash"
@@ -62,22 +81,48 @@ case "$CHANNEL" in
     assert_version alint --version
     ;;
   cargo-binstall)
-    retry cargo binstall --no-confirm "alint@${VER}"
+    # --disable-strategies compile: never silently fall back to a SOURCE build, so
+    # a missing / renamed / corrupt pre-built asset fails loudly (the point of
+    # MP-M5; binstall otherwise compiles from crates.io and exits 0, hiding it).
+    retry cargo binstall --no-confirm --disable-strategies compile "alint@${VER}"
     assert_version alint --version
     ;;
   npm)
     retry npm install -g "@asamarts/alint@${VER}"
     assert_version alint --version
+    check_floating "$(npm view "@asamarts/alint" version 2>/dev/null)"
     ;;
   docker)
     retry "$DOCKER" pull "${IMAGE}:${VER}"
     assert_version "$DOCKER" run --rm "${IMAGE}:${VER}" --version
+    check_floating "$("$DOCKER" run --rm "${IMAGE}:latest" --version 2>&1 | awk '/^alint [0-9]/ { print $2; exit }')"
     ;;
   homebrew)
-    # Homebrew serves only the latest formula, so this is meaningful only when
-    # smoking the newest release (the post-publish case), not an older tag.
+    # Homebrew serves only the LATEST formula (no version pin), so smoke it only
+    # when the resolved tag IS the latest (SMOKE_FLOATING=1); an older-tag manual
+    # dispatch would install the newer latest and false-fail. Retry the whole
+    # install+check so a tap lagging the just-published tag is ridden out (a bare
+    # `brew install` succeeds against the stale formula, which retrying only the
+    # install would miss).
+    if [[ "${SMOKE_FLOATING:-}" != "1" ]]; then
+      echo "  [smoke] homebrew: skipped (smoked tag ${TAG} is not the latest release)"
+      exit 0
+    fi
     brew tap asamarts/alint 2>/dev/null || true
-    retry brew install alint
+    hb_n=1
+    while true; do
+      brew update >/dev/null 2>&1 || true
+      brew reinstall alint >/dev/null 2>&1 || brew install alint || true
+      hb_got="$(alint --version 2>&1 | awk '/^alint [0-9]/ { print $2; exit }')"
+      [ "$hb_got" = "$VER" ] && break
+      if [ "$hb_n" -ge "$RETRY_MAX" ]; then
+        echo "  [smoke] FAIL: homebrew serves '${hb_got:-<none>}', expected '${VER}' after ${RETRY_MAX} attempts" >&2
+        exit 1
+      fi
+      echo "  [smoke] homebrew attempt ${hb_n}/${RETRY_MAX}: got '${hb_got:-<none>}', want '${VER}'; ${RETRY_SLEEP}s" >&2
+      sleep "$RETRY_SLEEP"
+      hb_n=$((hb_n + 1))
+    done
     assert_version alint --version
     ;;
   *)


### PR DESCRIPTION
Completes the **last unmet P1 success criterion** (`docs/design/distribution.md` §9: "the `MP-M5` post-publish smoke job exists and is observed green").

## What it does
A new advisory workflow **`post-publish-smoke.yml`** + **`ci/scripts/smoke-channel.sh`**: install alint from each live CLI channel and assert `alint --version` matches the released tag, so a broken/stale publish (wrong version, propagation gap, de-listed package) is caught by CI, not a user.

Channels: **install.sh, cargo, cargo-binstall, npm, docker** (ubuntu) + **homebrew** (macOS). Each retries to ride out registry/CDN propagation lag; the version check extracts field 2 of `alint --version` (awk, portable) and exact-matches.

**Advisory, not a gate:** it runs *after* publishing and blocks nothing -- a red run is a signal to investigate. `fail-fast: false` so each channel is an independent signal.

## Triggers
- `workflow_dispatch` (optional `tag`; blank = latest release)
- weekly cron (catches a channel that breaks *after* release day)
- dispatched by `release.yml`'s new `post-publish-smoke` job once the CLI channels publish (`needs: [release, docker, publish-crates, publish-npm, homebrew]`; `workflow_dispatch` is the documented anti-recursion exception, same pattern as the docs-bundle dispatch)

## Verified
Locally against the **live v0.15.0**: the **docker** channel (via podman) and the **install.sh** channel (`ALINT_VERSION` pin + `~/.local/bin` PATH) both assert `alint 0.15.0` and pass; a wrong-version case fails as expected. shellcheck + actionlint clean; yaml parses; dogfood green. The remaining channels (cargo/cargo-binstall/npm/homebrew) share the same retry+assert structure and run in CI. RELEASING.md documents the workflow in the tag-push table.

Note: the smoke workflow only triggers on dispatch/cron (not PRs), so its first *real* run is the dispatch after the first release cut following this merge.