### PR TITLE
ci: gate workflow secrets against the release-credentials.md inventory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,19 @@ jobs:
           PUSH_BEFORE_SHA: ${{ github.event.before }}
         run: ci/scripts/detect-changes.sh
 
+  # Drift gate (trivial, <1s): the release-credentials.md secrets inventory must
+  # stay in sync with the secrets the workflows use -- every referenced secret is
+  # documented, and no deleted/retired secret is still wired in. Unconditional on
+  # ubuntu-latest (no toolchain or secrets needed; the check is cheaper than the
+  # change-filter machinery, and the invariant is global -- a workflow OR a doc
+  # edit can break it, so it must not be gated on the rust/docs flags).
+  secrets-inventory:
+    name: Secrets Inventory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - run: bash ci/scripts/check-secrets-inventory.sh
+
   # ── Rust pipeline ─────────────────────────────────────────────────
   fmt:
     name: Format
@@ -395,6 +408,7 @@ jobs:
     if: always()
     needs:
       - changes
+      - secrets-inventory
       - fmt
       - clippy
       - test
@@ -421,6 +435,7 @@ jobs:
           EXAMPLES_CHANGED: ${{ needs.changes.outputs.examples }}
           EDITORS_CHANGED: ${{ needs.changes.outputs.editors }}
           SUPPLY_CHAIN_CHANGED: ${{ needs.changes.outputs.supply_chain }}
+          SECRETS_INVENTORY_RESULT: ${{ needs.secrets-inventory.result }}
           FMT_RESULT: ${{ needs.fmt.result }}
           CLIPPY_RESULT: ${{ needs.clippy.result }}
           TEST_RESULT: ${{ needs.test.result }}

--- a/ci/scripts/check-secrets-inventory.sh
+++ b/ci/scripts/check-secrets-inventory.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Drift gate: keep docs/development/release-credentials.md's secrets inventory in
+# sync with the secrets the workflows actually use. Two assertions:
+#
+#   1. every `${{ secrets.X }}` referenced by a workflow has an inventory row --
+#      a new secret cannot ship undocumented (how to obtain + rotate it, whether
+#      it expires). GITHUB_TOKEN is built-in (never provisioned), so it is exempt.
+#
+#   2. no secret the inventory marks *deleted* or *retired* is still wired into a
+#      workflow -- the inverse of the NPM_TOKEN drift (PR #196): once a secret is
+#      retired in the doc, it must be gone from the workflows.
+#
+# A documented-but-unused ACTIVE secret is allowed on purpose (e.g. the crates.io
+# CARGO_REGISTRY_TOKEN token *fallback* the OIDC path replaces), so there is no
+# orphan assertion -- only (1) used-implies-documented and (2) retired-implies-unwired.
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+DOC="docs/development/release-credentials.md"
+
+if [ ! -f "$DOC" ]; then
+  echo "[secrets-inventory] FAIL: ${DOC} not found" >&2
+  exit 1
+fi
+
+# (1) Secrets referenced by a real workflow EXPRESSION (a `${{ ... secrets.NAME`
+# on a non-comment line), not a `secrets.X` placeholder in prose/comments.
+mapfile -t USED < <(
+  grep -rhnE '\$\{\{[^}]*secrets\.[A-Za-z_][A-Za-z0-9_]*' .github/workflows/ 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*#' \
+    | grep -oE 'secrets\.[A-Za-z_][A-Za-z0-9_]*' \
+    | sed 's/^secrets\.//' \
+    | grep -vx 'GITHUB_TOKEN' \
+    | sort -u
+)
+
+# Parse the "## Inventory" markdown table. A row's secret name(s) are the
+# `code`-spanned UPPER_SNAKE tokens in the FIRST column (one row may list several,
+# e.g. the JetBrains cert/key/password). A row is RETIRED if it says "deleted" or
+# "retired" anywhere.
+inv_table="$(awk '/^## Inventory/{f=1;next} f && /^## /{f=0} f' "$DOC")"
+declare -A DOCUMENTED RETIRED
+while IFS= read -r row; do
+  [[ "$row" == \|* ]] || continue                     # markdown table rows only
+  col1="${row#|}"; col1="${col1%%|*}"                 # first data column
+  # shellcheck disable=SC2016  # the backticks are literal grep-pattern chars, not command substitution
+  names="$(printf '%s' "$col1" | grep -oE '`[A-Z][A-Z0-9_]*`' | tr -d '`' || true)"
+  [[ -n "$names" ]] || continue                       # header / separator rows
+  is_retired=0
+  printf '%s' "$row" | grep -qiE 'deleted|retired' && is_retired=1
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    DOCUMENTED["$name"]=1
+    [[ "$is_retired" -eq 1 ]] && RETIRED["$name"]=1
+  done <<< "$names"
+done <<< "$inv_table"
+
+if [ "${#DOCUMENTED[@]}" -eq 0 ]; then
+  echo "[secrets-inventory] FAIL: parsed no secrets from ${DOC} '## Inventory' table" >&2
+  exit 1
+fi
+
+rc=0
+
+# Assertion 1: every used secret is documented.
+for s in "${USED[@]:-}"; do
+  [[ -n "$s" ]] || continue
+  if [[ -z "${DOCUMENTED[$s]:-}" ]]; then
+    echo "[secrets-inventory] FAIL: a workflow references secrets.${s}, but it has no row in ${DOC} '## Inventory' (add how to obtain + rotate it)." >&2
+    rc=1
+  fi
+done
+
+# Assertion 2: no retired/deleted secret is still wired into a workflow.
+for s in "${!RETIRED[@]}"; do
+  if printf '%s\n' "${USED[@]:-}" | grep -qx "$s"; then
+    echo "[secrets-inventory] FAIL: ${s} is marked deleted/retired in ${DOC}, but a workflow still references secrets.${s} (remove the wiring or un-retire the row)." >&2
+    rc=1
+  fi
+done
+
+if [ "$rc" -eq 0 ]; then
+  echo "[secrets-inventory] OK -- ${#USED[@]} workflow secret(s) all documented; ${#RETIRED[@]} retired secret(s) unwired."
+fi
+exit "$rc"

--- a/ci/scripts/check-secrets-inventory.sh
+++ b/ci/scripts/check-secrets-inventory.sh
@@ -18,7 +18,10 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$REPO_ROOT"
-DOC="docs/development/release-credentials.md"
+# Paths are overridable so ci/scripts/test-check-secrets-inventory.sh can aim the
+# gate at fixtures instead of the live repo (absolute paths survive the cd above).
+DOC="${SECRETS_DOC:-docs/development/release-credentials.md}"
+WF_DIR="${SECRETS_WORKFLOWS_DIR:-.github/workflows}"
 
 if [ ! -f "$DOC" ]; then
   echo "[secrets-inventory] FAIL: ${DOC} not found" >&2
@@ -26,22 +29,27 @@ if [ ! -f "$DOC" ]; then
 fi
 
 # (1) Secrets referenced by a real workflow EXPRESSION (a `${{ ... secrets.NAME`
-# on a non-comment line), not a `secrets.X` placeholder in prose/comments.
+# on a non-comment line), in either `secrets.NAME` or `secrets['NAME']` form -- not
+# a `secrets.X` placeholder in a full-line comment. The first grep finds candidate
+# lines; the `-o` grep extracts both syntaxes precisely; sed strips to the name.
 mapfile -t USED < <(
-  grep -rhnE '\$\{\{[^}]*secrets\.[A-Za-z_][A-Za-z0-9_]*' .github/workflows/ 2>/dev/null \
+  grep -rhnE '\$\{\{[^}]*secrets(\.|\[)' "$WF_DIR" 2>/dev/null \
     | grep -vE '^[0-9]+:[[:space:]]*#' \
-    | grep -oE 'secrets\.[A-Za-z_][A-Za-z0-9_]*' \
-    | sed 's/^secrets\.//' \
+    | grep -oE "secrets\.[A-Za-z_][A-Za-z0-9_]*|secrets\[['\"][A-Za-z_][A-Za-z0-9_]*['\"]\]" \
+    | sed -E "s/^secrets\.//; s/^secrets\[['\"]//; s/['\"]\]$//" \
     | grep -vx 'GITHUB_TOKEN' \
     | sort -u
 )
 
 # Parse the "## Inventory" markdown table. A row's secret name(s) are the
 # `code`-spanned UPPER_SNAKE tokens in the FIRST column (one row may list several,
-# e.g. the JetBrains cert/key/password). A row is RETIRED if it says "deleted" or
-# "retired" anywhere.
+# e.g. the JetBrains cert/key/password). A row is RETIRED if its FIRST column
+# (where the `*(deleted YYYY-MM-DD)*` marker lives) says deleted/retired/removed/
+# revoked -- scoped to col1 so descriptive prose in a later column (e.g. "replaces
+# the retired PAT flow") can't misflag an ACTIVE secret. Init the arrays empty so
+# `${#RETIRED[@]}` is safe under `set -u` when nothing is retired.
 inv_table="$(awk '/^## Inventory/{f=1;next} f && /^## /{f=0} f' "$DOC")"
-declare -A DOCUMENTED RETIRED
+declare -A DOCUMENTED=() RETIRED=()
 while IFS= read -r row; do
   [[ "$row" == \|* ]] || continue                     # markdown table rows only
   col1="${row#|}"; col1="${col1%%|*}"                 # first data column
@@ -49,7 +57,7 @@ while IFS= read -r row; do
   names="$(printf '%s' "$col1" | grep -oE '`[A-Z][A-Z0-9_]*`' | tr -d '`' || true)"
   [[ -n "$names" ]] || continue                       # header / separator rows
   is_retired=0
-  printf '%s' "$row" | grep -qiE 'deleted|retired' && is_retired=1
+  printf '%s' "$col1" | grep -qiE 'deleted|retired|removed|revoked' && is_retired=1
   while IFS= read -r name; do
     [[ -n "$name" ]] || continue
     DOCUMENTED["$name"]=1
@@ -74,8 +82,9 @@ for s in "${USED[@]:-}"; do
 done
 
 # Assertion 2: no retired/deleted secret is still wired into a workflow.
+# `RETIRED=()` above makes "${!RETIRED[@]}" safe under `set -u` when empty.
 for s in "${!RETIRED[@]}"; do
-  if printf '%s\n' "${USED[@]:-}" | grep -qx "$s"; then
+  if printf '%s\n' "${USED[@]:-}" | grep -Fqx "$s"; then
     echo "[secrets-inventory] FAIL: ${s} is marked deleted/retired in ${DOC}, but a workflow still references secrets.${s} (remove the wiring or un-retire the row)." >&2
     rc=1
   fi

--- a/ci/scripts/preflight.sh
+++ b/ci/scripts/preflight.sh
@@ -74,6 +74,7 @@ run test          bash ci/scripts/test.sh                         || true
 run doc           bash ci/scripts/docs.sh                         || true
 run version-pins  bash ci/scripts/check-version-pins.sh           || true
 run dep-floors    bash ci/scripts/check-workspace-dep-floors.sh   || true
+run secrets-inv   bash ci/scripts/check-secrets-inventory.sh      || true
 run dogfood       bash ci/scripts/dogfood.sh                      || true
 
 if [[ "$failed" -ne 0 ]]; then

--- a/ci/scripts/summary.sh
+++ b/ci/scripts/summary.sh
@@ -69,6 +69,7 @@ row() {
   row "Docs"         "$DOCS_JOB_RESULT"    "$RUST_CHANGED"
   row "Dogfood"      "$DOGFOOD_RESULT"     "$RUST_CHANGED"
   row "Shell tests"  "$SHELL_TESTS_RESULT" "$RUST_CHANGED"
+  row "Secrets inventory" "$SECRETS_INVENTORY_RESULT" "true"
   echo ""
 
   echo "### Bench Pipeline"
@@ -94,6 +95,7 @@ row() {
 
 FAILED=false
 for result in \
+  "$SECRETS_INVENTORY_RESULT" \
   "$FMT_RESULT" "$CLIPPY_RESULT" "$TEST_RESULT" "$AUDIT_RESULT" \
   "$DENY_RESULT" "$SUPPLY_CHAIN_RESULT" "$BUILD_RESULT" "$DOCS_JOB_RESULT" \
   "$DOGFOOD_RESULT" "$BENCH_SMOKE_RESULT" "$EXAMPLES_RESULT" \

--- a/ci/scripts/test-check-secrets-inventory.sh
+++ b/ci/scripts/test-check-secrets-inventory.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Test harness for ci/scripts/check-secrets-inventory.sh -- the secrets-inventory
+# drift gate. Drives the gate against fixtures (via its SECRETS_DOC /
+# SECRETS_WORKFLOWS_DIR overrides) to lock in each assertion AND the edge cases an
+# adversarial audit surfaced, so a regression in the gate is caught here, not by a
+# spuriously red release or a drift that slips through:
+#   - empty RETIRED array must not crash the success path under `set -u`
+#   - `secrets['NAME']` bracket syntax must be seen by both assertions (fail-open)
+#   - the retired marker is scoped to column 1, so prose elsewhere can't misflag an
+#     active secret (fail-closed)
+#
+# shellcheck disable=SC2016  # the `${{ secrets.X }}` fixtures are literal by design
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+GATE="$REPO_ROOT/ci/scripts/check-secrets-inventory.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+pass=0
+fail=0
+
+# run_case <name> <ok|fail> <doc-body> <workflow-body>
+run_case() {
+  local name="$1" expect="$2" doc="$3" wf="$4"
+  local d
+  d="$(mktemp -d "$tmp/case.XXXXXX")"
+  mkdir -p "$d/wf"
+  printf '%s\n' "$doc" > "$d/doc.md"
+  printf '%s\n' "$wf" > "$d/wf/w.yml"
+  local rc=0
+  SECRETS_DOC="$d/doc.md" SECRETS_WORKFLOWS_DIR="$d/wf" \
+    bash "$GATE" >/dev/null 2>&1 || rc=$?
+  local got=ok
+  [ "$rc" -eq 0 ] || got=fail
+  if [ "$got" = "$expect" ]; then
+    echo "  ok: $name (expected $expect)"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $name -- expected $expect, got $got (rc=$rc)" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+# Shared valid table header; each case appends its own rows + a closing section.
+HDR='## Inventory
+
+| Secret | Channel | Note |
+|---|---|---|
+| `GITHUB_TOKEN` | ghcr | built-in |'
+
+# A [HIGH regression]: in-sync inventory with NOTHING retired -> PASS. Without the
+# `declare -A RETIRED=()` init this crashes on `${#RETIRED[@]}` under `set -u`.
+run_case "in-sync, nothing retired" ok \
+"$HDR
+| \`CARGO_REGISTRY_TOKEN\` | crates.io | active |
+## Next" \
+'jobs: {a: {steps: [{run: "echo ${{ secrets.CARGO_REGISTRY_TOKEN }}"}]}}'
+
+# B: used-but-undocumented -> FAIL (assertion 1).
+run_case "undocumented secret" fail \
+"$HDR
+## Next" \
+'jobs: {a: {steps: [{run: "echo ${{ secrets.MYSTERY_TOKEN }}"}]}}'
+
+# C: retired secret still wired -> FAIL (assertion 2).
+run_case "retired still wired" fail \
+"$HDR
+| \`OLD_TOK\` *(deleted 2026-01-01)* | npm | gone |
+## Next" \
+'jobs: {a: {steps: [{run: "echo ${{ secrets.OLD_TOK }}"}]}}'
+
+# D [bracket regression]: undocumented via secrets['NAME'] -> FAIL (was fail-open).
+run_case "undocumented bracket syntax" fail \
+"$HDR
+## Next" \
+"jobs: {a: {steps: [{run: \"echo \${{ secrets['BRACKET_MYSTERY'] }}\"}]}}"
+
+# E [retired-scope regression]: active secret whose LATER column mentions 'retired'
+# must NOT be misflagged -> PASS (was fail-closed on whole-row scan).
+run_case "active secret, 'retired' prose in col3" ok \
+"$HDR
+| \`ACTIVE_TOK\` | npm | replaces the retired PAT flow |
+## Next" \
+'jobs: {a: {steps: [{run: "echo ${{ secrets.ACTIVE_TOK }}"}]}}'
+
+# F: documented-but-unused ACTIVE secret is allowed -> PASS (no orphan assertion).
+run_case "documented-but-unused active" ok \
+"$HDR
+| \`UNUSED_TOK\` | crates.io | fallback |
+## Next" \
+'jobs: {a: {steps: [{run: "echo hi"}]}}'
+
+# G: GITHUB_TOKEN is built-in, exempt from assertion 1 -> PASS.
+run_case "GITHUB_TOKEN exempt" ok \
+"$HDR
+## Next" \
+'jobs: {a: {steps: [{run: "echo ${{ secrets.GITHUB_TOKEN }}"}]}}'
+
+# H [bracket + retired]: retired secret re-wired via bracket syntax -> FAIL.
+run_case "retired re-wired via bracket" fail \
+"$HDR
+| \`OLD_TOK\` *(deleted 2026-01-01)* | npm | gone |
+## Next" \
+"jobs: {a: {steps: [{run: \"echo \${{ secrets['OLD_TOK'] }}\"}]}}"
+
+echo "[test-check-secrets-inventory] ${pass} passed, ${fail} failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
The drift-gate follow-up flagged in #196's review. There was no automated check keeping the secrets inventory in sync with what the workflows actually use — which is exactly why the **NPM_TOKEN drift** (documented as active long after #193 stopped using it) survived until a manual review caught it.

## The gate — `ci/scripts/check-secrets-inventory.sh`
Two assertions:
1. **used ⊆ documented** — every `${{ secrets.X }}` a workflow references has an inventory row (a new secret can't ship undocumented: how to obtain + rotate it, whether it expires). `GITHUB_TOKEN` is built-in → exempt.
2. **retired ⊄ used** — no secret the inventory marks *deleted/retired* is still wired into a workflow (the direct inverse of the NPM_TOKEN mistake).

A documented-but-unused **active** secret is allowed on purpose (the crates.io `CARGO_REGISTRY_TOKEN` token *fallback* that OIDC replaces), so there's deliberately no orphan assertion.

## Wiring (two places)
- **`preflight.sh`** (pre-push) — alongside the sibling `check-version-pins` / `check-workspace-dep-floors` gates.
- A dedicated **`secrets-inventory` ci.yml job** (ubuntu-latest, **unconditional** — the check is <1s and the invariant is global, so it must catch doc-only edits too, not just rust/workflow changes), **integrated into the `summary` aggregate gate** (needs + result env + report row + fail-loop) so a drift **fails CI**, not just the bypassable pre-push hook.

## Tested
- **Passes on current `main`**: 9 workflow secrets all documented; NPM_TOKEN retired + unwired.
- **Fails** on (a) a workflow using an undocumented secret, and (b) re-wiring a retired secret — both verified with temp workflow files.
- `summary.sh` exits 1 when the gate result is `failure`, 0 otherwise (verified).
- actionlint clean; all three touched scripts shellcheck-clean.