### PR TITLE
docs(site): remove four low-value diagrams from the docs pages

### DIFF
--- a/docs/site/concepts/content-from.md
+++ b/docs/site/concepts/content-from.md
@@ -7,10 +7,6 @@ sidebar:
 
 The three content-providing fix ops — `file_create`, `file_prepend`, `file_append` — accept a `content_from: <path>` field as an alternative to inline `content:`. The path resolves relative to the lint root and is read when `alint fix` actually runs, so the source file's bytes flow into the target without round-tripping through YAML.
 
-Where `content_from:` is read during `alint fix`:
-
-<likec4-view view-id="fixFlow"></likec4-view>
-
 ## When to reach for it
 
 LICENSE / NOTICE / CONTRIBUTING / SPDX boilerplate is awkward to inline. A real Apache-2 LICENSE is ~10 KB; pasting it into YAML quotes is fragile (escape rules, indentation drift, code-search hits in the wrong column). Stash the canonical bytes under `.alint/templates/`, point `content_from:` at it:

--- a/docs/site/concepts/index.md
+++ b/docs/site/concepts/index.md
@@ -7,8 +7,6 @@ sidebar:
 
 The Concepts section is the conceptual foundation that the rest of the docs assume. Skim it once; come back when something downstream confuses you.
 
-<likec4-view view-id="catalogueOverview"></likec4-view>
-
 ## What alint is
 
 alint is a static Rust binary that lints the *shape* of a repository. Where ESLint lints code and Semgrep lints semantics, alint lints the things in between — required files (READMEs, LICENSEs, SECURITY.md), filename conventions, content patterns, the values inside `package.json` / `Cargo.toml` / GitHub workflows, and cross-file relationships like "every package has a README" or "every header has a matching source file."

--- a/docs/site/getting-started/installation.md
+++ b/docs/site/getting-started/installation.md
@@ -7,8 +7,6 @@ sidebar:
 
 alint ships as a single native executable with no language runtime, no JVM, and nothing else to install. Pick whichever path matches your environment.
 
-<likec4-view view-id="distributionFlow"></likec4-view>
-
 ## Homebrew (macOS + Linuxbrew)
 
 ```bash

--- a/xtask/src/docs_export.rs
+++ b/xtask/src/docs_export.rs
@@ -1524,7 +1524,6 @@ fn emit_rules_master_index(
 /// The architecture view embedded atop a generated concept page, if any.
 pub(crate) fn concept_view_id(slug: &str) -> Option<&'static str> {
     match slug {
-        "fix-operations" => Some("fixFlow"),
         "nested-configs" => Some("monorepoNesting"),
         _ => None,
     }


### PR DESCRIPTION
Removes four LikeC4 diagram embeds that add no clear value or sit in the wrong context. You flagged the concepts-page rule-catalogue diagram; an audit of every diagram across the docs surfaced three more of the same character. Everything else — flow diagrams a page introduces and walks through, plus the two Architecture pages (diagram galleries by design) — stays.

## Removed
| Page | Diagram | Why |
|------|---------|-----|
| **concepts/** | `catalogueOverview` (flagged) | Static rule-family taxonomy above the concepts intro — off-topic + space-hungry. |
| **concepts/fix-operations** | `fixFlow` | Page catalogues the 12 fix *ops*; the diagram is the fix *pipeline* — wrong subject. |
| **concepts/content-from** | `fixFlow` (3rd reuse) | Intro promised "where content_from is read"; the generic flow doesn't show it. |
| **getting-started/installation** | `distributionFlow` | Release-architecture diagram on a task page where readers want commands. |

## Mechanism
- **content-from / installation / concepts index** are authored in `docs/site/` (copied verbatim by `docs-export`) — plain markdown edits, incl. content-from's orphaned lead-in.
- **fix-operations** is a *generated* concept page, so its diagram is dropped from `docs_export`'s `concept_view_id` map.

All four views stay defined and referenced by `about/architecture-diagrams.md`, so no model view is orphaned. `fmt`/`clippy` clean; `xtask` docs_export unit tests pass; the `docs-export --check` CI gate re-validates the bundle.