### PR TITLE
fix(ci): add SBOM serialNumber + make attestations non-blocking for the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,25 +256,13 @@ jobs:
           #     SHA256SUMS
           cosign sign-blob --yes --bundle SHA256SUMS.cosign.bundle SHA256SUMS
 
-      - name: attest build provenance for every asset in SHA256SUMS
-        # subject-checksums reads SHA256SUMS and attests each listed file's digest,
-        # so `gh attestation verify <tarball> --repo asamarts/alint` works for the
-        # tarballs, installer, SBOM, and license bundle in one attestation. (Not
-        # SHA256SUMS itself, the .cosign.bundle, or the .sha256 sidecars.)
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
-        with:
-          subject-checksums: release-artifacts/SHA256SUMS
-
-      - name: attest the CycloneDX SBOM against the tarballs
-        # attest-sbom is deprecated in favour of actions/attest with an SBOM
-        # predicate, but is SHA-pinned here so it keeps working; it still wraps
-        # actions/attest and handles the CycloneDX predicate for us. Migrate when
-        # convenient.
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
-        with:
-          subject-path: "release-artifacts/alint-*.tar.gz"
-          sbom-path: release-artifacts/alint.cdx.json
-
+      # Create the Release + its cosign-signed assets FIRST, then attest. The two
+      # attestations below are best-effort (continue-on-error): a broken
+      # attestation must never block the Release itself or the downstream publishes
+      # that `needs:` this job (npm/homebrew/editors). This ordering is the direct
+      # lesson of v0.15.1, where a rejected SBOM attestation -- ordered BEFORE this
+      # step -- skipped the Release even though crates.io + Docker had already
+      # published, stranding a half-released version.
       - name: create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -295,6 +283,36 @@ jobs:
             install.sh SHA256SUMS SHA256SUMS.cosign.bundle \
             THIRD-PARTY-LICENSES.html alint.cdx.json \
             alint-*.tar.gz alint-*.tar.gz.sha256
+
+      - name: attest build provenance for every asset in SHA256SUMS
+        id: attest_provenance
+        continue-on-error: true   # best-effort: never block a published Release
+        # subject-checksums reads SHA256SUMS and attests each listed file's digest,
+        # so `gh attestation verify <tarball> --repo asamarts/alint` works for the
+        # tarballs, installer, SBOM, and license bundle in one attestation. (Not
+        # SHA256SUMS itself, the .cosign.bundle, or the .sha256 sidecars.)
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-checksums: release-artifacts/SHA256SUMS
+
+      - name: attest the CycloneDX SBOM against the tarballs
+        id: attest_sbom
+        continue-on-error: true   # best-effort: never block a published Release
+        # attest-sbom is deprecated in favour of actions/attest with an SBOM
+        # predicate, but is SHA-pinned here so it keeps working; it still wraps
+        # actions/attest and handles the CycloneDX predicate for us. Migrate when
+        # convenient. NOTE: actions/attest's checkIsCycloneDX REQUIRES a
+        # serialNumber (optional in the spec); supply-chain-artifacts.sh injects a
+        # deterministic one, without which this step fails "Unsupported SBOM format".
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: "release-artifacts/alint-*.tar.gz"
+          sbom-path: release-artifacts/alint.cdx.json
+
+      - name: surface any incomplete attestation (non-blocking)
+        if: steps.attest_provenance.outcome != 'success' || steps.attest_sbom.outcome != 'success'
+        run: |
+          echo "::warning::Release shipped but an attestation did not succeed (build-provenance=${{ steps.attest_provenance.outcome }}, sbom=${{ steps.attest_sbom.outcome }}). Investigate before relying on 'gh attestation verify'."
 
       - name: trigger docs-bundle rebuild from the freshly-published Release
         env:

--- a/ci/scripts/supply-chain-artifacts.sh
+++ b/ci/scripts/supply-chain-artifacts.sh
@@ -43,10 +43,13 @@ BINARY_MANIFEST="crates/alint/Cargo.toml"
 CARGO_ABOUT_VERSION="0.9.2"
 CARGO_CYCLONEDX_VERSION="0.5.9"
 
-# Byte-reproducible artifacts: pin cargo-cyclonedx's wall-clock stamps
-# (metadata.timestamp + the random serialNumber UUID) to the tagged commit's
-# date. Without this each run embeds now() + a fresh UUID, so a verifier
+# Byte-reproducible artifacts: pin cargo-cyclonedx's metadata.timestamp to the
+# tagged commit's date. Without this each run embeds now(), so a verifier
 # regenerating from the tag would compute a different hash than the signed one.
+# (cargo-cyclonedx OMITS the optional CycloneDX serialNumber under
+# SOURCE_DATE_EPOCH -- a random per-run UUID cannot be reproducible -- so a
+# deterministic serialNumber is injected after generation below; actions/attest
+# rejects an SBOM that carries none.)
 SOURCE_DATE_EPOCH="$(git -C "$REPO_ROOT" log -1 --format=%ct 2>/dev/null || echo 0)"
 export SOURCE_DATE_EPOCH
 
@@ -90,6 +93,30 @@ cargo cyclonedx --manifest-path "$BINARY_MANIFEST" \
   --format json --target all --no-build-deps --spec-version 1.5 \
   --override-filename alint -q
 mv "crates/alint/alint.json" "$OUT_DIR/alint.cdx.json"
+
+# actions/attest's checkIsCycloneDX treats serialNumber as MANDATORY, though the
+# CycloneDX spec marks it optional -- and cargo-cyclonedx emits none under
+# SOURCE_DATE_EPOCH (see above), so `attest-sbom` rejects the bundle with
+# "Unsupported SBOM format. Must be valid SPDX or CycloneDX JSON." Inject a
+# DETERMINISTIC RFC-4122 v5 URN derived from the crate version: reproducible
+# across runs (preserving the byte-identity cosign-over-SHA256SUMS relies on) yet
+# unique per release. python3's uuid5 is portable across Linux + macOS dev boxes
+# (uuidgen's v5 flags are Linux-only).
+sbom_version="$(jq -r '.metadata.component.version' "$OUT_DIR/alint.cdx.json")"
+serial_uuid="$(python3 -c 'import uuid, sys; print(uuid.uuid5(uuid.NAMESPACE_URL, "https://alint.org/sbom/alint@" + sys.argv[1]))' "$sbom_version")"
+sbom_tmp="$(mktemp)"
+jq --arg sn "urn:uuid:${serial_uuid}" '.serialNumber = $sn' "$OUT_DIR/alint.cdx.json" > "$sbom_tmp"
+mv "$sbom_tmp" "$OUT_DIR/alint.cdx.json"
+echo "==> injected deterministic serialNumber (urn:uuid:${serial_uuid})"
+
+# Gate the invariant this whole fix rests on: actions/attest's checkIsCycloneDX
+# requires bomFormat + specVersion + a serialNumber. Assert the generated SBOM
+# carries a urn:uuid: serialNumber HERE -- run by the ci.yml `supply-chain` job
+# and the release preflight -- so a regression (e.g. a cargo-cyclonedx bump that
+# changes its serialNumber behaviour) fails a PR or the preflight, never
+# mid-release the way v0.15.1's attest-sbom did.
+jq -e '(.serialNumber // "") | startswith("urn:uuid:")' "$OUT_DIR/alint.cdx.json" >/dev/null \
+  || { echo "FATAL: alint.cdx.json lacks a urn:uuid: serialNumber; attest-sbom would reject it" >&2; exit 1; }
 
 echo "==> supply-chain artifacts written to ${OUT_DIR}:"
 ls -la "$OUT_DIR/THIRD-PARTY-LICENSES.html" "$OUT_DIR/alint.cdx.json"


### PR DESCRIPTION
## Incident

The **v0.15.1** release run (32500182849) left a **half-released version**:

| Job | Result |
|---|---|
| `publish to crates.io` (`needs: build`) | ✅ **published** — irreversible |
| `push Docker to ghcr.io` (`needs: build,supply-chain`) | ✅ **published** |
| `create GitHub Release` | ❌ **failed** → no Release |
| `publish npm` / `homebrew` / vscode / jetbrains (`needs: release`) | ⏭️ skipped |

## Root cause

The `attest the CycloneDX SBOM` step (`actions/attest-sbom` → `actions/attest`) rejected our SBOM:

```
##[error]Error: Unsupported SBOM format. Must be valid SPDX or CycloneDX JSON.
```

`actions/attest`'s detector is:

```js
const checkIsCycloneDX = (o) => !!(o?.bomFormat && o?.serialNumber && o?.specVersion);
```

It treats `serialNumber` as **mandatory** (the CycloneDX spec marks it *optional*), and `cargo-cyclonedx` **omits `serialNumber` under `SOURCE_DATE_EPOCH`** (a random per-run UUID can't be reproducible). That step was ordered **before** `create GitHub Release`, so its failure skipped the Release — and everything that `needs:` it.

## Fixes

1. **`supply-chain-artifacts.sh`** injects a **deterministic** RFC-4122 v5 `serialNumber` (`urn:uuid:` derived from the crate version): reproducible across runs (so cosign-over-`SHA256SUMS` byte-identity holds) yet unique per release. A **self-check gate** then asserts the SBOM carries a `urn:uuid:` serialNumber — run by the `supply-chain` CI job and the release preflight — so any regression fails a PR, never mid-release.
2. **`release.yml`** creates the GitHub Release (with its cosign-signed assets) **before** the attestations, and both attestations are now `continue-on-error` with a non-blocking `::warning::` if incomplete. A best-effort attestation can no longer strand a release.

## Validation

- `shellcheck` + `bash -n` clean; `actionlint` reports **zero** new findings (the 2 it flags are pre-existing on `main`)
- Injection verified end-to-end against the real v0.15.1 SBOM → `checkIsCycloneDX` passes
- The self-check gate proven both ways: passes with the serialNumber, fails without

## Recovery (post-merge)

crates.io + Docker are already out; `publish-crates.sh` is idempotent (skips already-published). Move `v0.15.1` to this fix commit and re-trigger — the `release` job creates the Release and npm/Homebrew/editors publish.