### PR TITLE
fix(ci): trust the tap in the homebrew smoke + add a pre-merge macOS install gate

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -19,6 +19,10 @@ concurrency:
   group: cross-platform-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: both jobs only check out and read the public releases API.
+permissions:
+  contents: read
+
 env:
   # Mirrored verbatim across ci.yml / coverage.yml / release.yml /
   # cross-platform.yml — keep identical (see ci.yml for rationale).
@@ -70,18 +74,25 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: brew install the latest published alint via the tap
+      # Resolve the tag in its OWN step so GH_TOKEN never shares an environment with
+      # the reused smoke script (fork-PR least-exposure; the token is read-only on
+      # forks anyway, but the install step has no business seeing it).
+      - name: Resolve the latest published release tag
+        id: rel
         env:
-          SMOKE_FLOATING: "1"                    # tag == latest, so the leg runs (not skips)
           GH_TOKEN: ${{ github.token }}          # authenticate the releases API call (rate limit)
         run: |
           set -euo pipefail
-          # Capture curl separately: piping it straight into `grep -m1` lets grep
-          # close the pipe early, so curl exits 23 (write error) and pipefail aborts
-          # before we ever reach the install.
+          # Capture curl separately: piping it straight into a truncating filter lets
+          # that filter close the pipe early, so curl exits 23 (write error) and
+          # pipefail aborts before we resolve the tag.
           resp="$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest")"
           tag="$(printf '%s\n' "$resp" | sed -nE 's/.*"tag_name": *"([^"]+)".*/\1/p' | head -1)"
           echo "==> latest published release: ${tag}"
           [ -n "${tag}" ] || { echo "could not resolve the latest release tag" >&2; exit 1; }
-          ci/scripts/smoke-channel.sh homebrew "${tag}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+      - name: brew install the latest published alint via the tap
+        env:
+          SMOKE_FLOATING: "1"                    # tag == latest, so the leg runs (not skips)
+        run: ci/scripts/smoke-channel.sh homebrew "${{ steps.rel.outputs.tag }}"

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -19,10 +19,6 @@ concurrency:
   group: cross-platform-${{ github.ref }}
   cancel-in-progress: true
 
-# Least privilege: both jobs only check out and read the public releases API.
-permissions:
-  contents: read
-
 env:
   # Mirrored verbatim across ci.yml / coverage.yml / release.yml /
   # cross-platform.yml — keep identical (see ci.yml for rationale).
@@ -60,39 +56,3 @@ jobs:
 
       - name: cargo test
         run: cargo test --workspace --locked
-
-  # Pre-merge counterpart to the post-publish-smoke homebrew leg: brew-install the
-  # LATEST published alint from the tap on a fresh macOS runner, so an install-path
-  # regression (e.g. Homebrew 6.x's tap-trust gate -- the v0.15.1/v0.15.2 blocker)
-  # is caught HERE, before a release, not after. Reuses ci/scripts/smoke-channel.sh
-  # so the pre- and post-release paths can't drift. A new formula's tarball only
-  # exists post-tag, so this validates the install MECHANICS against the current
-  # release, not the PR's version (the actual new-version install stays the job of
-  # post-publish-smoke). GitHub-hosted macOS (free on this public repo; no VM).
-  homebrew-install:
-    name: Homebrew install (macOS)
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      # Resolve the tag in its OWN step so GH_TOKEN never shares an environment with
-      # the reused smoke script (fork-PR least-exposure; the token is read-only on
-      # forks anyway, but the install step has no business seeing it).
-      - name: Resolve the latest published release tag
-        id: rel
-        env:
-          GH_TOKEN: ${{ github.token }}          # authenticate the releases API call (rate limit)
-        run: |
-          set -euo pipefail
-          # Capture curl separately: piping it straight into a truncating filter lets
-          # that filter close the pipe early, so curl exits 23 (write error) and
-          # pipefail aborts before we resolve the tag.
-          resp="$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest")"
-          tag="$(printf '%s\n' "$resp" | sed -nE 's/.*"tag_name": *"([^"]+)".*/\1/p' | head -1)"
-          echo "==> latest published release: ${tag}"
-          [ -n "${tag}" ] || { echo "could not resolve the latest release tag" >&2; exit 1; }
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-      - name: brew install the latest published alint via the tap
-        env:
-          SMOKE_FLOATING: "1"                    # tag == latest, so the leg runs (not skips)
-        run: ci/scripts/smoke-channel.sh homebrew "${{ steps.rel.outputs.tag }}"

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -56,3 +56,32 @@ jobs:
 
       - name: cargo test
         run: cargo test --workspace --locked
+
+  # Pre-merge counterpart to the post-publish-smoke homebrew leg: brew-install the
+  # LATEST published alint from the tap on a fresh macOS runner, so an install-path
+  # regression (e.g. Homebrew 6.x's tap-trust gate -- the v0.15.1/v0.15.2 blocker)
+  # is caught HERE, before a release, not after. Reuses ci/scripts/smoke-channel.sh
+  # so the pre- and post-release paths can't drift. A new formula's tarball only
+  # exists post-tag, so this validates the install MECHANICS against the current
+  # release, not the PR's version (the actual new-version install stays the job of
+  # post-publish-smoke). GitHub-hosted macOS (free on this public repo; no VM).
+  homebrew-install:
+    name: Homebrew install (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: brew install the latest published alint via the tap
+        env:
+          SMOKE_FLOATING: "1"                    # tag == latest, so the leg runs (not skips)
+          GH_TOKEN: ${{ github.token }}          # authenticate the releases API call (rate limit)
+        run: |
+          set -euo pipefail
+          # Capture curl separately: piping it straight into `grep -m1` lets grep
+          # close the pipe early, so curl exits 23 (write error) and pipefail aborts
+          # before we ever reach the install.
+          resp="$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest")"
+          tag="$(printf '%s\n' "$resp" | sed -nE 's/.*"tag_name": *"([^"]+)".*/\1/p' | head -1)"
+          echo "==> latest published release: ${tag}"
+          [ -n "${tag}" ] || { echo "could not resolve the latest release tag" >&2; exit 1; }
+          ci/scripts/smoke-channel.sh homebrew "${tag}"

--- a/.github/workflows/homebrew-smoke.yml
+++ b/.github/workflows/homebrew-smoke.yml
@@ -1,0 +1,60 @@
+name: Homebrew Smoke
+
+# Pre-merge + canary check that the LATEST published alint still `brew install`s
+# from the tap on a fresh macOS runner -- so an install-path regression (e.g.
+# Homebrew 6.x's tap-trust gate, the v0.15.1/v0.15.2 blocker) is caught before a
+# release, not after. It installs the latest RELEASE (a new formula's tarball only
+# exists post-tag), so it validates the install MECHANICS -- the actual new-version
+# install stays post-publish-smoke's job. Reuses ci/scripts/smoke-channel.sh so the
+# pre- and post-release paths can't drift.
+#
+# Scope: on PRs it runs ONLY when the install mechanics change (smoke-channel.sh or
+# this workflow). Because it tests the latest RELEASE -- orthogonal to an unrelated
+# PR's code -- gating every PR on it would couple them to post-release tap-sync
+# state. A daily schedule keeps it a standing canary; workflow_dispatch is on-demand.
+# GitHub-hosted macOS (free on this public repo; no VM).
+on:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - ci/scripts/smoke-channel.sh
+      - .github/workflows/homebrew-smoke.yml
+  schedule:
+    - cron: "0 7 * * *"          # daily tap canary (fires on the default branch)
+  workflow_dispatch:
+
+concurrency:
+  group: homebrew-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  homebrew-install:
+    name: Homebrew install (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # Resolve the tag in its OWN step so GH_TOKEN never shares an environment with
+      # the reused smoke script (fork-PR least-exposure; the token is read-only on
+      # forks anyway, but the install step has no business seeing it).
+      - name: Resolve the latest published release tag
+        id: rel
+        env:
+          GH_TOKEN: ${{ github.token }}          # authenticate the releases API call (rate limit)
+        run: |
+          set -euo pipefail
+          # Capture curl separately: piping it straight into a truncating filter lets
+          # that filter close the pipe early, so curl exits 23 (write error) and
+          # pipefail aborts before we resolve the tag.
+          resp="$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest")"
+          tag="$(printf '%s\n' "$resp" | sed -nE 's/.*"tag_name": *"([^"]+)".*/\1/p' | head -1)"
+          echo "==> latest published release: ${tag}"
+          [ -n "${tag}" ] || { echo "could not resolve the latest release tag" >&2; exit 1; }
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+      - name: brew install the latest published alint via the tap
+        env:
+          SMOKE_FLOATING: "1"                    # tag == latest, so the leg runs (not skips)
+        run: ci/scripts/smoke-channel.sh homebrew "${{ steps.rel.outputs.tag }}"

--- a/ci/scripts/smoke-channel.sh
+++ b/ci/scripts/smoke-channel.sh
@@ -108,20 +108,18 @@ case "$CHANNEL" in
       echo "  [smoke] homebrew: skipped (smoked tag ${TAG} is not the latest release)"
       exit 0
     fi
-    # Homebrew refuses formulae from third-party taps it deems "untrusted" in
-    # non-interactive CI. v0.15.1's smoke hit exactly this -- "Refusing to load
-    # formula asamarts/alint/alint from untrusted tap asamarts/alint" -- and the
-    # `brew install` never landed alint, so the later `alint --version` was
-    # command-not-found (exit 127). The leg already taps; the gate is trust, not
-    # order. Cover the two documented gates: read the formula from the local tap
-    # clone (NO_INSTALL_FROM_API), and add our tap to the allowlist IF the runner
-    # set one (leaving it unset when it was unset, so we don't turn on an
-    # allowlist that would then forbid alint's own deps). The diagnostic line
-    # prints brew's version + the allowlist so a still-red run pinpoints the gate.
+    # Homebrew 6.x refuses formulae from an "untrusted" third-party tap in
+    # non-interactive CI ("Refusing to load formula asamarts/alint/alint from
+    # untrusted tap asamarts/alint"; the `brew install` never lands alint, so the
+    # later `alint --version` is command-not-found -> exit 127). The gate is TAP
+    # TRUST -- v0.15.2's env-var attempt (NO_INSTALL_FROM_API + an allowlist) did
+    # NOT clear it, because trust is a separate mechanism with no env override.
+    # `brew trust --tap` records the tap in ~/.homebrew/trust.json so the install
+    # is allowed; NO_INSTALL_FROM_API keeps brew reading from the tapped clone.
     export HOMEBREW_NO_INSTALL_FROM_API=1
-    [ -n "${HOMEBREW_ALLOWED_TAPS:-}" ] && export HOMEBREW_ALLOWED_TAPS="${HOMEBREW_ALLOWED_TAPS} asamarts/alint"
     brew tap asamarts/alint 2>/dev/null || true
-    echo "  [smoke] brew=$(brew --version 2>/dev/null | head -1) HOMEBREW_ALLOWED_TAPS='${HOMEBREW_ALLOWED_TAPS:-<unset>}'"
+    brew trust --tap asamarts/alint || echo "  [smoke] note: 'brew trust --tap' failed/absent on $(brew --version 2>/dev/null | head -1)"
+    echo "  [smoke] brew=$(brew --version 2>/dev/null | head -1)"
     hb_n=1
     while true; do
       brew update >/dev/null 2>&1 || true

--- a/ci/scripts/smoke-channel.sh
+++ b/ci/scripts/smoke-channel.sh
@@ -124,7 +124,11 @@ case "$CHANNEL" in
     while true; do
       brew update >/dev/null 2>&1 || true
       brew reinstall alint >/dev/null 2>&1 || brew install alint || true
-      hb_got="$(alint --version 2>&1 | awk '/^alint [0-9]/ { print $2; exit }')"
+      # `|| true`: when the install did not land (transient bottle blip, a tap still
+      # catching up, trust not cleared), `alint` exits 127 and pipefail would abort
+      # the whole script HERE -- killing the very retry loop this lives in. Swallow
+      # it so an empty hb_got falls through to the retry / graceful-FAIL logic below.
+      hb_got="$(alint --version 2>&1 | awk '/^alint [0-9]/ { print $2; exit }')" || true
       [ "$hb_got" = "$VER" ] && break
       if [ "$hb_n" -ge "$RETRY_MAX" ]; then
         echo "  [smoke] FAIL: homebrew serves '${hb_got:-<none>}', expected '${VER}' after ${RETRY_MAX} attempts" >&2


### PR DESCRIPTION
Fixes the homebrew install path (#157) and adds a **scoped, self-validating macOS install gate**.

## The #157 fix
The post-publish-smoke homebrew leg failed on v0.15.1 **and** v0.15.2 with `Refusing to load formula … from untrusted tap` (exit 127). Root cause proven via the v0.15.2 diagnostic: **Homebrew 6.x's tap-trust gate** (no env-var override). Fix: `brew trust --tap asamarts/alint` in `ci/scripts/smoke-channel.sh` (proven live — the gate's own macOS run installs v0.15.2 cleanly).

## The gate — `homebrew-smoke.yml` (scoped per review)
A dedicated workflow that `brew install`s the latest published alint via the tap on a fresh `macos-latest` runner, reusing `smoke-channel.sh` so pre-/post-release paths can't drift. It installs the latest *release* (a new formula's tarball only exists post-tag), so it validates install **mechanics**; the new-version install stays post-publish-smoke's job. Triggers:
- **PRs** — only when the install mechanics change (`ci/scripts/smoke-channel.sh` or this workflow), so a #157-class regression is caught pre-merge on exactly the PRs that could introduce it, **without** coupling unrelated PRs to post-release tap-sync state.
- **Daily schedule** — a standing canary for tap drift between releases.
- **workflow_dispatch** — on demand.

## Audit hardening (this PR was adversarially re-audited)
- `smoke-channel.sh` retry loop: fixed a `set -e`+pipefail abort (`hb_got="$(…)"` → append `|| true`) that made the retry loop dead code when an install didn't land — so a transient blip now retries instead of instantly reddening.
- Workflow-level `permissions: contents: read`; `GH_TOKEN` split into its own tag-resolve step so the reused (fork-authored) smoke script runs tokenless.

**Self-validating:** this PR changes `smoke-channel.sh`, so its own **Homebrew install (macOS)** run exercises the fixed path against the live tap — a green run here is the proof.