### PR TITLE
ci(release): publish npm tokenlessly via OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -525,20 +525,28 @@ jobs:
     # being live.
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # OIDC token for npm Trusted Publishing (tokenless publish)
+      contents: read    # checkout only; no writes needed here
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: "20"
+          node-version: "22"   # Trusted Publishing needs Node >= 22.14
           registry-url: "https://registry.npmjs.org"
+      - name: use an OIDC-capable npm (Trusted Publishing needs npm >= 11.5.1; pin the latest 11.x)
+        run: npm install -g npm@11.19.0   # not 12.x: it may drop Node 22 support
       - name: stamp package version from tag + publish
         env:
-          # PAT auth (NPM_TOKEN). npm OIDC Trusted Publishing is now GA, but npm
-          # provenance is only meaningful once the package ships native bytes via
-          # the optionalDependencies migration (ADR-0015 / P2) -- the current
-          # postinstall-download shim has nothing to attest. Until that lands this
-          # stays on the PAT; the migration switches to keyless `--provenance`.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Tokenless publish via npm Trusted Publishing (OIDC): no NPM_TOKEN, so
+          # nothing here can expire mid-release (the v0.15.1 failure mode). Requires a
+          # Trusted Publisher on npmjs.com for @asamarts/alint (repo=asamarts/alint,
+          # workflow=release.yml); npm validates it only at publish time, so a missing
+          # entry fails THIS job on the next release (fix it, then rerun --failed). The
+          # auto-provenance attests only this shim (install script + bin shim), NOT the
+          # binaries it downloads from GitHub Releases -- those carry their own
+          # build-provenance. The optionalDependencies migration (ADR-0015 / P2) will
+          # ship native bytes so the same provenance covers real payload.
           TAG: ${{ github.ref_name }}
         shell: bash
         run: |
@@ -557,7 +565,9 @@ jobs:
             fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
           echo "==> package.json version set to $ver"
-          npm publish --access public
+          # --provenance rides the OIDC id-token; with Trusted Publishing npm also
+          # generates provenance automatically, so this is explicit-and-belt.
+          npm publish --access public --provenance
 
   homebrew:
     name: bump Homebrew tap (asamarts/homebrew-alint)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -163,6 +163,22 @@ is permanent; see Yanking). The publish script is idempotent, so the
 recovery is: add the publisher, then `gh run rerun <id> --failed`
 (never re-tag). `alint-lsp` hit this on v0.11.1.
 
+## npm Trusted Publishing
+
+npm publishes tokenlessly via **npm Trusted Publishing** (OIDC), the same
+keyless model as the crates.io publisher above: no `NPM_TOKEN`, so nothing here
+can expire mid-release. One-time setup on npmjs.com: package `@asamarts/alint`
+→ Settings → Trusted Publisher → repo `asamarts/alint`, workflow `release.yml`,
+no environment. npm validates this only at publish time, so a missing or
+mismatched entry fails the `publish npm` job on the next release; recovery is
+add/fix the entry, then `gh run rerun <id> --failed` (never re-tag). The
+`publish-npm` job needs `id-token: write`, npm CLI `>= 11.5.1`, and Node
+`>= 22.14`. Trusted Publishing auto-attaches provenance; today it attests only
+the download shim (install script + bin shim), not the binaries the shim
+fetches from GitHub Releases (those carry their own build-provenance). When the
+optionalDependencies migration ships native bytes, the same provenance covers
+real payload.
+
 ## Recovering a partial release
 
 Most publish jobs run *after* the GitHub Release exists (`needs: release`), but
@@ -186,13 +202,13 @@ never re-tag** (crates.io / npm / ghcr are permanent, and a new tag would collid
   published to ghcr / crates.io. Re-run the release job: the cosign + attest steps are
   idempotent and precede Release creation, so a clean re-run re-signs and then creates
   the Release. Never re-tag.
-- **Expiring credentials** (`MP-M2`). Four channels carry secrets that can expire: the
-  npm PAT (`NPM_TOKEN`), VS Code + Open VSX (`VSCE_PAT` / `OVSX_PAT`), JetBrains (the
-  marketplace token + signing cert/key), and the Homebrew tap SSH deploy key. On a
-  401/403 from any, rotate the secret (inventory + storage in
+- **Expiring credentials** (`MP-M2`). Three channels carry secrets that can expire: VS
+  Code + Open VSX (`VSCE_PAT` / `OVSX_PAT`), JetBrains (the marketplace token + signing
+  cert/key), and the Homebrew tap SSH deploy key. On a 401/403 from any, rotate the
+  secret (inventory + storage in
   [`release-credentials.md`](docs/development/release-credentials.md)), then
-  `gh run rerun <id> --failed`. (npm OIDC trusted publishing is now GA and will retire
-  the `NPM_TOKEN` PAT once the package migrates to per-platform sub-packages.)
+  `gh run rerun <id> --failed`. (npm no longer carries a PAT: it publishes tokenlessly
+  via OIDC Trusted Publishing, see [npm Trusted Publishing](#npm-trusted-publishing).)
 - **A build-matrix flake blocking crates.io** (`MP-M1`). `publish-crates` deliberately
   `needs: build` (a cross-platform compile gate before the irreversible publish), so a
   flaky windows or aarch64 leg can block it. Re-run once the leg heals with

--- a/docs/development/release-credentials.md
+++ b/docs/development/release-credentials.md
@@ -33,7 +33,7 @@ to rotate.
 |---|---|---|---|---|
 | `GITHUB_TOKEN` | ghcr.io Docker | built-in | per-run | already keyless |
 | `CARGO_REGISTRY_TOKEN` | crates.io | crates.io account | manual | **yes → migrate to Trusted Publishing** |
-| `NPM_TOKEN` | npm (`@asamarts/alint`) | npmjs.com | **yes (bit us in v0.10.0)** | yes, but deferred (npmjs trusted-publisher UI is broken) |
+| `NPM_TOKEN` | npm (`@asamarts/alint`) | npmjs.com | retired | **migrated → Trusted Publishing (tokenless)** |
 | `HOMEBREW_TAP_DEPLOY_KEY` | `asamarts/homebrew-alint` | ssh-keygen + repo deploy key | no (SSH key) | n/a (use a GitHub App for org scale) |
 | `VSCE_PAT` | VS Code Marketplace | Azure DevOps PAT | **yes (max 1 yr)** | no (Azure DevOps has no GH OIDC) |
 | `OVSX_PAT` | Open VSX | open-vsx.org token | no | no |
@@ -47,12 +47,11 @@ to rotate.
 Both crates.io and npm support **GitHub OIDC Trusted Publishing**
 (launched 2025). **crates.io is live on it:** the `publish-crates` job
 carries `id-token: write` and mints a short-lived token, so there is no
-`CARGO_REGISTRY_TOKEN` to rotate. **npm is deferred** to the
-`NPM_TOKEN` PAT: npmjs.com's UI to enable a trusted publisher is
-currently broken (the same blocker hit at v0.10.0), so the
-`publish-npm` job still uses `NODE_AUTH_TOKEN`. Revisit npm OIDC when
-that UI ships; it would eliminate the one token with a recurring
-expiry-failure history.
+`CARGO_REGISTRY_TOKEN` to rotate. **npm is now live on it too:** the
+`publish-npm` job carries `id-token: write` and publishes tokenlessly
+via Trusted Publishing, so the `NPM_TOKEN` PAT is retired. This
+eliminated the one token with a recurring expiry-failure history (it
+bit us again at v0.15.1, the trigger for the migration).
 
 - **crates.io:** configure a Trusted Publisher (crate Settings →
   Trusted Publishing: repo `asamarts/alint`, the release workflow file,
@@ -63,12 +62,12 @@ expiry-failure history.
 - **npm:** configure a Trusted Publisher on the package
   (npmjs.com → package → Settings → Trusted Publisher → GitHub Actions:
   `asamarts/alint` + workflow + optional environment). The
-  `publish-npm` job needs `permissions: id-token: write` and a recent
-  npm; `npm publish` then authenticates via OIDC (no `NODE_AUTH_TOKEN`)
-  and gets build provenance for free.
+  `publish-npm` job needs `permissions: id-token: write`, npm CLI
+  `>= 11.5.1`, and Node `>= 22.14`; `npm publish` then authenticates via
+  OIDC (no `NODE_AUTH_TOKEN`) and gets build provenance for free.
 
-crates.io is migrated, so `CARGO_REGISTRY_TOKEN` can be deleted.
-`NPM_TOKEN` stays in use until npm's trusted-publisher UI is fixed.
+crates.io and npm are both migrated, so `CARGO_REGISTRY_TOKEN` and
+`NPM_TOKEN` can both be deleted once each first OIDC release proves out.
 
 ## Per-channel setup runbook
 


### PR DESCRIPTION
Retires the `NPM_TOKEN` PAT on `publish-npm` in favour of **npm Trusted Publishing** (OIDC, GA 2025) — the same keyless model crates.io already uses. Implements the ADR-0015 decision to *"migrate npm to OIDC trusted publishing, retiring the `NPM_TOKEN` PAT."*

**Why now:** an expired `NPM_TOKEN` blocked the v0.15.1 npm publish (E404) — exactly the recurring failure mode this removes. It's the only release credential with an expiry-failure history.

## What changed (`publish-npm` job)
- `permissions: id-token: write` (+ `contents: read`) for the OIDC token
- Node `20 → 22`, `npm install -g npm@11.5.1` (Trusted Publishing needs npm ≥ 11.5.1 on Node ≥ 22.14)
- drop `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`
- `npm publish --access public --provenance`
- docs: `RELEASING.md` (new *npm Trusted Publishing* section + expiring-credentials reframe) and `release-credentials.md` (npm row + strategy narrative)

## ⚠️ Required before merging / next release
npm validates the Trusted Publisher config **only at publish time** (like the crates.io per-crate gap), so the next release's `publish-npm` job **fails** without this one-time setup:

> npmjs.com → **`@asamarts/alint`** → Settings → **Trusted Publisher** → GitHub Actions: repo `asamarts/alint`, workflow `release.yml`, no environment

*(The old `release-credentials.md` noted npm's trusted-publisher UI was broken at v0.10.0 — TP is GA now, but you'll confirm the UI works when you add this.)* Recovery if it's missing: add it, then `gh run rerun <id> --failed` — never re-tag.

## The tradeoff you chose (tokenless + shim provenance)
Trusted Publishing bundles tokenless auth **and** auto-provenance — you can't take one without the other. The provenance attests **only the download shim** (install script + bin shim), **not** the binaries it fetches from GitHub Releases (those keep their own build-provenance). When the optionalDependencies (P2) migration ships native bytes, the same provenance starts covering real payload. Comments say exactly this.

## Verification
- `actionlint` clean (only the 2 pre-existing `main` findings); `RELEASING.md` em-dash-free (dogfood)
- `NPM_TOKEN` refs swept: runbooks updated; ADR-0015 (decision record) + `distribution.md` MP-M2 left for the documented bulk `resolved-in` pass
- **E2E only provable on a real tag** (needs the Actions OIDC token) — first proof point is the next release after this + the npm-side config
- `NPM_TOKEN` secret can be deleted once that first OIDC release proves out

Queued for review — hold the merge until you've added the npm Trusted Publisher config, so the next release is clean.