### PR TITLE
feat(install): opt-in cosign verification in install.sh

### DIFF
--- a/docs/site/getting-started/installation.md
+++ b/docs/site/getting-started/installation.md
@@ -125,6 +125,28 @@ alint --version
 
 Should print `alint <version>` matching the channel you installed from.
 
+### Verify the release signature and provenance
+
+From the release that introduced signing onward, every release is cosign-signed
+and carries GitHub build provenance, so you can confirm a download was built by
+alint's CI from alint's source before you trust it. `install.sh` does this
+automatically when `cosign` is present (best-effort: it never blocks the install,
+and you can opt out with `ALINT_SKIP_VERIFY=1`). To verify by hand:
+
+```bash
+# Build provenance, with the GitHub CLI:
+gh attestation verify alint-<version>-<target>.tar.gz --repo asamarts/alint
+
+# Signature over the checksum manifest, with cosign v3+ (no GitHub account needed):
+cosign verify-blob --bundle SHA256SUMS.cosign.bundle \
+  --certificate-identity-regexp '^https://github\.com/asamarts/alint/\.github/workflows/release\.yml@refs/tags/v' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  SHA256SUMS
+```
+
+See [SECURITY.md](https://github.com/asamarts/alint/blob/main/SECURITY.md#verifying-release-artifacts)
+for the full set (the container image signature, macOS notes, and prerequisites).
+
 ## Uninstall
 
 alint's footprint is the binary itself (no managed config or data directory), plus — only if you used remote `extends:` rulesets — a cache under your platform cache dir (`~/.cache/alint/` on Linux). Remove the binary with whatever installed it: `brew uninstall alint`, `npm uninstall -g @asamarts/alint`, `cargo uninstall alint`, or for `install.sh`, `rm ~/.local/bin/alint`; delete the cache dir too if you used remote rulesets.

--- a/docs/site/getting-started/installation.md
+++ b/docs/site/getting-started/installation.md
@@ -142,6 +142,8 @@ cosign verify-blob --bundle SHA256SUMS.cosign.bundle \
   --certificate-identity-regexp '^https://github\.com/asamarts/alint/\.github/workflows/release\.yml@refs/tags/v' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   SHA256SUMS
+# then confirm your downloaded tarball is one of the signed entries:
+sha256sum --check --ignore-missing SHA256SUMS   # macOS: shasum -a 256 --check --ignore-missing SHA256SUMS
 ```
 
 See [SECURITY.md](https://github.com/asamarts/alint/blob/main/SECURITY.md#verifying-release-artifacts)

--- a/install.sh
+++ b/install.sh
@@ -8,10 +8,19 @@
 # Usage:
 #   curl -sSL https://alint.org/install.sh | bash
 #
+# The one-liner fetches this script from the `main` branch (a moving ref). To pin
+# and/or read the installer itself before running, use a tag-pinned raw URL:
+#   curl -fsSL https://raw.githubusercontent.com/asamarts/alint/<tag>/install.sh -o install.sh
+#   less install.sh && bash install.sh
+# When `cosign` is present, this script also verifies the release's cosign-signed
+# SHA256SUMS before installing (see SECURITY.md, "Verifying release artifacts").
+#
 # Environment variables:
-#   ALINT_VERSION   Tag to install (e.g. v0.1.0). Defaults to the latest release.
-#   INSTALL_DIR     Destination directory. Defaults to $HOME/.local/bin.
-#   ALINT_REPO      Override repository (for testing forks). Defaults to asamarts/alint.
+#   ALINT_VERSION      Tag to install (e.g. v0.1.0). Defaults to the latest release.
+#   INSTALL_DIR        Destination directory. Defaults to $HOME/.local/bin.
+#   ALINT_REPO         Override repository (for testing forks). Defaults to asamarts/alint.
+#   ALINT_SKIP_VERIFY  Set to 1 to skip cosign signature verification (best-effort;
+#                      verification is skipped anyway when cosign is absent).
 
 set -euo pipefail
 
@@ -80,6 +89,57 @@ else
   echo "error: neither sha256sum nor shasum is available — cannot verify download"
   exit 1
 fi
+
+# ── Optional signature verification (best-effort, cosign) ────────────
+# If cosign is present, verify the release's cosign-signed SHA256SUMS and confirm
+# this archive's digest is listed in it: authenticity, not just the integrity the
+# per-file .sha256 above already checked. NEVER a hard dependency: skipped (with a
+# note) when cosign is absent, when the release predates signing (no
+# .cosign.bundle asset), or when ALINT_SKIP_VERIFY=1. cosign verifies the bundle
+# offline (the Rekor proof is embedded), so a genuine verification FAILURE means a
+# bad signature: treated as possible tampering, and aborts the install.
+verify_signature() {
+  if [[ "${ALINT_SKIP_VERIFY:-}" == "1" ]]; then
+    echo "==> Skipping signature verification (ALINT_SKIP_VERIFY=1)"
+    return 0
+  fi
+  if ! command -v cosign >/dev/null 2>&1; then
+    echo "note: cosign not found; skipping signature verification (integrity was"
+    echo "      checked above). Install cosign v3+ to verify authenticity, or see"
+    echo "      https://github.com/${REPO}/blob/main/SECURITY.md#verifying-release-artifacts"
+    return 0
+  fi
+  if ! curl -fsSL -o SHA256SUMS "${BASE_URL}/SHA256SUMS" 2>/dev/null \
+     || ! curl -fsSL -o SHA256SUMS.cosign.bundle "${BASE_URL}/SHA256SUMS.cosign.bundle" 2>/dev/null; then
+    echo "note: ${VERSION} has no cosign signature (predates release signing); skipping."
+    return 0
+  fi
+  echo "==> Verifying release signature (cosign)"
+  if ! cosign verify-blob \
+      --bundle SHA256SUMS.cosign.bundle \
+      --certificate-identity-regexp "^https://github\\.com/${REPO}/\\.github/workflows/release\\.yml@refs/tags/v" \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+      SHA256SUMS >/dev/null 2>&1; then
+    echo "error: cosign could not verify SHA256SUMS for ${VERSION}: it is not validly" >&2
+    echo "       signed by ${REPO}'s release workflow. Aborting (possible tampering)." >&2
+    echo "       Set ALINT_SKIP_VERIFY=1 to bypass." >&2
+    exit 1
+  fi
+  # Confirm this archive's digest appears in the now-authenticated manifest.
+  local want got
+  want="$(awk -v f="${ARCHIVE}" '{ n = $2; sub(/^\*/, "", n); if (n == f) { print $1; exit } }' SHA256SUMS)"
+  if command -v sha256sum >/dev/null 2>&1; then
+    got="$(sha256sum "${ARCHIVE}" | awk '{print $1}')"
+  else
+    got="$(shasum -a 256 "${ARCHIVE}" | awk '{print $1}')"
+  fi
+  if [[ -z "${want}" || "${want}" != "${got}" ]]; then
+    echo "error: ${ARCHIVE} is not the file signed in SHA256SUMS. Aborting (tampering?)." >&2
+    exit 1
+  fi
+  echo "==> Signature OK (SHA256SUMS signed by ${REPO}'s release workflow)"
+}
+verify_signature
 
 # ── Extract + install ────────────────────────────────────────────────
 

--- a/install.sh
+++ b/install.sh
@@ -19,8 +19,12 @@
 #   ALINT_VERSION      Tag to install (e.g. v0.1.0). Defaults to the latest release.
 #   INSTALL_DIR        Destination directory. Defaults to $HOME/.local/bin.
 #   ALINT_REPO         Override repository (for testing forks). Defaults to asamarts/alint.
-#   ALINT_SKIP_VERIFY  Set to 1 to skip cosign signature verification (best-effort;
-#                      verification is skipped anyway when cosign is absent).
+#   ALINT_SKIP_VERIFY  Set to 1 to skip cosign signature verification (which is
+#                      best-effort: skipped anyway when cosign is absent/too old or
+#                      the release is unsigned).
+#   ALINT_REQUIRE_VERIFY  Set to 1 to FAIL CLOSED instead: abort if the release
+#                      cannot be cosign-verified (cosign missing/old, unsigned, or
+#                      an error). For installs over an untrusted network.
 
 set -euo pipefail
 
@@ -91,27 +95,46 @@ else
 fi
 
 # ── Optional signature verification (best-effort, cosign) ────────────
-# If cosign is present, verify the release's cosign-signed SHA256SUMS and confirm
-# this archive's digest is listed in it: authenticity, not just the integrity the
-# per-file .sha256 above already checked. NEVER a hard dependency: skipped (with a
-# note) when cosign is absent, when the release predates signing (no
-# .cosign.bundle asset), or when ALINT_SKIP_VERIFY=1. cosign verifies the bundle
-# offline (the Rekor proof is embedded), so a genuine verification FAILURE means a
-# bad signature: treated as possible tampering, and aborts the install.
+# If cosign v3+ is present, verify the release's cosign-signed SHA256SUMS and
+# confirm this archive's digest is listed in it: authenticity, not just the
+# integrity the per-file .sha256 above already checked. Best-effort by default,
+# NEVER a hard dependency: skipped (with a note) when cosign is absent or older
+# than v3 (the signature uses the new-format Sigstore bundle, which older cosign
+# cannot parse), when the release has no .cosign.bundle asset, or when
+# ALINT_SKIP_VERIFY=1. Set ALINT_REQUIRE_VERIFY=1 to fail closed on any of those
+# (a hostile-network lever). A cosign signature that is present but does not
+# verify always aborts.
+
+# Best-effort skip vs strict (ALINT_REQUIRE_VERIFY=1) abort for a cannot-verify
+# condition. ALINT_SKIP_VERIFY=1 (checked first in verify_signature) wins over both.
+_verify_skip_or_fail() {
+  if [[ "${ALINT_REQUIRE_VERIFY:-}" == "1" ]]; then
+    echo "error: $1 (ALINT_REQUIRE_VERIFY=1 is set). Aborting." >&2
+    exit 1
+  fi
+  echo "note: $1; skipping signature verification."
+}
+
 verify_signature() {
   if [[ "${ALINT_SKIP_VERIFY:-}" == "1" ]]; then
     echo "==> Skipping signature verification (ALINT_SKIP_VERIFY=1)"
     return 0
   fi
   if ! command -v cosign >/dev/null 2>&1; then
-    echo "note: cosign not found; skipping signature verification (integrity was"
-    echo "      checked above). Install cosign v3+ to verify authenticity, or see"
-    echo "      https://github.com/${REPO}/blob/main/SECURITY.md#verifying-release-artifacts"
+    _verify_skip_or_fail "cosign not found (install cosign v3+ to verify authenticity; the per-file SHA-256 above was still checked)"
+    return 0
+  fi
+  # The release signs with the new-format Sigstore bundle (cosign v3+); an older
+  # cosign cannot parse it and would false-abort a perfectly good release.
+  local cver
+  cver="$(cosign version 2>/dev/null | awk -F'v' '/GitVersion/ { split($2, a, "."); print a[1] + 0; exit }')"
+  if (( ${cver:-0} < 3 )); then
+    _verify_skip_or_fail "cosign ${cver:-<unknown>}.x is too old for the new-format signature (need v3+)"
     return 0
   fi
   if ! curl -fsSL -o SHA256SUMS "${BASE_URL}/SHA256SUMS" 2>/dev/null \
      || ! curl -fsSL -o SHA256SUMS.cosign.bundle "${BASE_URL}/SHA256SUMS.cosign.bundle" 2>/dev/null; then
-    echo "note: ${VERSION} has no cosign signature (predates release signing); skipping."
+    _verify_skip_or_fail "no cosign signature found for ${VERSION} (unsigned release, or it could not be downloaded)"
     return 0
   fi
   echo "==> Verifying release signature (cosign)"
@@ -120,9 +143,10 @@ verify_signature() {
       --certificate-identity-regexp "^https://github\\.com/${REPO}/\\.github/workflows/release\\.yml@refs/tags/v" \
       --certificate-oidc-issuer https://token.actions.githubusercontent.com \
       SHA256SUMS >/dev/null 2>&1; then
-    echo "error: cosign could not verify SHA256SUMS for ${VERSION}: it is not validly" >&2
-    echo "       signed by ${REPO}'s release workflow. Aborting (possible tampering)." >&2
-    echo "       Set ALINT_SKIP_VERIFY=1 to bypass." >&2
+    echo "error: cosign could not verify SHA256SUMS for ${VERSION}. A genuinely bad" >&2
+    echo "       signature is possible tampering; an unreachable Sigstore trust root" >&2
+    echo "       is a verification error. Aborting either way. Set ALINT_SKIP_VERIFY=1" >&2
+    echo "       to install without verifying." >&2
     exit 1
   fi
   # Confirm this archive's digest appears in the now-authenticated manifest.


### PR DESCRIPTION
Verification UX (`docs/design/distribution.md` §6.5, `MP-H1`): make `install.sh` verify a release's **authenticity**, not just integrity, and document the manual paths. Builds on P1-b (the signatures now exist).

## install.sh
When `cosign` is present, download the release's cosign-signed `SHA256SUMS` + `SHA256SUMS.cosign.bundle`, `verify-blob` them against the release workflow's OIDC identity, and confirm the downloaded archive's digest is in the now-authenticated manifest. **Best-effort, never a hard dependency:**
- cosign absent → note + proceed (the per-file `.sha256` integrity check stays)
- release predates signing (no `.cosign.bundle`) → note + proceed
- `ALINT_SKIP_VERIFY=1` → skip
- genuine failure (bad signature, or archive not in the signed manifest) → **abort** (possible tampering). cosign verifies the bundle offline (embedded Rekor proof), so a failure is a real mismatch, not a network blip.

## Docs
The installation page's "Verify the install" section gains the signature/provenance commands (`gh attestation verify` + `cosign verify-blob`, matching SECURITY.md's tightened identity regexp) and notes the auto-verify + `ALINT_SKIP_VERIFY`. The `MP-N1` mutable-ref caveat + inspectable/tag-pinned-URL path already live in the install.sh section (P0); install.sh's header now points at both.

## Deferred
The **npm-shim** opt-in verify → the **P2** optionalDependencies rewrite, which brings npm provenance (a different verification model); adding cosign to the soon-to-be-replaced download shim would be redone.

## Verified
Locally against the live **v0.15.0** (predates signing): install.sh with cosign present **skips gracefully and still installs**; `ALINT_SKIP_VERIFY=1` skips; shellcheck + dogfood green; no curly quotes. The success + abort paths are release-only-testable (they need a signed release) and use SECURITY.md's validated cosign syntax.