### PR TITLE
chore(release): bump workspace to 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-08-21
+
+A supply-chain-hardening release. The alint tool is unchanged from 0.15.0, but
+every release is now cryptographically verifiable end to end: releases are
+cosign-signed and carry GitHub build provenance, a CycloneDX SBOM and a
+third-party license bundle ship with every artifact, `install.sh` verifies the
+signature when `cosign` is present, and each published crate carries its license
+texts. See [SECURITY.md](SECURITY.md#verifying-release-artifacts) to verify a
+download. Implements ADR-0015.
+
 ### Added
 
 - Supply-chain artifacts on every release (P1-a of the supply-chain-hardening
@@ -13,7 +23,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   license bundle (`THIRD-PARTY-LICENSES.html`), both scoped to the shipped `alint`
   binary, attached to the GitHub Release and embedded in every binary tarball and
   the Docker image. A root `NOTICE` states the dual license and accompanies each
-  distribution. The image now also carries `LICENSE-APACHE` / `LICENSE-MIT`.
+  distribution. The image now also carries `LICENSE-APACHE` / `LICENSE-MIT`, and
+  each published crate ships its `LICENSE-*` + `NOTICE` in the crates.io archive.
+- `install.sh` verifies the release signature when `cosign` (v3+) is present
+  (best-effort: `ALINT_SKIP_VERIFY=1` skips, `ALINT_REQUIRE_VERIFY=1` fails closed
+  on an untrusted network). Its header documents a tag-pinned installer URL for
+  inspection before running.
 
 ### Security
 
@@ -6553,7 +6568,8 @@ Initial release. MVP.
   verification.
 - Dogfood `.alint.yml` exercising the tool against its own repo.
 
-[Unreleased]: https://github.com/asamarts/alint/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/asamarts/alint/compare/v0.15.1...HEAD
+[0.15.1]: https://github.com/asamarts/alint/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/asamarts/alint/compare/v0.14.2...v0.15.0
 [0.14.2]: https://github.com/asamarts/alint/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/asamarts/alint/compare/v0.14.0...v0.14.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "alint"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "alint-core",
  "alint-dsl",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "alint-bench"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "alint-core",
  "alint-dsl",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "alint-core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "globset",
  "ignore",
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "alint-dsl"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "alint-core",
  "alint-rules",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "alint-e2e"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "alint-core",
  "alint-dsl",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "alint-lsp"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "alint-core",
  "alint-dsl",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "alint-output"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "alint-core",
  "anstream",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "alint-rules"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "alint-core",
  "content_inspector",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "alint-testkit"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "alint-core",
  "alint-dsl",
@@ -3501,7 +3501,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "alint-bench",
  "alint-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 default-members = ["crates/alint"]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Most bundled rulesets are gated by ecosystem facts (`has_rust`, `has_node`, `has
 - **8 output formats**: `human`, `json` (stable schema), `sarif` (GitHub Code Scanning), `github` (inline PR annotations), `markdown` (PR comments), `junit` (CI test reports), `gitlab` (Code Quality), `agent` (LLM-shaped JSON with `agent_instruction` per violation).
 - **JSON Schemas**: config at [`schemas/v1/config.json`](schemas/v1/config.json) for editor autocomplete; report shapes at [`schemas/v1/check-report.json`](schemas/v1/check-report.json) and [`schemas/v1/fix-report.json`](schemas/v1/fix-report.json) for downstream tooling.
 - **Telemetry-free.** No network access at runtime, except the user-explicit `extends: https://...` URLs (SRI-pinned). Reproducible builds (`Cargo.lock` committed, pinned toolchain). See [SECURITY.md](SECURITY.md) for the threat model.
-- **Official GitHub Action**: [`asamarts/alint@v0.15.0`](https://github.com/asamarts/alint).
+- **Official GitHub Action**: [`asamarts/alint@v0.15.1`](https://github.com/asamarts/alint).
 
 ## Where alint shines
 
@@ -149,7 +149,7 @@ A distroless multi-arch image (`linux/amd64`, `linux/arm64`) is published to ghc
 docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:latest
 
 # Pin to an exact version:
-docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.15.0 check
+docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.15.1 check
 ```
 
 The image runs as the distroless `nonroot` user (UID 65532); host files must be world-readable. To apply fixes and preserve host ownership, pass `-u`:
@@ -158,7 +158,7 @@ The image runs as the distroless `nonroot` user (UID 65532); host files must be 
 docker run --rm -u $(id -u):$(id -g) -v "$PWD:/repo" ghcr.io/asamarts/alint:latest fix
 ```
 
-Also published: the bare semver (`:0.15.0`), the `:<major>.<minor>` rolling channel, and the raw git tag (`:v0.15.0`).
+Also published: the bare semver (`:0.15.1`), the `:<major>.<minor>` rolling channel, and the raw git tag (`:v0.15.1`).
 
 ## Usage
 
@@ -286,15 +286,15 @@ All rulesets ship with non-blocking defaults (`info` / `warning` for recommendat
 Inline PR annotations (default):
 
 ```yaml
-- uses: asamarts/alint@v0.15.0
+- uses: asamarts/alint@v0.15.1
 ```
 
 All inputs (all optional):
 
 ```yaml
-- uses: asamarts/alint@v0.15.0
+- uses: asamarts/alint@v0.15.1
   with:
-    version: v0.15.0        # alint release tag (default: latest)
+    version: v0.15.1        # alint release tag (default: latest)
     path: .                # directory to lint (default: .)
     format: github         # human | json | sarif | github | markdown | junit | gitlab | agent (default: github)
     config: |              # extra config path(s), one per line
@@ -306,7 +306,7 @@ All inputs (all optional):
 Upload findings to GitHub Code Scanning:
 
 ```yaml
-- uses: asamarts/alint@v0.15.0
+- uses: asamarts/alint@v0.15.1
   id: alint
   with:
     format: sarif
@@ -324,7 +324,7 @@ Add to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/asamarts/alint
-    rev: v0.15.0
+    rev: v0.15.1
     hooks:
       - id: alint
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -116,7 +116,7 @@ Out of scope (report directly to upstream):
 Published advisories live at
 https://github.com/asamarts/alint/security/advisories.
 
-No advisories published as of the v0.15.0 release.
+No advisories published as of the v0.15.1 release.
 
 ## Threat model
 

--- a/docs/design/ROADMAP.md
+++ b/docs/design/ROADMAP.md
@@ -10,7 +10,12 @@
 > markers. See [`v0.11/roadmap_generator.md`](https://github.com/asamarts/alint/blob/main/docs/design/v0.11/roadmap_generator.md)
 > for the marker syntax and the v0.9.22 migration plan.
 
-**Latest release: v0.15.0** (2026-08-16): `alint explain` now surfaces a rule's
+**Latest release: v0.15.1** (2026-08-21): a supply-chain-hardening release. The
+alint tool is unchanged from v0.15.0, but every release is now cosign-signed with
+GitHub build provenance, ships a CycloneDX SBOM and a third-party license bundle,
+`install.sh` verifies signatures when `cosign` is present, and each published
+crate carries its license texts (ADR-0015). The prior v0.15.0 (2026-08-16) made
+`alint explain` surface a rule's
 full configured detail with a `docs:` link and a one-line summary, `alint rules
 show` / `list --search` browse the catalog offline, and a new `scope_filter:
 include_manifest_paths:` / `exclude_manifest_paths:` scopes a per-file rule by

--- a/docs/site/getting-started/installation.md
+++ b/docs/site/getting-started/installation.md
@@ -29,10 +29,10 @@ Detects platform (Linux / macOS, x86_64 / aarch64), downloads the matching tarba
 Pin a specific version (and skip the "latest release" GitHub API lookup, which can rate-limit on shared CI egress IPs):
 
 ```bash
-ALINT_VERSION=v0.15.0 curl -sSL https://alint.org/install.sh | bash
+ALINT_VERSION=v0.15.1 curl -sSL https://alint.org/install.sh | bash
 ```
 
-Supply-chain note: the installer verifies the SHA-256 of the release tarball it downloads, but the script itself is fetched from the `main` branch (`alint.org/install.sh` redirects there). To pin the installer too, point `curl` at a release tag instead of `main` (for example `https://raw.githubusercontent.com/asamarts/alint/v0.15.0/install.sh`), or download it from the [Releases page](https://github.com/asamarts/alint/releases) and review it before running.
+Supply-chain note: the installer verifies the SHA-256 of the release tarball it downloads, but the script itself is fetched from the `main` branch (`alint.org/install.sh` redirects there). To pin the installer too, point `curl` at a release tag instead of `main` (for example `https://raw.githubusercontent.com/asamarts/alint/v0.15.1/install.sh`), or download it from the [Releases page](https://github.com/asamarts/alint/releases) and review it before running.
 
 ## npm
 
@@ -71,7 +71,7 @@ A distroless multi-arch image (`linux/amd64`, `linux/arm64`) is published to ghc
 docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:latest
 
 # Pin to an exact version:
-docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.15.0 check
+docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.15.1 check
 ```
 
 The image is OCI-standard, so **Podman runs it unchanged** — just use the fully-qualified name (Podman does not assume a default registry):
@@ -86,7 +86,7 @@ The image runs as the distroless `nonroot` user (UID 65532); host files must be 
 docker run --rm -u $(id -u):$(id -g) -v "$PWD:/repo" ghcr.io/asamarts/alint:latest fix
 ```
 
-Also published: the bare semver (`:0.15.0`), the `:<major>.<minor>` rolling channel, and the raw git tag (`:v0.15.0`).
+Also published: the bare semver (`:0.15.1`), the `:<major>.<minor>` rolling channel, and the raw git tag (`:v0.15.1`).
 
 ## Windows
 
@@ -94,7 +94,7 @@ The `install.sh` one-liner is shell-based and does not cover Windows. On Windows
 
 - **npm:** `npm install -g @asamarts/alint` (see [npm](#npm)) — the simplest path;
 - **cargo:** `cargo install alint` or `cargo binstall alint` (see [cargo](#cargo));
-- **manual:** download `alint-v0.15.0-x86_64-pc-windows-msvc.tar.gz` from the [Releases page](https://github.com/asamarts/alint/releases), extract, and put `alint.exe` on your `PATH`.
+- **manual:** download `alint-v0.15.1-x86_64-pc-windows-msvc.tar.gz` from the [Releases page](https://github.com/asamarts/alint/releases), extract, and put `alint.exe` on your `PATH`.
 
 Note on manually-downloaded binaries: a tarball downloaded through a **browser** carries a "mark of the web", so the first run can trip Windows SmartScreen ("More info → Run anyway") or, on macOS, Gatekeeper quarantine — clear it with `xattr -d com.apple.quarantine ./alint`. Binaries fetched by `curl`/npm/cargo/Homebrew/Docker carry no such mark and run without prompts.
 

--- a/docs/site/integrations/docker.md
+++ b/docs/site/integrations/docker.md
@@ -18,10 +18,10 @@ The image's `WORKDIR` is `/repo`, so the bind-mount lets alint see your repo as 
 ## Pin to a version
 
 ```bash
-docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.15.0 check
+docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.15.1 check
 ```
 
-Tags published per release: the exact git tag (`:v0.15.0`), the bare semver (`:0.15.0`), the `<major>.<minor>` channel (`:0.15`), and `:latest`.
+Tags published per release: the exact git tag (`:v0.15.1`), the bare semver (`:0.15.1`), the `<major>.<minor>` channel (`:0.15`), and `:latest`.
 
 ## Apply auto-fixes
 
@@ -46,7 +46,7 @@ For one-shot lint runs in CI systems that prefer containers over running custom 
 ```yaml
 # Generic CI (GitLab, Drone, BuildKite, …)
 script:
-  - docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.15.0 check --format json
+  - docker run --rm -v "$PWD:/repo" ghcr.io/asamarts/alint:v0.15.1 check --format json
 ```
 
 For GitHub Actions specifically, the [official Action](/docs/integrations/github-actions/) is more ergonomic.

--- a/docs/site/integrations/github-actions.md
+++ b/docs/site/integrations/github-actions.md
@@ -14,7 +14,7 @@ The official Action wraps the `install.sh` flow plus alint invocation into one s
 ## Inline PR annotations (default)
 
 ```yaml
-- uses: asamarts/alint@v0.15.0
+- uses: asamarts/alint@v0.15.1
 ```
 
 This runs `alint check --format github` against `.` and emits findings as `::error::` / `::warning::` workflow commands, which GitHub renders inline on the PR.
@@ -22,9 +22,9 @@ This runs `alint check --format github` against `.` and emits findings as `::err
 ## Inputs (all optional)
 
 ```yaml
-- uses: asamarts/alint@v0.15.0
+- uses: asamarts/alint@v0.15.1
   with:
-    version: v0.15.0        # release tag; omit to follow the pinned action ref
+    version: v0.15.1        # release tag; omit to follow the pinned action ref
     path: .                # directory to lint (default: .)
     working-directory: .   # dir the action runs in (default: the runner workspace)
     format: github         # human | json | sarif | github (default)
@@ -39,7 +39,7 @@ This runs `alint check --format github` against `.` and emits findings as `::err
 Use `format: sarif` and pipe to the standard upload action:
 
 ```yaml
-- uses: asamarts/alint@v0.15.0
+- uses: asamarts/alint@v0.15.1
   id: alint
   with:
     format: sarif
@@ -59,7 +59,7 @@ alint's SARIF carries a stable [`partialFingerprints`](/docs/reference/output-fo
 For supply-chain hygiene (and to satisfy alint's own [`ci/github-actions@v1`](/docs/bundled-rulesets/) bundled ruleset), pin the action to a commit SHA:
 
 ```yaml
-- uses: asamarts/alint@<40-char-sha>  # v0.15.0
+- uses: asamarts/alint@<40-char-sha>  # v0.15.1
 ```
 
 Look up the SHA on the [tag page](https://github.com/asamarts/alint/tags).
@@ -88,7 +88,7 @@ jobs:
       - name: alint check
         env:
           ALINT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        uses: asamarts/alint@v0.15.0
+        uses: asamarts/alint@v0.15.1
 ```
 
 The rule in `.alint.yml`:

--- a/docs/site/integrations/pre-commit.md
+++ b/docs/site/integrations/pre-commit.md
@@ -10,7 +10,7 @@ alint ships a [pre-commit](https://pre-commit.com/) hook definition. Add it to y
 ```yaml
 repos:
   - repo: https://github.com/asamarts/alint
-    rev: v0.15.0
+    rev: v0.15.1
     hooks:
       - id: alint
 ```
@@ -36,7 +36,7 @@ Pin to a tagged release. Updating the `rev:` is how you upgrade alint:
 ```yaml
 repos:
   - repo: https://github.com/asamarts/alint
-    rev: v0.15.0
+    rev: v0.15.1
     hooks:
       - id: alint
         # Pass extra args here if you need to:

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alint-zed"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 publish = false
 license = "Apache-2.0 OR MIT"

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "alint"
 name = "alint"
-version = "0.15.0"
+version = "0.15.1"
 schema_version = 1
 authors = ["alint contributors"]
 description = "Repository-structure linting (alint) in Zed via the alint language server."

--- a/facts.json
+++ b/facts.json
@@ -1,6 +1,6 @@
 {
   "format_version": 2,
-  "alint_version": "0.15.0",
+  "alint_version": "0.15.1",
   "counts": {
     "rule_kinds": 89,
     "families": 13,

--- a/npm/README.md
+++ b/npm/README.md
@@ -23,7 +23,7 @@ alint check
 ```
 
 The npm package version tracks alint releases exactly: `npm install
-@asamarts/alint@0.15.0` downloads alint v0.15.0.
+@asamarts/alint@0.15.1` downloads alint v0.15.1.
 
 ## Supported platforms
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asamarts/alint",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Language-agnostic linter for repository structure, file existence, filename conventions, and file content rules. This package downloads and wraps the platform-matched native alint binary.",
   "keywords": ["lint", "linter", "repository", "filename", "policy", "compliance"],
   "homepage": "https://github.com/asamarts/alint",


### PR DESCRIPTION
Release prep for **v0.15.1** — cutting the supply-chain-hardening arc.

**Patch, not minor:** the alint tool is byte-identical to 0.15.0 (zero `.rs` changes since the v0.15.0 tag). What ships is release infrastructure + install verification + docs + license files. Caret `^0.15.0` includes 0.15.1, so no dep-floor pre-bump was needed.

## What this bump contains
- `bump-version.sh 0.15.1`: `Cargo.toml`/`Cargo.lock`, all install snippets (README, SECURITY, docs-site, Zed, npm).
- CHANGELOG `[Unreleased]` → `[0.15.1]` with a summary + Added (SBOM/bundle/crate-licenses + install.sh verify) + Security (signing/attestation).
- ROADMAP "Latest release" line refreshed to 0.15.1.
- `facts.json` regenerated (`alint_version: 0.15.1`); roadmap.json unchanged (no phase change).

## Verified locally
Full preflight green: fmt / clippy / test / doc / dogfood (only the known non-blocking `docs_export.rs` warning), version-pins (all → 0.15.1), dep-floors (7 pins ≤ 0.15.1), the crate-license drift-gate, and all 6 em-dash-restricted docs.

**Merging this + tagging `v0.15.1` triggers `release.yml`** (the first release to exercise attestation, cosign signing, the MP-M5 smoke, and install.sh's verify success-path live). Holding that for explicit go-ahead.