### PR TITLE
docs(release): remove NPM_TOKEN wiring after the OIDC migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -645,9 +645,9 @@ jobs:
           #   VSCE_PAT — Azure DevOps PAT for the `asamarts` VS Code
           #              Marketplace publisher (Marketplace → Manage).
           #   OVSX_PAT — Open VSX access token (open-vsx.org → settings).
-          # Same mid-release-token-expiry risk as NPM_TOKEN: if either
-          # 401s, rotate it and `gh run rerun <id> --failed` — no new
-          # tag needed (the .vsix is idempotent per version).
+          # Expiring PATs (unlike the keyless crates.io / npm OIDC
+          # publishes): if either 401s, rotate it and `gh run rerun <id>
+          # --failed` — no new tag needed (the .vsix is idempotent per version).
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
           TAG: ${{ github.ref_name }}

--- a/docs/design/distribution.md
+++ b/docs/design/distribution.md
@@ -141,7 +141,7 @@ preflight ─▶ build (5-target matrix) ─▶ release ─▶ publish-npm
 | **install.sh** (`curl \| bash` via alint.org) | platform-detect → SHA-256 verified download → `$HOME/.local/bin` (prints a PATH hint if that dir is not on `PATH`, `install.sh:104-108`) | 4 (no Windows) | none |
 | **GitHub Action** `asamarts/alint@v0` | composite; fetches install.sh at the consumer's pinned ref with 3x retry; binary version derives from the action ref | 4 (no Windows) | none |
 | **crates.io** `cargo install alint` | source build; publishes 6 crates in dep order; **keyless OIDC** publishing | any Rust target | OIDC |
-| **npm** `@asamarts/alint` | **postinstall-download** wrapper (no native bytes in the tarball; `install.js` downloads + SHA-256-verifies at install time) | 5 (declares win-arm64 it can't serve) | `NPM_TOKEN` (PAT) |
+| **npm** `@asamarts/alint` | **postinstall-download** wrapper (no native bytes in the tarball; `install.js` downloads + SHA-256-verifies at install time); keyless OIDC publishing | 5 (declares win-arm64 it can't serve) | OIDC |
 | **Docker** `ghcr.io/asamarts/alint` | distroless-static, nonroot (UID 65532), re-extracts the *release* binaries so the image is byte-identical to the tarballs; OCI labels set in CI (`release.yml:313-317`); tags `:vX.Y.Z`/`:X.Y.Z`/`:X.Y`/`:latest` | linux amd64+arm64 | `GITHUB_TOKEN` |
 | **Homebrew tap** `asamarts/homebrew-alint` | formula regenerated from `SHA256SUMS` in CI (no rebuild), golden-tested in preflight, committed over SSH | macOS arm/intel + Linuxbrew x64/aarch64 | SSH deploy key |
 | **VS Code + Open VSX** | `vsce publish` + `ovsx publish`, version stamped from tag; real-client e2e in `editors-e2e.yml` | n/a | `VSCE_PAT`, `OVSX_PAT` |

--- a/docs/development/release-credentials.md
+++ b/docs/development/release-credentials.md
@@ -19,7 +19,7 @@ to rotate.
 
   ```sh
   # single-line token (prompts, or pipe from a password manager):
-  gh secret set NPM_TOKEN --repo asamarts/alint
+  gh secret set VSCE_PAT --repo asamarts/alint
 
   # multi-line value (SSH key, cert chain) from a file:
   gh secret set HOMEBREW_TAP_DEPLOY_KEY --repo asamarts/alint < deploy_key
@@ -33,7 +33,7 @@ to rotate.
 |---|---|---|---|---|
 | `GITHUB_TOKEN` | ghcr.io Docker | built-in | per-run | already keyless |
 | `CARGO_REGISTRY_TOKEN` | crates.io | crates.io account | manual | **yes → migrate to Trusted Publishing** |
-| `NPM_TOKEN` | npm (`@asamarts/alint`) | npmjs.com | retired | **migrated → Trusted Publishing (tokenless)** |
+| `NPM_TOKEN` *(deleted 2026-08-22)* | npm (`@asamarts/alint`) | n/a | n/a | **replaced by keyless OIDC Trusted Publishing** |
 | `HOMEBREW_TAP_DEPLOY_KEY` | `asamarts/homebrew-alint` | ssh-keygen + repo deploy key | no (SSH key) | n/a (use a GitHub App for org scale) |
 | `VSCE_PAT` | VS Code Marketplace | Azure DevOps PAT | **yes (max 1 yr)** | no (Azure DevOps has no GH OIDC) |
 | `OVSX_PAT` | Open VSX | open-vsx.org token | no | no |
@@ -66,8 +66,9 @@ bit us again at v0.15.1, the trigger for the migration).
   `>= 11.5.1`, and Node `>= 22.14`; `npm publish` then authenticates via
   OIDC (no `NODE_AUTH_TOKEN`) and gets build provenance for free.
 
-crates.io and npm are both migrated, so `CARGO_REGISTRY_TOKEN` and
-`NPM_TOKEN` can both be deleted once each first OIDC release proves out.
+crates.io and npm are both migrated. `NPM_TOKEN` was **deleted 2026-08-22**
+after v0.15.2 proved OIDC live end to end; `CARGO_REGISTRY_TOKEN` can be
+deleted once a crates.io release proves out the same way.
 
 ## Per-channel setup runbook
 
@@ -78,10 +79,10 @@ two that go keyless if you take the OIDC path).
 2. **crates.io** — keyless: add the Trusted Publisher (above). Token
    fallback: crates.io → Account Settings → API Tokens → new token
    scoped to publish; `gh secret set CARGO_REGISTRY_TOKEN`.
-3. **npm** — currently the token path (OIDC deferred, npmjs UI bug):
-   npmjs.com → Access Tokens → Granular, `@asamarts` scope, read+write
-   packages, set a calendar reminder for the expiry; `gh secret set
-   NPM_TOKEN`.
+3. **npm** — keyless via Trusted Publishing (OIDC), no secret. One-time:
+   npmjs.com → `@asamarts/alint` → Settings → Trusted Publisher → GitHub
+   Actions: repo `asamarts/alint`, workflow `release.yml`, no environment
+   (see the keyless section above).
 4. **Homebrew tap** — `ssh-keygen -t ed25519 -f tap_key -N ""`; add
    `tap_key.pub` as a **write** deploy key on `asamarts/homebrew-alint`;
    `gh secret set HOMEBREW_TAP_DEPLOY_KEY --repo asamarts/alint < tap_key`;
@@ -104,11 +105,11 @@ two that go keyless if you take the OIDC path).
 
 After the one-time setup, the only recurring human steps are:
 
-- **VS Code Azure DevOps PAT** and **`NPM_TOKEN`** rotation (the two
-  credentials with expiry; npm has no keyless path yet, VS Code never
-  will). Minimize: set the maximum expiry, add a calendar reminder, and
-  on a `401` rotate + `gh run rerun <id> --failed` (no new tag, the
-  artifacts are idempotent per version).
+- **VS Code Azure DevOps PAT** rotation (a 1-yr-max PAT with no keyless
+  path, now that npm went keyless via OIDC; the JetBrains signing cert
+  also expires, but is set long-lived). Minimize: set the maximum expiry,
+  add a calendar reminder, and on a `401` rotate + `gh run rerun <id>
+  --failed` (no new tag, the artifacts are idempotent per version).
 - **Zed extension version bump.** The Zed registry pins a version, so
   each release needs a one-line bump PR to `zed-industries/extensions`.
   This is the only per-release PR; it can be automated later with a


### PR DESCRIPTION
Follow-up to the npm OIDC migration (#193), now that it's **proven live on v0.15.2** (tokenless publish + SLSA provenance).

## The secret is deleted
`NPM_TOKEN` was removed from the repo's Actions secrets (2026-08-22). `secrets.NPM_TOKEN` had already been dropped from the workflow in #193, so **nothing active referenced it** — verified with `git grep 'secrets\.NPM_TOKEN'` (none) before deleting.

## This PR removes the residual wiring
- **`release-credentials.md`**: the npm per-channel runbook step is now *"keyless via Trusted Publishing, no secret"* (was the Granular-token path); the inventory row is marked **deleted 2026-08-22**; the rotation schedule drops `NPM_TOKEN` (VS Code's Azure DevOps PAT is the only expiring credential left); the single-line `gh secret set` example uses `VSCE_PAT`.
- **`release.yml`**: the VS Code / Open VSX env comment no longer draws its token-expiry analogy from the retired `NPM_TOKEN`.

## Left in place (correct current-state docs, not wiring)
`release.yml` / `RELEASING.md` / `ROADMAP.md` statements that npm is *tokenless / NPM_TOKEN retired*, and — per the documented bulk-`resolved-in` policy — ADR-0015 (the decision record) and `distribution.md`'s MP-M2 finding.

actionlint clean; queued for your review.