### PR TITLE
docs(design): prototype build plan for animated docs diagrams (engine + diagrams + dev-only QA)

### DIFF
--- a/docs/design/animated-diagrams-prototype.md
+++ b/docs/design/animated-diagrams-prototype.md
@@ -1,387 +1,324 @@
-# Design doc: animated-diagram prototype (engine + diagrams + dev-only QA)
+# Design doc: animated-diagram engine + diagrams (spike-gated, dev-only QA)
 
-Status: Draft (prototype build plan). Not implemented. Revised after an adversarial
-audit (two independent auditors + codebase verification); the corrections are folded in
-below and noted where they changed a prior claim.
+Status: Draft (build plan). Not implemented. Revised across two adversarial audit
+rounds (independent auditors + codebase verification); corrections are folded in and
+noted where they changed a prior claim.
 Decisions: builds on `animated-diagrams.md` (the interactive "Tier 3" track) and
-ADR-0005 (adopt LikeC4). If the prototype validates and graduates, record the
-production decision as ADR-0016. No engine/DSL/schema change to alint itself; all code
-lands in the alint.org site repo.
+ADR-0005. If it graduates, record the production decision as ADR-0016. No engine/DSL/
+schema change to alint itself; all code lands in the alint.org site repo.
 
-## 1. Context
+## 1. Context and honest framing
 
-`animated-diagrams.md` proposed adding Cursor-style animated diagrams to the docs and
-recommended a three-tier track. This is the build plan for a **prototype/MVP** that
-validates the most interactive tier: a reusable rendering engine plus a few real,
-educational animated diagrams, embedded on `/docs/about/architecture/` in **dev/local
-only** (never live) for hands-on QA. The point is to prove the look/feel and the
-authoring model before any production or live-docs commitment.
+`animated-diagrams.md` proposed Cursor-style animated docs diagrams and recommended a
+three-tier track. This plans the interactive tier as a **reusable animated-diagram
+engine + a few diagrams**, embedded on `/docs/about/architecture/` in **dev/local only**
+(never live) for QA.
 
-Two facts from exploring both repos shape everything (all verified against the code):
+Two framing corrections from the audit, stated up front because they reshape the plan:
 
-- alint.org is Astro + Starlight with **no framework islands** (no React/Vue/Svelte).
-  Its interactivity model is **vanilla custom elements + a static loader**, exactly the
-  existing LikeC4 setup: `public/likec4-loader.js` lazily injects the heavy
-  `public/likec4-views.js` only on pages that embed `<likec4-view>`. So the engine is a
-  **framework-free web component** mirroring that pattern, not a React island.
-- Dev-only rests on two independent mechanisms (see section 6 for the exact test):
-  (i) the loader `<script>` is emitted only under `import.meta.env.DEV`, gated in the
-  existing `src/components/Head.astro` Starlight override (`public/*.js` cannot read
-  env, so the gate lives in the `.astro` layer); (ii) the page
-  `src/content/docs/docs/about/architecture.md` is **gitignored and wiped+re-synced by
-  `sync-from-alint.mjs` on every real build** (Cloudflare runs the sync-gated `build`),
-  so local embeds can never reach production. Note the engine's static files under
-  `public/anim/` copy verbatim into `dist/anim/` on any build, but are **inert** unless
-  the DEV-gated loader references them -- so "dev-only" means "never referenced/activated
-  in production HTML," not "absent from `dist/`."
+- **This is a small reusable product, not a throwaway prototype.** The engine (a
+  declarative schema, a validated render/animation core, transport controls, first-class
+  accessibility, and two forward graduation paths) is production-shaped by design. Full
+  WCAG work on a never-live artifact only makes sense as *graduation-readiness*, so it is
+  deferred to **after** the go/no-go gate below, not built up front.
+- **The expensive-to-be-wrong question is the aesthetic, and it must be answered first.**
+  "Do Cursor-style animated diagrams actually look good and earn their maintenance in
+  these docs?" is answered by *one polished diagram*, not by the engine's architecture.
+  The plan therefore gates the whole engine behind a **1-day throwaway spike** (Phase -1)
+  whose only deliverable is that go/no-go. Building the engine first would sink ~80% of
+  the work before anyone can judge the look, creating sunk-cost pressure to ship a
+  mediocre result.
 
-The existing LikeC4 dynamic-view steps are **coarse C4 boxes**
-(`dev -> alintBin -> dsl -> core -> rules -> output`) -- too abstract for the intended
-detail -- so the engine consumes a **new, richer, hand-authored declarative spec**, not
-the raw `.c4` steps. (Reusing the C4 steps and build-time SVG generation are graduation
-paths, not MVP; see section 7.)
+Verified integration facts (evidence in the audits): alint.org is Astro + Starlight with
+**no framework islands**; interactivity is **vanilla custom elements + a static loader**
+(the LikeC4 pattern -- but note LikeC4 ships one *pre-bundled* file, whereas this engine
+is multiple sibling ES modules that fetch each other at runtime, which is net-new here).
+Dev-only rests on two independent mechanisms: the loader `<script>` is emitted only under
+`import.meta.env.DEV` in `src/components/Head.astro`, and `architecture.md` is gitignored
+and wiped+re-synced by `sync-from-alint.mjs` on every real `npm run build`.
 
-## 2. Approach
+## 2. Phase -1: throwaway aesthetic spike (the go/no-go gate)
 
-A dependency-free web component `<alint-anim spec="...">` that renders an inline SVG from
-a declarative spec (nodes + edges + a captioned step timeline) and animates it: nodes
-light up as the pipeline advances, tokens (files, facts, violations) flow along edges,
-one caption per step. Transport controls (Prev / Play-Pause / Next / progress), full
-keyboard a11y, and first-class `prefers-reduced-motion`. Runtime-rendered like LikeC4
-(the *spec* is the text artifact; render live). Engine + specs are committed to
-alint.org (durable); the architecture-page embeds are local/dev-only (throwaway by
-construction).
+Before any engine: **one hand-built inline `<svg>`** on the architecture page, at the real
+target size (~1000x520), using the real Starlight `--sl-color-*` tokens, with ~30 lines of
+*hardcoded* `requestAnimationFrame` token motion along *one* path and bare Prev/Next.
 
-Three decisions the audit pinned down, stated up front because they are load-bearing:
+- No schema, no web component, no `validateSpec`, no registry, no accessibility, no
+  reduced-motion, no responsive work -- none of the generality that makes the engine
+  expensive. It exists only to show the *look* and the polish gap vs Cursor.
+- Build it as a **single self-contained `.html` file** opened directly (not through
+  `astro dev`), because `public/**` gets no HMR in Astro (section 6) -- a standalone file
+  you refresh directly is the fastest iteration loop for pure look/feel.
+- **Hard rule: throwaway.** Do not evolve the spike into the engine; that reintroduces the
+  sunk-cost bias. Time-box ~1 day.
+- **Exit gate:** an explicit decision. If the look does not clear the bar (honestly judged
+  against Cursor, not a pre-lowered bar), stop here -- the engine is not authorized. If it
+  clears, proceed to Phase 0 with a felt sense of the required polish.
 
-- **Light DOM, not shadow DOM.** For a *documentation* diagram, the caption narrative and
-  the step-list are real prose a reader will Ctrl-F, select, copy, and print -- all of
-  which are unreliable inside a shadow root (find-in-page across shadow DOM is
-  inconsistent; global docs typography does not cross the boundary). Render into light
-  DOM with a scoped class prefix (`.alint-anim`), and **namespace every `<defs>` id per
-  instance** (the id/marker/gradient collision that a shadow root would otherwise hide;
-  see 3.2). CSS-custom-property theming works identically in light DOM.
-- **Author-routed edges, not auto-routed.** Real obstacle-avoiding auto-layout is the
-  Graphviz/ELK problem; a from-scratch heuristic among ~15 nodes produces spaghetti. The
-  author places nodes AND specifies edge anchors (`fromSide`/`toSide`) + optional
-  waypoints; the engine draws a smooth/elbowed path through them. See 3.7.
-- **Staged build (de-risk first).** Build the engine against **check-pipeline only**,
-  end-to-end, and iterate on look/feel + authoring ergonomics before authoring the other
-  diagrams. Freeze the schema, then author the rest. See section 4.
+## 3. The engine (authorized only after Phase -1 says go)
 
-## 3. The engine (the rendering pipeline)
-
-All net-new under `public/anim/` (native ES modules served verbatim, no build step),
-plus one guarded line in `Head.astro`. Mirrors the LikeC4 split: a tiny static loader
-injects the heavier engine module on demand.
+Net-new under `public/anim/` (native ES modules served verbatim), plus two committed edits
+(`Head.astro` + `custom.css`; the second is required by the CLS fix). Tests live OUTSIDE
+`public/` (section 6). The render core is **string-first** (below) so it is Node-testable
+and shareable with the build-time graduation.
 
 ### 3.1 File layout
 
 | Path | Role |
 |---|---|
-| `public/anim/anim-loader.js` | Static ES5 loader; mirror of `public/likec4-loader.js`. Presence-gate `if (!document.querySelector('alint-anim')) return;`, mirror `data-theme`, inject `<script type=module src=/anim/anim-engine.js>` once. |
-| `public/anim/anim-engine.js` | `class AlintAnim extends HTMLElement` + guarded `customElements.define`. `connectedCallback`: resolve spec -> `validateSpec()` -> render into light DOM -> wire controls + clock -> pick reduced-motion path. |
-| `public/anim/anim-render.js` | Pure SVG builder (edges/nodes/tokens layers; per-instance `<defs>` id namespacing) + `computeFrame(spec, i)` + `applyFrame`. Shared with the build-time graduation (7a). |
-| `public/anim/anim-clock.js` | The rAF clock: `seek/next/prev/play/pause`, token spawn with cached path lengths, `getPointAtLength` motion, elapsed-time pause, dt-clamp, visibility/IntersectionObserver pause. |
-| `public/anim/anim-controls.js` | Transport bar (native `<button>`s + a native `<input type=range>` progress), keyboard map, `aria-live` caption, the step `<ol>`. |
-| `public/anim/anim-validate.js` | `validateSpec(spec)`: every edge `from`/`to` and every step-referenced id resolves; returns errors. |
-| `public/anim/anim-spec.d.ts` | TypeScript types (3.6). Types only; never shipped. |
-| `public/anim/specs/index.js` | Registry `export const SPECS = {...}`. |
-| `public/anim/specs/*.js` | One hand-authored spec per diagram. |
+| `public/anim/anim-loader.js` | Static ES5 loader; mirror of `likec4-loader.js`. Presence-gate, mirror `data-theme`, inject `anim-engine.js` **once** (guard against N elements). |
+| `public/anim/anim-engine.js` | `class AlintAnim extends HTMLElement` + guarded `customElements.define`. Lifecycle in 3.2. Types via JSDoc `@typedef` only (never a runtime `import type` -- that is a SyntaxError in an untranspiled `public/` module). |
+| `public/anim/anim-render.js` | **String-first** SVG builder: `renderSvg(spec, frame) -> string` (nodes/edges/tokens layers, per-instance `<defs>` id namespacing); `computeFrame(spec, i) -> {status, text}`; the shared anchor-resolution function (3.7). No DOM APIs -> runs in Node. Runtime sets `el.innerHTML` and queries nodes for motion. |
+| `public/anim/anim-clock.js` | rAF clock: `seek/next/prev/play/pause`, token spawn (cached path lengths), `getPointAtLength` motion. Step-transition logic is separated from the rAF pump so it is synchronously unit-testable (only token motion needs rAF). |
+| `public/anim/anim-controls.js` | Transport bar (native `<button>`s + native `<input type=range>` scrubber, 3.4), keyboard, `aria-live` caption, the step `<ol>`. |
+| `public/anim/anim-validate.js` | `validateSpec(spec)`: unknown ids; chained edges whose **resolved anchor points** (not just sides) differ (3.7). |
+| `public/anim/anim-spec.d.ts` | Types (3.6). Advisory-only; note it *is* copied to `dist/anim/` (served, not executed) -- not "never shipped". |
+| `public/anim/specs/index.js`, `specs/*.js` | Registry + one spec per diagram. |
 
-Edited (only committed edit) -- `src/components/Head.astro`, after the existing
-appended tags, matching how the Cloudflare beacon `<script>` is emitted there (**`is:inline`
-is required** -- Astro bundles bare `<script>` tags and a hoisted one can silently
-vanish; the beacon and the astro.config `head[]` likec4-loader both use the raw-tag form):
+Committed edits:
+- `src/components/Head.astro` -- the dev gate (`is:inline` is required; Astro bundles a
+  bare `<script>` and a hoisted one can silently vanish):
+  ```astro
+  {import.meta.env.DEV && <script is:inline src="/anim/anim-loader.js" defer></script>}
+  ```
+- `src/styles/custom.css` (already `customCss`-registered, present at first paint) --
+  `alint-anim { display: block; min-height: <px>; }`. The CLS reservation **must** be here,
+  not in the JS-injected stylesheet: an unstyled custom element is `display:inline` (zero
+  box) until the deferred engine runs, so a min-height applied by the engine arrives after
+  the shift it is meant to prevent.
 
-```astro
-{import.meta.env.DEV && (
-  <script is:inline src="/anim/anim-loader.js" defer></script>
-)}
-```
+### 3.2 Web component, lifecycle, DOM containment
 
-When the prototype graduates, this line moves into `astro.config.mjs` `head[]` beside
-`likec4-loader.js` (unconditional/production; section 7).
+`connectedCallback`: resolve the spec (`spec="id"` -> `SPECS[id]`, or inline
+`<script type="application/json">`); `validateSpec()`; on failure render a visible fallback
+(the step `<ol>` + a bordered error) and **never enter the rAF loop**; else set
+`innerHTML` from `renderSvg(...)` into **light DOM**, build controls, init the clock.
 
-### 3.2 Web component, lifecycle, DOM
-
-`connectedCallback`: resolve the spec (`spec="id"` -> `SPECS[id]`, or an inline
-`<script type="application/json">` child); run `validateSpec()`; on failure render a
-visible fallback (the step `<ol>` + a bordered error note) and **do not enter the rAF
-loop**; else render the SVG into **light DOM** under a `.alint-anim` scoped wrapper, build
-controls, init the clock, pick reduced-motion vs interactive. Reserve a `min-height` on
-the host so lazy engine injection does not cause layout shift (CLS). Guard double-connect;
-`disconnectedCallback` tears down rAF + observers.
-
-Light DOM means CSS could leak both ways; contain it with a single scoped stylesheet
-(`.alint-anim ...` selectors) injected once. The only thing a shadow root was buying --
-`<defs>` id isolation across multiple diagrams on one page -- is handled explicitly:
-**prefix every gradient/marker/filter/clip id with the instance id** (`arrow-<uid>`), so
-N diagrams never collide.
+Light DOM is chosen (over shadow DOM) so the caption + step list are real prose a reader
+can Ctrl-F, select, copy, and print. But light DOM sits inside Starlight's
+`.sl-markdown-content`, whose **descendant** rules (lobotomized-owl block margins; a direct
+`svg { display:block; max-width:100%; height:auto }`; `a`/`li`/list styling) reach into the
+component regardless of a class prefix. **Fix: put `class="not-content"` on the host** --
+Starlight's official opt-out (every markdown rule excludes `:where(.not-content *)`), which
+the existing shadow-DOM LikeC4 embeds never needed. The engine then supplies its own styles
+for the caption/`<ol>` using `--sl-*` font/color tokens so they still read as docs prose;
+because Starlight's content styles live in `@layer starlight.content`, the engine's
+**unlayered** styles win automatically (there is no specificity battle). A `.alint-anim`
+prefix is then only for preventing leak-*out*.
 
 ### 3.3 Animation model
 
-**One `requestAnimationFrame` scalar clock** drives token-along-path motion via
-`path.getPointAtLength()` (per-path `getTotalLength()` is cached once at render, not per
-frame). Discrete node/edge appearance is a function of the current step -- a
-`computeFrame(spec, i)` pass -- applied as scoped CSS classes. This keeps Prev/Next/seek a
-clean "compute the frame, swap the classes" with no half-finished tweens.
+One rAF scalar clock drives token-along-path motion via `getPointAtLength()` (per-path
+`getTotalLength()` cached once). Discrete node/edge appearance is a function of the current
+step via `computeFrame`. Per-instance clock for the MVP (a single shared ticker across
+instances is a graduation optimization; do not over-build it now). Clean pause/seek/step
+because appearance is recomputed, not tweened.
 
-Chosen over the Web Animations API (unified scrub across N concurrent animations is more
-bookkeeping) and pure CSS transitions (backward seek + per-step scrub fight the
-declarative model; CSS cannot interpolate a token along a path). Manual rAF wins on the
-four axes that matter: framework-free, smooth token motion, clean pause/seek/step, and a
-trivial reduced-motion path.
-
-`computeFrame` -- **corrected from the audit**: `reveal` and the visited/`done` trail are
-**monotonic** (folded over `0..i`), but `active` and `dim` are **state at step i**
-(computed from the current step, NOT folded), so a later step can freely restore a node
-to `done`/`resting` instead of being forced to over-emphasize it via `activate`:
+`computeFrame(spec, i)` returns **`{status, text}`** (the round-1 rewrite returned only
+status and left `setText` as a dead comment -- fixed):
 
 ```js
-// per-element status: hidden | resting | done | active | dim
 function computeFrame(spec, i) {
-  const status = new Map();
-  // monotonic layer: reveal (hidden->present) + the visited trail (done)
+  const status = new Map(), text = new Map();
   for (const n of spec.nodes) status.set(n.id, n.hidden ? 'hidden' : 'resting');
   for (const e of spec.edges) status.set(e.id, endpointHidden(spec, e) ? 'hidden' : 'resting');
-  for (let s = 0; s <= i; s++) {
+  for (let s = 0; s <= i; s++) {                       // monotonic layer (folded)
     (spec.steps[s].reveal ?? []).forEach(id => { if (status.get(id) === 'hidden') status.set(id, 'resting'); });
-    (spec.steps[s].activate ?? []).forEach(id => status.set(id, 'done')); // trail lit
+    (spec.steps[s].activate ?? []).forEach(id => status.set(id, 'done'));   // visited trail
+    (spec.steps[s].setText ?? []).forEach(t => text.set(t.id, t.text));     // last-set wins
   }
-  // current-step layer (not folded): this step's actives are strongest; its dims muted
-  (spec.steps[i].dim ?? []).forEach(id => status.set(id, 'dim'));
-  (spec.steps[i].activate ?? []).forEach(id => status.set(id, 'active'));
-  // per-step dynamic text (accumulating counts etc.) applied from the fold
-  return status;
+  (spec.steps[i].dim ?? []).forEach(id => status.set(id, 'dim'));           // current-step layer
+  (spec.steps[i].activate ?? []).forEach(id => status.set(id, 'active'));   // active > dim if both
+  return { status, text };
 }
 ```
 
-Visual hierarchy (specify it, the "lights up as you go" look depends on it):
-`resting` = full muted graph; `done` = brighter than resting (traversed); `active` =
-brightest + accent glow; `dim` = below resting (pushed back this step); `hidden` = absent.
+Semantics to state in the doc so authors are not surprised: `reveal` and the visited/`done`
+trail are **monotonic**; `active` and `dim` are **single-step** -- a node dimmed at step 4
+returns to `done`/`resting` at step 5 unless step 5 re-lists it, so **`dim` must be repeated
+to sustain a mute** (persistent de-emphasis is out of scope; revisit with a folded
+`mute`/`unmute` pair only if authoring proves it necessary). `activate` implicitly reveals a
+still-hidden node. Visual hierarchy: `resting` < `done` < `active`(+accent glow); `dim`
+below `resting`; `hidden` absent. `setText` overrides a node's rendered value; static
+`label`/`sublabel` are the default.
 
-Per-step **dynamic text**: nodes may carry an accumulating value (e.g. "FileIndex: 1,234
-files", "violations: 7"). A `setText` step op (3.6) overrides a node's rendered value at
-that step; the fold applies the last-set value. Static `label`/`sublabel` remain for
-fixed text.
+Tokens are ephemeral: cleared on **any** manual seek (forward `Next` included, not only
+backward). Timing accumulates **elapsed** time (pause freezes exactly; never
+`now - startTime`) with `dt` clamped ~64ms. Chained `edges:[...]` travel: consecutive edges
+must share the **resolved anchor point** on the shared node -- validated against the same
+anchor-resolution function the renderer uses (3.7), not merely "same side", or port-offset
+distribution places the seams apart and the token teleports.
 
-The clock spawns `<circle>` tokens per the step's `flow`, moves them along the edge path
-over `durationMs`, staggers multiple tokens, and settles (removes them). Tokens are
-ephemeral, so a seeked/settled frame never has partial token state; **clear in-flight
-tokens on any manual seek, forward Next included** (not only backward). Timing uses
-`performance.now()` deltas with `dt` clamped (~64ms) and accumulates **elapsed** time so
-pause freezes exactly (never `now - startTime`, which jumps on resume).
+### 3.4 Controls, accessibility, reduced motion (graduation-readiness; built after go)
 
-Chained `edges: [...]` travel: **require consecutive edges to share an identical anchor
-point** on the shared node (validated by `validateSpec`), and cache per-token the
-`[path, cumulativeOffset]` list at spawn. Document whether the token passes *through* the
-shared node or dwells; default = passes through. Without the shared-anchor requirement a
-token teleports across the node at the seam.
+**No autoplay on connect** (satisfies WCAG 2.2.2, which triggers only on auto-starting
+motion). Under `prefers-reduced-motion` Play is **disabled** (snapped auto-advance still
+updates content automatically and can re-trigger 2.2.2); the user steps manually.
 
-### 3.4 Controls, accessibility, reduced motion
-
-**No autoplay on connect** -- default is user-driven stepping, which satisfies WCAG 2.2.2
-(Pause/Stop/Hide, Level A) because that criterion is triggered only by content that
-starts *automatically* (verified). Play is an opt-in button; under reduced motion it
-advances discrete snapped steps (or is disabled), never a running rAF.
-
-- **Transport:** native `<button>`s (`aria-pressed` Play toggle) and a **native
-  `<input type="range">`** for progress (free keyboard arrows/Home/End, `aria-valuenow`,
-  and touch drag; avoids a hand-rolled `role=slider`). Wrapper `role="group"
-  aria-label="Diagram playback"`. Keyboard `<-/->`, Space, Home/End. Ensure the
-  component's global Left/Right handler does not *also* fire while the range has focus
-  (double-step). Touch targets meet WCAG 2.5.8 (>=24x24).
-- **The SVG has an accessible exposure:** `role="img"` on the diagram with an
-  `aria-label` + `aria-describedby` one-line summary; decorative token/edge layers marked
-  `aria-hidden`.
-- **The numbered step `<ol>` exists in BOTH modes** (in light DOM, so it is findable,
-  copyable, printable, and inherits docs typography). It is the structural, browsable map;
-  the `aria-live="polite"` caption announces the *current* step. Complementary, not
-  redundant (carousel status + list).
-- **Reduced motion starts at step 0** (not the final fold -- starting at the end is
-  disorienting), transitions disabled (states snap), token motion skipped; transport
-  steps instantly. The static `<ol>` gives the full narrative without motion. Captions
-  carry the flow's invariants in prose so the still frames + list are genuinely
-  meaningful.
+- Transport: native `<button>`s + a native `<input type=range>`. The scrubber is
+  **step-granular** (`min=0 max=N-1 step=1`; arrows = prev/next step) -- not continuous time,
+  which would fight the clear-tokens-on-seek rule -- and exposes **`aria-valuetext`**
+  ("Step 5 of 11: <caption>"), since a bare `aria-valuenow` announces only "5". Wrapper
+  `role=group aria-label`; keys arrows/Space/Home/End; ensure the global arrow handler does
+  not double-fire while the range has focus; touch targets >=24x24 (WCAG 2.5.8).
+- The SVG carries `role="img"` + a static `aria-label` summary; decorative token/edge layers
+  `aria-hidden`. Because `role="img"` gives a **static** accessible name, all per-step
+  semantics live in the `aria-live="polite"` caption and the step `<ol>`.
+- The numbered step `<ol>` exists in **both** modes (light DOM: findable, copyable,
+  printable). Reduced motion **starts at step 0** (not the final fold), transitions
+  disabled, token motion skipped.
 
 ### 3.5 Theme
 
-SVG strokes/fills use `var(--sl-color-*)` and `currentColor`; Starlight sets
-`data-theme="light|dark"` on `<html>` before first paint, so recolor on toggle is
-automatic with no per-frame JS (custom properties are inherited and pierce into light or
-shadow DOM -- verified). **Use the real Starlight docs tokens (never hardcode a hex; the
-`~#93a4fd` in an earlier draft was the marketing accent, not these docs tokens):**
-- accent stroke/highlight: `var(--sl-color-text-accent)` (adaptive -- light periwinkle on
-  dark, indigo on light);
-- solid accent fill (with `--sl-color-white` text): `var(--sl-color-accent)`;
-- background `var(--sl-color-bg)`; foreground `var(--sl-color-text)` / `--sl-color-white`;
-  borders `var(--sl-color-gray-5)` / `--sl-color-hairline`.
+SVG uses `var(--sl-color-*)` / `currentColor`; `data-theme` on `<html>` recolors with no
+per-frame JS (custom properties inherit into light DOM -- verified). Use the real Starlight
+docs tokens (never hardcode; the earlier `~#93a4fd` was the marketing accent):
+`var(--sl-color-text-accent)` (adaptive accent), `var(--sl-color-accent)` (solid fill with
+`--sl-color-white` text), `var(--sl-color-bg)`, `var(--sl-color-text)`,
+`var(--sl-color-gray-5)` / `--sl-color-hairline` (borders).
 
 ### 3.6 Spec schema
 
-Hand-placed coordinates + author-specified edge anchors (not auto-layout): dependency-free,
-art-directed, deterministic. `fromSide`/`toSide` are **restored** (the audit flagged their
-loss); `label` accepts `string | string[]` for manual line breaks; `setText` supports
-per-step dynamic values.
+Hand-placed coordinates + author-specified edge anchors (not auto-layout).
 
 ```ts
 type NodeKind = 'process'|'artifact'|'store'|'decision'|'terminal'|'group';
 type Side = 'top'|'right'|'bottom'|'left';
 interface AnimNode { id; x; y; w; h; label: string|string[]; kind?; sublabel?; group?; hidden?; }
-interface AnimEdge { id; from; to; label?; fromSide?: Side; toSide?: Side; waypoints?: {x;y}[]; kind?:'flow'|'dep'|'back'; curve?:'smooth'|'orthogonal'|'straight'; }
+interface AnimEdge { id; from; to; label?; fromSide?: Side; toSide?: Side; port?: string; waypoints?: {x;y}[]; kind?:'flow'|'dep'|'back'; curve?:'smooth'|'orthogonal'|'straight'; }
 interface AnimFlow { edge?; edges?; count?; spread?; reverse?; variant?; }
 interface AnimStep { caption; activate?; dim?; reveal?; flow?: AnimFlow[]; setText?: {id;text}[]; durationMs?; dwellMs?; note?; }
-interface AnimSpec { id; title; width; height; nodes: AnimNode[]; edges: AnimEdge[]; steps: AnimStep[]; defaults?; }
+interface AnimSpec { id; title; width; height; defaults?: {durationMs?; dwellMs?; curve?: 'smooth'|'orthogonal'|'straight'; kind?: NodeKind}; nodes: AnimNode[]; edges: AnimEdge[]; steps: AnimStep[]; }
 ```
 
-`validateSpec` (run on connect, and unit-tested per section 6) rejects: unknown ids in any
-edge/step reference, chained edges that do not share an anchor point, and empty
-nodes/steps. On failure the component renders the fallback rather than a broken SVG.
+`group` nodes render at **lowest z-order** (a labelled backdrop behind their members); a
+member references its container via `group`. `defaults` supplies per-spec fallbacks for
+`durationMs`/`curve`/`kind`. Chained edges may pin a shared `port` on the seam node so
+port-offset distribution keeps their anchor identical. A **small, complete fixture spec**
+(a handful of nodes/edges/steps exercising every field: `fromSide`/`toSide`/`waypoints`,
+`setText`, `dim`+`activate`+`reveal`, a chained `edges:[...]` flow) lives beside the tests
+as the schema-coherence proof and test fixture -- deliberately NOT the full ~15-node
+`check-pipeline` coordinate dump, which cannot be validated as readable without rendering
+and would be instantly stale.
 
-### 3.7 Edge routing (author-routed) + node text
+### 3.7 Edge routing (author-routed) + shared anchor resolution
 
-Not auto-routing. Each edge draws from `from`'s `fromSide` anchor, through any
-`waypoints`, to `to`'s `toSide` anchor, as a `curve` (`smooth` = quadratic/cubic through
-the points; `orthogonal` = rounded elbows; `straight`). Default side (when a hint is
-absent) is the geometric nearest, but the author is expected to set sides on any edge that
-would otherwise cross a node. When several edges share a node side, distribute their
-anchor points along that side by index (port offset) so they do not stack. Token motion
-then follows exactly the path the author sees (3.3).
+Each edge draws from `from`'s `fromSide` anchor, through `waypoints`, to `to`'s `toSide`,
+as `curve`. When several edges share a node side they are distributed by index (port
+offset); an explicit `port` pins a specific anchor. A **single `resolveAnchor(edge, node,
+side)` function** is used by both `validateSpec` and `anim-render` so validation checks the
+same point the renderer draws (this is what makes the chained-edge continuity check real).
+Default side (absent a hint) is the geometric nearest, but authors set sides on any edge
+that would otherwise cross a node. Node labels are `string[]` for explicit `<tspan>` line
+breaks (SVG `<text>` does not wrap); size `w`/`h` for the longest line and QA for overflow
+against real terminology.
 
-Node text does not wrap in SVG `<text>`; author labels as `string[]` for explicit
-`<tspan>` line breaks, and keep `w`/`h` sized for the longest line (a QA pass checks for
-overflow against the real terminology, e.g. ".alint.yml + extends sources").
+### 3.8 The diagrams, staged (after go)
 
-### 3.8 Worked example -- the `alint check` pipeline (Phase 0)
+- **Phase 0:** engine + **`check-pipeline`** only, end-to-end, iterating on legibility,
+  routing, timing, ergonomics -- surfacing schema/behavior issues once, not four times.
+  Host `## Execution model` (heading `:338`).
+- **Phase 1 (after freezing the schema):** `walker-gitignore` (walk -> gitignore/alintignore
+  filtering -> deterministic sort -> lazy indices; `## Execution model`), `dispatch-partition`
+  (rule-major vs per-file, read-once fan-out; heading `### Dispatch flip + PerFileRule
+  (v0.9.3)`, `:81`), and *(stretch)* `monorepo-scoping` (`### Closest-ancestor scoping
+  (scope_filter:, v0.9.6+)`, `:304`). Use the exact current heading slugs; they are
+  bundle-synced and can drift.
 
-`specs/check-pipeline.js`: ~15 nodes hand-placed (dev, alint binary, `.alint.yml`, extends
-sources, facts, rule filter, parallel walk, FileIndex, dispatch, per-file rules,
-cross-file rules, aggregate, emit, fixers, report), ~16 author-routed edges (with
-`fromSide`/`toSide`), and ~11 captioned steps mirroring `docs/design/ARCHITECTURE.md`'s
-Execution model. Captions carry the four invariants visually: **walk once** (one walk
-step), **read each file once** (single file token per file), **facts + rules parallel**
-(concurrent tokens), **fixers serial** (one slow token). This is the **Phase 0** diagram:
-build the whole engine against it, iterate on legibility, edge routing, timing, and
-authoring ergonomics, and only then freeze the schema and author the rest. Coordinates
-will need visual iteration -- they cannot be validated as readable without rendering.
+Aesthetic bar, honestly: **clean, legible, on-brand animated line diagrams** (mono +
+`--sl-color-text-accent`). Matching Cursor's designer-crafted polish is a real
+visual-iteration cost that the Phase -1 spike measures before this is authorized.
 
 ### 3.9 Responsive + overflow
 
-The specs use a fixed viewBox (~1000x520); SVG scales to container width, so on a phone a
-15-node diagram shrinks ~3x and labels turn illegible. Strategy: below a breakpoint wrap
-the SVG in an `overflow-x: auto` scroller that preserves a minimum legible text size (with
-a subtle "scroll to see more" affordance), rather than shrinking to fit. The transport bar
-wraps/stacks on narrow widths; the caption wraps. This is part of Phase 0 QA, on a real
-phone viewport.
+Fixed viewBox scales down on phones until labels are illegible. Below a breakpoint wrap the
+SVG in an `overflow-x: auto` scroller preserving a minimum legible text size (with a
+"scroll to see more" affordance) rather than shrinking to fit; the transport bar and caption
+wrap. Part of Phase 0 QA on a real phone viewport.
 
-### 3.10 Gotchas (established, must-honor)
+### 3.10 Gotchas
 
-- **Node scaling:** position the node **group** via the `transform="translate(x y)"`
-  attribute and scale the **inner** box via CSS with `transform-box: fill-box;
-  transform-origin: center` (a CSS transform replaces the presentation attribute, so use
-  different elements).
-- **Never animate path `d`** (SMIL banned; CSS `d` support uneven). Draw an edge in via
-  `stroke-dashoffset`; move a token along the static path via `getPointAtLength`.
-- **Token motion:** cache `getTotalLength()` once at render; `getPointAtLength()` per frame
-  sets the token `translate`. `getPointAtLength` is universally supported;
-  `offset-path` is avoided for coordinate-origin friction (its old browser gaps are now
-  moot, but the friction reason stands).
-- **rAF hygiene:** elapsed-time accumulation (pause freezes), clamp `dt`, pause on
-  `visibilitychange` hidden + off-screen via `IntersectionObserver`, `cancelAnimationFrame`
-  on disconnect. Wrap the rAF body so one bad frame cannot wedge the clock. For several
-  diagrams, a single shared rAF ticker iterating active instances is preferable to N
-  loops (IO-pausing offscreen ones makes either acceptable at MVP scale).
+Node scaling: position the group via the `transform` attribute, scale the inner box via CSS
+`transform-box: fill-box; transform-origin: center` (CSS transform replaces the attribute).
+Never animate path `d` (draw edges via `stroke-dashoffset`; move tokens along a static
+path). Cache `getTotalLength()` at render. rAF: elapsed-time accumulation, `dt`-clamp,
+pause on `visibilitychange` hidden + off-screen via `IntersectionObserver`,
+`cancelAnimationFrame` on disconnect, wrap the rAF body so one bad frame cannot wedge the
+clock.
 
-## 4. The diagrams (specs), staged
+## 4. Browser + authoring notes
 
-Staged to de-risk the engine before multiplying work across specs:
-
-- **Phase 0:** engine + **`check-pipeline`** only, end-to-end (real author-routed edges,
-  tokens, chained travel, controls, reduced-motion, responsive). Iterate until the look is
-  right and authoring is ergonomic; this surfaces edge-routing, fold, and token issues
-  once, not four times. Host section `## Execution model`.
-- **Phase 1 (after freezing the schema):**
-  - `walker-gitignore` -- parallel walk -> honor `.gitignore`/`.alintignore`/`ignore:`
-    globs (files dropped) -> merge + deterministic sort -> lazy indices. Host `## Execution
-    model` (net-new embed).
-  - `dispatch-partition` -- partition rules (rule-major vs per-file); file-major loop reads
-    each file once and fans out; cross-file scans the index. Host `### Dispatch flip`.
-  - *(stretch)* `monorepo-scoping` -- nested `.alint.yml` + closest-ancestor `scope_filter`
-    walk. Host `### Closest-ancestor scoping`.
-
-Aesthetic target, stated honestly: **clean, legible, on-brand animated line diagrams**
-(monochrome + `--sl-color-text-accent`, Cursor-style token variants file/fact/violation).
-Matching Cursor's *designer-crafted* polish (custom easing, glow, token trails, bespoke
-timing) is a visual-iteration cost; budget explicit iteration cycles in Phase 0 rather
-than asserting "Cursor-grade" up front.
+- **Evergreen-only.** `public/anim` ships **untranspiled** (no `vite.build.target`, no
+  browserslist for `public/`); target ES2020+. Revisit at graduation (b) only if analytics
+  show meaningful old-browser docs traffic.
+- **Spec captions escape the site's prose gates.** `alint check`'s em-dash/curly-quote rules
+  target `.astro`/`.md`/`.mdx` + `llms.txt`, not `public/anim/specs/*.js`, so an em-dash in a
+  caption sails through. Author captions to the same no-em-dash discipline manually.
+- **Typing posture:** JSDoc `@typedef` (the `tsconfig` sweeps `public/` under strict, but no
+  `astro check` CI gate exists, so this is for editor sanity only).
 
 ## 5. Dev-only embedding + QA
 
-- Add the `Head.astro` dev gate (3.1).
-- Embed `<alint-anim spec="..."></alint-anim>` in the **local**
-  `src/content/docs/docs/about/architecture.md` in the relevant sections (verified present
-  locally, with the target section anchors). Gitignored + wiped by the sync-gated build, so
-  embeds are dev-only by construction; the local `astro dev` server never runs sync, so the
-  hand-added embeds simply persist between runs (the local `npm run sync` is Node-broken,
-  so nothing wipes them locally -- a dedicated re-apply helper is therefore unnecessary).
-- QA with `astro dev` under nvm (`. ~/.nvm/nvm.sh && nvm use default`; the shell's default
-  Node is too old).
+Add the two committed edits (3.1). Embed `<alint-anim spec="...">` in the **local**
+`architecture.md` (present, gitignored, wiped by the sync-gated build). The local `astro
+dev` server never runs sync and the local `npm run sync` is Node-broken, so hand-added
+embeds simply persist. **`public/**` has no HMR in `astro dev`** -- after editing
+`anim-engine.js`/specs, hard-refresh (or dev-inject the engine URL with a `?v=` cache-bust);
+this asymmetry (content hot-reloads, `public/` does not) is a reason the Phase -1 spike is a
+standalone HTML file. QA under nvm (`. ~/.nvm/nvm.sh && nvm use default`).
 
-## 6. Verification (end-to-end)
+## 6. Verification
 
-At `astro dev`, load `/docs/about/architecture/`, per diagram confirm: renders inline SVG;
-Prev/Next/Play/Pause and the range progress work; captions update in the `aria-live`
-region and the step `<ol>` is present + findable via Ctrl-F; tokens flow; concurrent
-tokens read as parallel and the serial-fixer step as one slow token; light/dark recolors
-with no reflow; emulated `prefers-reduced-motion` starts at step 0, no autoplay, static
-`<ol>` narrative; keyboard controls + no double-step; a bad spec id renders the fallback,
-not a broken SVG or a console-spamming dead clock; responsive on a phone viewport; no CLS
-on load; the loader is inert on pages with no `<alint-anim>`.
+**Tests (out of `public/`, wired to CI).** Put them beside the existing
+`src/lib/nav.test.mjs` (or `tests/anim/`) -- NOT under `public/`, where they would copy to
+`dist/` and be served at `https://alint.org/anim/*.test.mjs`. Add a `test:anim` script and a
+CI step (fold into an existing workflow; the only wired test today is `test:nav`). Run under
+nvm (Node >=18 for `node --test`). Coverage: `computeFrame(spec, i)` `{status, text}` maps
+(including text after a backward seek); `validateSpec` (unknown ids; chained-edge resolved-
+anchor mismatch); clock transitions (`seek` empties the token layer; `next`/`prev` clamp;
+`play`->`pause` preserves elapsed with a mocked `performance.now`; reduced motion never
+enters rAF); and -- enabled by the string-first render -- a `renderSvg()` smoke that every
+registered spec builds a non-empty SVG string without throwing (this needs no DOM/jsdom).
 
-**Automated tests (add now, not at graduation):** unit-test `computeFrame(spec, i)`
-status maps; a Node test that asserts **every registered spec passes `validateSpec`**; a
-headless smoke that each spec builds its SVG without throwing.
+**Manual QA** at `astro dev`, `/docs/about/architecture/`: renders; transport + step
+scrubber + `aria-valuetext`; captions in the live region and a findable step `<ol>`; tokens
+flow, parallel reads as concurrent, serial-fixer as one slow token; light/dark recolor;
+reduced motion starts at step 0 with Play disabled; keyboard, no double-step; bad spec ->
+fallback not a dead clock; responsive on a phone; no CLS on load.
 
-**Production-exclusion test (corrected).** The prior `build:no-sync` + grep check was
-wrong: `build:no-sync` is bare `astro build` (skips sync), so it does NOT wipe the local
-embeds, and `public/anim/*.js` copy into `dist/anim/` on any build -- so the tags survive
-and the static files are always present. The correct checks:
-- **Structural (primary, no build needed):** the embeds live only in the gitignored,
-  sync-overwritten `architecture.md`, and the loader `<script>` is emitted only under
-  `import.meta.env.DEV`. Both are inspectable facts; neither reaches a production build.
-- **Full-build confirmation:** run **`npm run build`** (the sync-gated production build)
-  under nvm, then grep `dist/**/*.html` only, asserting (i) no `<alint-anim` element and
-  (ii) no `<script>` referencing `/anim/anim-loader.js`. (Sync wipes the embeds; the
-  DEV gate omits the loader.) Caveat: the full build clones the docs bundle and runs a
-  network freshness cross-check that can fail if the site's version pin is ahead of the
-  bundle -- if that blocks locally, the structural check above is authoritative. Do not use
-  `build:no-sync` for this proof; grepping all of `dist/` for the static `/anim/` files
-  will always match and is not evidence of a leak.
+**Production-exclusion.** Primary = structural: embeds live only in the gitignored/sync-
+wiped `architecture.md`, and the loader `<script>` is DEV-gated. Confirmation = full
+`npm run build` (the sync-gated production build) under nvm, then grep `dist/**/*.html`
+only for (i) no `<alint-anim` element and (ii) no `/anim/anim-loader.js` reference. **Do
+not use `build:no-sync`** for this proof -- it skips sync, so its `dist` HTML still contains
+the (inert) embed tags; a `build:no-sync` output must never be deployed. Note the engine's
+static `dist/anim/*.js` (+ the `.d.ts`) are present-but-unreferenced on any build and are
+crawlable in prod (robots `Allow: /`, AI bots allowed); keep the shipped footprint minimal,
+keep tests out of `public/`, and optionally add a build assertion that fails if `dist/anim`
+is present without a graduation flag.
 
 ## 7. Scope boundaries and graduation paths (NOT in the MVP)
 
-- **Build-time deterministic-SVG variant** (graduation (a)): a `scripts/` Node script
-  (mirroring `scripts/build-likec4.mjs`, already chained in `npm run build`) imports the
-  same `specs/*.js` and the shared `anim-render.js` core and emits a static, fully-labelled
-  SVG (final fold + caption list) -- a no-JS/print/GitHub rendering and a deterministic
-  artifact for perf-gating. Runtime engine and build script share one render core so they
-  cannot diverge.
-- **Live docs** (graduation (b)): move the dev gate into `astro.config.mjs` `head[]`
-  (unconditional) and author embeds in the alint repo's `docs/design/ARCHITECTURE.md` so
-  they flow through the docs-bundle pipeline. Caveat (already documented for LikeC4):
-  GitHub strips the custom element, so the build-time static SVG from (a) is what renders
-  on GitHub, while alint.org shows the animated version.
-- No auto-layout (author-routed), no LikeC4-derived specs (the C4 steps are too coarse),
-  **no new npm dependencies** (dependency-free). Engine + specs are committed to alint.org
-  only; nothing lands in the alint repo or the live site in this prototype.
+- **Build-time deterministic-SVG variant** (graduation (a)): a `scripts/` Node script imports
+  the same specs and the **string-first** `renderSvg` and emits a static, fully-labelled SVG.
+  Because `getPointAtLength`/rAF are browser-only, the shared core is precisely the
+  string-emitting structure/frame builder; token motion + the clock are runtime-only. The
+  "cannot diverge" guarantee therefore covers the **static** half only -- do not over-claim
+  it.
+- **Live docs** (graduation (b)): move the dev gate into `astro.config.mjs` `head[]` and
+  author embeds in the alint repo's `docs/design/ARCHITECTURE.md`. GitHub strips the custom
+  element, so the graduation-(a) static SVG is what renders there; alint.org shows the
+  animation. Revisit the browser baseline here.
+- No auto-layout, no LikeC4-derived specs, no new npm dependencies. Engine + specs committed
+  to alint.org only.
 
 ## 8. Files
 
 - Create in alint.org: `public/anim/{anim-loader,anim-engine,anim-render,anim-clock,
   anim-controls,anim-validate}.js`, `public/anim/anim-spec.d.ts`, `public/anim/specs/
-  index.js`, `public/anim/specs/{check-pipeline,walker-gitignore,dispatch-partition,
-  monorepo-scoping}.js`, plus unit tests (`*.test.mjs`).
-- Edit (committed): `src/components/Head.astro` (the `is:inline` dev-gate line).
-- Edit (local/dev-only, not committed): `src/content/docs/docs/about/architecture.md`
-  (demo embeds).
+  index.js`, `public/anim/specs/*.js`; tests under `src/lib/anim/` or `tests/anim/`
+  (`*.test.mjs`, NOT under `public/`); the Phase -1 spike as a standalone `.html` (throwaway).
+- Edit (committed): `src/components/Head.astro` (the `is:inline` dev gate) and
+  `src/styles/custom.css` (the eager `alint-anim { display:block; min-height }` CLS
+  reservation).
+- Edit (local/dev-only, not committed): `src/content/docs/docs/about/architecture.md`.

--- a/docs/design/animated-diagrams-prototype.md
+++ b/docs/design/animated-diagrams-prototype.md
@@ -1,10 +1,12 @@
 # Design doc: animated-diagram prototype (engine + diagrams + dev-only QA)
 
-Status: Draft (prototype build plan). Not implemented.
+Status: Draft (prototype build plan). Not implemented. Revised after an adversarial
+audit (two independent auditors + codebase verification); the corrections are folded in
+below and noted where they changed a prior claim.
 Decisions: builds on `animated-diagrams.md` (the interactive "Tier 3" track) and
 ADR-0005 (adopt LikeC4). If the prototype validates and graduates, record the
-production decision as ADR-0016. No engine/DSL/schema change to alint itself; all
-code lands in the alint.org site repo.
+production decision as ADR-0016. No engine/DSL/schema change to alint itself; all code
+lands in the alint.org site repo.
 
 ## 1. Context
 
@@ -15,22 +17,26 @@ educational animated diagrams, embedded on `/docs/about/architecture/` in **dev/
 only** (never live) for hands-on QA. The point is to prove the look/feel and the
 authoring model before any production or live-docs commitment.
 
-Two facts from exploring both repos shape everything:
+Two facts from exploring both repos shape everything (all verified against the code):
 
 - alint.org is Astro + Starlight with **no framework islands** (no React/Vue/Svelte).
   Its interactivity model is **vanilla custom elements + a static loader**, exactly the
   existing LikeC4 setup: `public/likec4-loader.js` lazily injects the heavy
   `public/likec4-views.js` only on pages that embed `<likec4-view>`. So the engine is a
   **framework-free web component** mirroring that pattern, not a React island.
-- Dev-only is clean, three ways over: (1) the loader is injected only under
-  `import.meta.env.DEV`, gated in the existing `src/components/Head.astro` Starlight
-  override (`public/*.js` cannot read env, so the gate lives in the `.astro` layer);
-  (2) the page `src/content/docs/docs/about/architecture.md` is **gitignored and
-  wiped+re-synced on every build** (Cloudflare runs sync first), so local embeds can
-  never reach production; (3) the tag is absent from the deployed bundle entirely.
+- Dev-only rests on two independent mechanisms (see section 6 for the exact test):
+  (i) the loader `<script>` is emitted only under `import.meta.env.DEV`, gated in the
+  existing `src/components/Head.astro` Starlight override (`public/*.js` cannot read
+  env, so the gate lives in the `.astro` layer); (ii) the page
+  `src/content/docs/docs/about/architecture.md` is **gitignored and wiped+re-synced by
+  `sync-from-alint.mjs` on every real build** (Cloudflare runs the sync-gated `build`),
+  so local embeds can never reach production. Note the engine's static files under
+  `public/anim/` copy verbatim into `dist/anim/` on any build, but are **inert** unless
+  the DEV-gated loader references them -- so "dev-only" means "never referenced/activated
+  in production HTML," not "absent from `dist/`."
 
 The existing LikeC4 dynamic-view steps are **coarse C4 boxes**
-(`dev -> alintBin -> dsl -> core -> rules -> output`) -- too abstract for Cursor-grade
+(`dev -> alintBin -> dsl -> core -> rules -> output`) -- too abstract for the intended
 detail -- so the engine consumes a **new, richer, hand-authored declarative spec**, not
 the raw `.c4` steps. (Reusing the C4 steps and build-time SVG generation are graduation
 paths, not MVP; see section 7.)
@@ -38,13 +44,30 @@ paths, not MVP; see section 7.)
 ## 2. Approach
 
 A dependency-free web component `<alint-anim spec="...">` that renders an inline SVG from
-a declarative spec (nodes + edges + a captioned step timeline) and animates it
-Cursor-style: nodes light up as the pipeline advances, tokens (files, facts, violations)
-flow along edges, one caption per step. Transport controls (Prev / Play-Pause / Next /
-progress), full keyboard a11y, and first-class `prefers-reduced-motion`. Runtime-rendered
-like LikeC4 (gate the *spec* text, render live). Engine + specs are committed to
+a declarative spec (nodes + edges + a captioned step timeline) and animates it: nodes
+light up as the pipeline advances, tokens (files, facts, violations) flow along edges,
+one caption per step. Transport controls (Prev / Play-Pause / Next / progress), full
+keyboard a11y, and first-class `prefers-reduced-motion`. Runtime-rendered like LikeC4
+(the *spec* is the text artifact; render live). Engine + specs are committed to
 alint.org (durable); the architecture-page embeds are local/dev-only (throwaway by
 construction).
+
+Three decisions the audit pinned down, stated up front because they are load-bearing:
+
+- **Light DOM, not shadow DOM.** For a *documentation* diagram, the caption narrative and
+  the step-list are real prose a reader will Ctrl-F, select, copy, and print -- all of
+  which are unreliable inside a shadow root (find-in-page across shadow DOM is
+  inconsistent; global docs typography does not cross the boundary). Render into light
+  DOM with a scoped class prefix (`.alint-anim`), and **namespace every `<defs>` id per
+  instance** (the id/marker/gradient collision that a shadow root would otherwise hide;
+  see 3.2). CSS-custom-property theming works identically in light DOM.
+- **Author-routed edges, not auto-routed.** Real obstacle-avoiding auto-layout is the
+  Graphviz/ELK problem; a from-scratch heuristic among ~15 nodes produces spaghetti. The
+  author places nodes AND specifies edge anchors (`fromSide`/`toSide`) + optional
+  waypoints; the engine draws a smooth/elbowed path through them. See 3.7.
+- **Staged build (de-risk first).** Build the engine against **check-pipeline only**,
+  end-to-end, and iterate on look/feel + authoring ergonomics before authoring the other
+  diagrams. Freeze the schema, then author the rest. See section 4.
 
 ## 3. The engine (the rendering pipeline)
 
@@ -56,217 +79,309 @@ injects the heavier engine module on demand.
 
 | Path | Role |
 |---|---|
-| `public/anim/anim-loader.js` | Static ES5 loader; verbatim mirror of `public/likec4-loader.js`. Presence-gate `if (!document.querySelector('alint-anim')) return;`, mirror `data-theme` + `MutationObserver`, inject `<script type=module src=/anim/anim-engine.js>`. |
-| `public/anim/anim-engine.js` | `class AlintAnim extends HTMLElement` + `customElements.define`. `connectedCallback` resolves the spec, attaches an **open shadow root**, renders, wires controls + clock, picks the reduced-motion path. |
-| `public/anim/anim-render.js` | Pure SVG builder (edges/nodes/tokens layers) + the `computeFrame(spec, i)` fold + `applyFrame` class application. Returns `index: Map<id,{el,kind,path?}>`. |
-| `public/anim/anim-clock.js` | The rAF clock: `seek/next/prev/play/pause`, token spawn, `getPointAtLength` motion, stagger, chained-edge travel, `dt`-clamp, visibility/IntersectionObserver pause. |
-| `public/anim/anim-controls.js` | Transport bar (native `<button>`s, `aria-pressed` Play, `role=slider` progress, `role=group`), keyboard map, `aria-live` caption, static caption `<ol>` for reduced motion. |
-| `public/anim/anim-spec.d.ts` | The TypeScript types (3.6). Types only; give the `.js` specs autocomplete via `/** @type {...} */`; never shipped. |
-| `public/anim/specs/index.js` | Registry: `export const SPECS = { 'check-pipeline': ..., ... }`. |
+| `public/anim/anim-loader.js` | Static ES5 loader; mirror of `public/likec4-loader.js`. Presence-gate `if (!document.querySelector('alint-anim')) return;`, mirror `data-theme`, inject `<script type=module src=/anim/anim-engine.js>` once. |
+| `public/anim/anim-engine.js` | `class AlintAnim extends HTMLElement` + guarded `customElements.define`. `connectedCallback`: resolve spec -> `validateSpec()` -> render into light DOM -> wire controls + clock -> pick reduced-motion path. |
+| `public/anim/anim-render.js` | Pure SVG builder (edges/nodes/tokens layers; per-instance `<defs>` id namespacing) + `computeFrame(spec, i)` + `applyFrame`. Shared with the build-time graduation (7a). |
+| `public/anim/anim-clock.js` | The rAF clock: `seek/next/prev/play/pause`, token spawn with cached path lengths, `getPointAtLength` motion, elapsed-time pause, dt-clamp, visibility/IntersectionObserver pause. |
+| `public/anim/anim-controls.js` | Transport bar (native `<button>`s + a native `<input type=range>` progress), keyboard map, `aria-live` caption, the step `<ol>`. |
+| `public/anim/anim-validate.js` | `validateSpec(spec)`: every edge `from`/`to` and every step-referenced id resolves; returns errors. |
+| `public/anim/anim-spec.d.ts` | TypeScript types (3.6). Types only; never shipped. |
+| `public/anim/specs/index.js` | Registry `export const SPECS = {...}`. |
 | `public/anim/specs/*.js` | One hand-authored spec per diagram. |
 
-Edited (only committed edit): `src/components/Head.astro` -- after the existing appended
-tags, a dev gate mirroring how the Cloudflare beacon `<script>` is already emitted:
+Edited (only committed edit) -- `src/components/Head.astro`, after the existing
+appended tags, matching how the Cloudflare beacon `<script>` is emitted there (**`is:inline`
+is required** -- Astro bundles bare `<script>` tags and a hoisted one can silently
+vanish; the beacon and the astro.config `head[]` likec4-loader both use the raw-tag form):
 
 ```astro
 {import.meta.env.DEV && (
-  <script src="/anim/anim-loader.js" defer></script>
+  <script is:inline src="/anim/anim-loader.js" defer></script>
 )}
 ```
 
 When the prototype graduates, this line moves into `astro.config.mjs` `head[]` beside
 `likec4-loader.js` (unconditional/production; section 7).
 
-### 3.2 Web component + lifecycle
+### 3.2 Web component, lifecycle, DOM
 
 `connectedCallback`: resolve the spec (`spec="id"` -> `SPECS[id]`, or an inline
-`<script type="application/json">` child) -> attach open shadow root -> render base SVG
--> build controls -> init the clock -> pick reduced-motion vs interactive path. Guard
-double-connect; `disconnectedCallback` tears down rAF + observers.
+`<script type="application/json">` child); run `validateSpec()`; on failure render a
+visible fallback (the step `<ol>` + a bordered error note) and **do not enter the rAF
+loop**; else render the SVG into **light DOM** under a `.alint-anim` scoped wrapper, build
+controls, init the clock, pick reduced-motion vs interactive. Reserve a `min-height` on
+the host so lazy engine injection does not cause layout shift (CLS). Guard double-connect;
+`disconnectedCallback` tears down rAF + observers.
 
-**Open shadow DOM** encapsulates the controls CSS while CSS custom properties still
-inherit through the boundary -- so `var(--sl-color-*)` inside the shadow tree tracks the
-theme automatically. One inlined `<style>`.
+Light DOM means CSS could leak both ways; contain it with a single scoped stylesheet
+(`.alint-anim ...` selectors) injected once. The only thing a shadow root was buying --
+`<defs>` id isolation across multiple diagrams on one page -- is handled explicitly:
+**prefix every gradient/marker/filter/clip id with the instance id** (`arrow-<uid>`), so
+N diagrams never collide.
 
-### 3.3 Animation model (the key decision)
+### 3.3 Animation model
 
 **One `requestAnimationFrame` scalar clock** drives token-along-path motion via
-`path.getPointAtLength()`. Discrete node/edge appearance is a **pure function of the
-current step** -- a `computeFrame(spec, i)` fold. This keeps Prev/Next/seek a clean
-"compute the frame, swap the classes" with no half-finished tweens to unwind.
+`path.getPointAtLength()` (per-path `getTotalLength()` is cached once at render, not per
+frame). Discrete node/edge appearance is a function of the current step -- a
+`computeFrame(spec, i)` pass -- applied as scoped CSS classes. This keeps Prev/Next/seek a
+clean "compute the frame, swap the classes" with no half-finished tweens.
 
 Chosen over the Web Animations API (unified scrub across N concurrent animations is more
-bookkeeping, and token-along-path forces `offset-path`/pre-sampled keyframes) and over
-pure CSS transitions (backward seek and per-step scrubbing fight the declarative model;
-CSS cannot interpolate a token along a path). Manual rAF wins on the four axes that
-matter: framework-free, smooth token motion, clean pause/seek/step, and a trivial
-reduced-motion path.
+bookkeeping) and pure CSS transitions (backward seek + per-step scrub fight the
+declarative model; CSS cannot interpolate a token along a path). Manual rAF wins on the
+four axes that matter: framework-free, smooth token motion, clean pause/seek/step, and a
+trivial reduced-motion path.
 
-The fold -- every element's status is derived by folding step deltas `0..i`:
+`computeFrame` -- **corrected from the audit**: `reveal` and the visited/`done` trail are
+**monotonic** (folded over `0..i`), but `active` and `dim` are **state at step i**
+(computed from the current step, NOT folded), so a later step can freely restore a node
+to `done`/`resting` instead of being forced to over-emphasize it via `activate`:
 
 ```js
-// status in {hidden, resting, done, active, dim}
+// per-element status: hidden | resting | done | active | dim
 function computeFrame(spec, i) {
   const status = new Map();
+  // monotonic layer: reveal (hidden->present) + the visited trail (done)
   for (const n of spec.nodes) status.set(n.id, n.hidden ? 'hidden' : 'resting');
   for (const e of spec.edges) status.set(e.id, endpointHidden(spec, e) ? 'hidden' : 'resting');
   for (let s = 0; s <= i; s++) {
-    const step = spec.steps[s];
-    (step.reveal ?? []).forEach(id => { if (status.get(id) === 'hidden') status.set(id, 'resting'); });
-    (step.activate ?? []).forEach(id => status.set(id, s === i ? 'active' : 'done'));
-    (step.dim ?? []).forEach(id => status.set(id, 'dim'));
+    (spec.steps[s].reveal ?? []).forEach(id => { if (status.get(id) === 'hidden') status.set(id, 'resting'); });
+    (spec.steps[s].activate ?? []).forEach(id => status.set(id, 'done')); // trail lit
   }
-  return status; // applyFrame() toggles .is-active/.is-done/.is-dim/[hidden]
+  // current-step layer (not folded): this step's actives are strongest; its dims muted
+  (spec.steps[i].dim ?? []).forEach(id => status.set(id, 'dim'));
+  (spec.steps[i].activate ?? []).forEach(id => status.set(id, 'active'));
+  // per-step dynamic text (accumulating counts etc.) applied from the fold
+  return status;
 }
 ```
 
-`reveal` is monotonic (hidden -> present, stays); `activate` lights the current step
-strongest and leaves the traversed path lit as `done` (the "pipeline lights up as you go"
-look); `dim` explicitly de-emphasizes a branch we are past. The clock spawns `<circle>`
-tokens into a `tokens` layer per the step's `flow`, moves them along the edge path over
-`durationMs` (`performance.now()` deltas, `dt` clamped ~64ms so a tab-away does not
-teleport them), staggers multiple tokens, chains `edges: [...]` as one continuous travel,
-then removes them on settle. Tokens are ephemeral, so a seeked/settled frame never has
-partial token state -- backward is as cheap as forward.
+Visual hierarchy (specify it, the "lights up as you go" look depends on it):
+`resting` = full muted graph; `done` = brighter than resting (traversed); `active` =
+brightest + accent glow; `dim` = below resting (pushed back this step); `hidden` = absent.
 
-### 3.4 Controls, a11y, reduced motion
+Per-step **dynamic text**: nodes may carry an accumulating value (e.g. "FileIndex: 1,234
+files", "violations: 7"). A `setText` step op (3.6) overrides a node's rendered value at
+that step; the fold applies the last-set value. Static `label`/`sublabel` remain for
+fixed text.
+
+The clock spawns `<circle>` tokens per the step's `flow`, moves them along the edge path
+over `durationMs`, staggers multiple tokens, and settles (removes them). Tokens are
+ephemeral, so a seeked/settled frame never has partial token state; **clear in-flight
+tokens on any manual seek, forward Next included** (not only backward). Timing uses
+`performance.now()` deltas with `dt` clamped (~64ms) and accumulates **elapsed** time so
+pause freezes exactly (never `now - startTime`, which jumps on resume).
+
+Chained `edges: [...]` travel: **require consecutive edges to share an identical anchor
+point** on the shared node (validated by `validateSpec`), and cache per-token the
+`[path, cumulativeOffset]` list at spawn. Document whether the token passes *through* the
+shared node or dwells; default = passes through. Without the shared-anchor requirement a
+token teleports across the node at the seam.
+
+### 3.4 Controls, accessibility, reduced motion
 
 **No autoplay on connect** -- default is user-driven stepping, which satisfies WCAG 2.2.2
-(Pause/Stop/Hide, Level A) trivially. Play is an opt-in button; it never auto-starts under
-reduced motion. Controls are native `<button>`s (`aria-pressed` Play toggle), a
-`role=slider`/range progress with `aria-valuenow/min/max/text`, inside a
-`role=group aria-label`; keyboard `<-/->`, Space, Home/End, visible focus rings. The
-caption is an `aria-live="polite"` region.
+(Pause/Stop/Hide, Level A) because that criterion is triggered only by content that
+starts *automatically* (verified). Play is an opt-in button; under reduced motion it
+advances discrete snapped steps (or is disabled), never a running rAF.
 
-Under `prefers-reduced-motion: reduce`: the initial frame is the **final fold** (everything
-revealed, the whole path shown traversed, no tokens) plus a permanently-visible **numbered
-`<ol>` of every step caption** -- the full narrative without motion. Transitions are
-disabled (states snap); transport still steps instantly. This is the mandated
-static-meaningful fallback.
+- **Transport:** native `<button>`s (`aria-pressed` Play toggle) and a **native
+  `<input type="range">`** for progress (free keyboard arrows/Home/End, `aria-valuenow`,
+  and touch drag; avoids a hand-rolled `role=slider`). Wrapper `role="group"
+  aria-label="Diagram playback"`. Keyboard `<-/->`, Space, Home/End. Ensure the
+  component's global Left/Right handler does not *also* fire while the range has focus
+  (double-step). Touch targets meet WCAG 2.5.8 (>=24x24).
+- **The SVG has an accessible exposure:** `role="img"` on the diagram with an
+  `aria-label` + `aria-describedby` one-line summary; decorative token/edge layers marked
+  `aria-hidden`.
+- **The numbered step `<ol>` exists in BOTH modes** (in light DOM, so it is findable,
+  copyable, printable, and inherits docs typography). It is the structural, browsable map;
+  the `aria-live="polite"` caption announces the *current* step. Complementary, not
+  redundant (carousel status + list).
+- **Reduced motion starts at step 0** (not the final fold -- starting at the end is
+  disorienting), transitions disabled (states snap), token motion skipped; transport
+  steps instantly. The static `<ol>` gives the full narrative without motion. Captions
+  carry the flow's invariants in prose so the still frames + list are genuinely
+  meaningful.
 
 ### 3.5 Theme
 
 SVG strokes/fills use `var(--sl-color-*)` and `currentColor`; Starlight sets
 `data-theme="light|dark"` on `<html>` before first paint, so recolor on toggle is
-automatic with no per-frame JS. The loader's `data-theme` mirror is belt-and-suspenders.
+automatic with no per-frame JS (custom properties are inherited and pierce into light or
+shadow DOM -- verified). **Use the real Starlight docs tokens (never hardcode a hex; the
+`~#93a4fd` in an earlier draft was the marketing accent, not these docs tokens):**
+- accent stroke/highlight: `var(--sl-color-text-accent)` (adaptive -- light periwinkle on
+  dark, indigo on light);
+- solid accent fill (with `--sl-color-white` text): `var(--sl-color-accent)`;
+- background `var(--sl-color-bg)`; foreground `var(--sl-color-text)` / `--sl-color-white`;
+  borders `var(--sl-color-gray-5)` / `--sl-color-hairline`.
 
 ### 3.6 Spec schema
 
-Hand-placed coordinates (not auto-layout): dependency-free, art-directed, deterministic
-across builds; edges auto-route from node anchors, so authoring is "place ~15 nodes on a
-20px grid, add the occasional waypoint." Auto-layout can graduate in later if specs
-proliferate.
+Hand-placed coordinates + author-specified edge anchors (not auto-layout): dependency-free,
+art-directed, deterministic. `fromSide`/`toSide` are **restored** (the audit flagged their
+loss); `label` accepts `string | string[]` for manual line breaks; `setText` supports
+per-step dynamic values.
 
 ```ts
-type NodeKind = 'process' | 'artifact' | 'store' | 'decision' | 'terminal' | 'group';
-interface AnimNode { id; x; y; w; h; label; kind?; sublabel?; group?; hidden?; }
-interface AnimEdge { id; from; to; label?; waypoints?; kind?: 'flow'|'dep'|'back'; curve?; }
+type NodeKind = 'process'|'artifact'|'store'|'decision'|'terminal'|'group';
+type Side = 'top'|'right'|'bottom'|'left';
+interface AnimNode { id; x; y; w; h; label: string|string[]; kind?; sublabel?; group?; hidden?; }
+interface AnimEdge { id; from; to; label?; fromSide?: Side; toSide?: Side; waypoints?: {x;y}[]; kind?:'flow'|'dep'|'back'; curve?:'smooth'|'orthogonal'|'straight'; }
 interface AnimFlow { edge?; edges?; count?; spread?; reverse?; variant?; }
-interface AnimStep { caption; activate?; dim?; reveal?; flow?: AnimFlow[]; durationMs?; dwellMs?; note?; }
+interface AnimStep { caption; activate?; dim?; reveal?; flow?: AnimFlow[]; setText?: {id;text}[]; durationMs?; dwellMs?; note?; }
 interface AnimSpec { id; title; width; height; nodes: AnimNode[]; edges: AnimEdge[]; steps: AnimStep[]; defaults?; }
 ```
 
-Node shapes by `kind`: process (rounded rect), terminal (pill), store (cylinder),
-artifact (folded-corner note), decision (diamond), group (low-opacity backdrop).
+`validateSpec` (run on connect, and unit-tested per section 6) rejects: unknown ids in any
+edge/step reference, chained edges that do not share an anchor point, and empty
+nodes/steps. On failure the component renders the fallback rather than a broken SVG.
 
-### 3.7 Worked example -- the `alint check` pipeline
+### 3.7 Edge routing (author-routed) + node text
 
-`specs/check-pipeline.js`: ~15 nodes hand-placed on a 20px grid (dev, alint binary,
-`.alint.yml`, extends sources, facts, rule filter, parallel walk, FileIndex, dispatch,
-per-file rules, cross-file rules, aggregate, emit, fixers, report), ~16 auto-routed edges,
-and 11 captioned steps mirroring `docs/design/ARCHITECTURE.md`'s Execution model: run ->
-load + resolve extends (cache/cycle/SRI) -> facts (parallel) -> filter by `when` -> walk
-once -> FileIndex (deterministic sort) -> partition dispatch -> evaluate (each file read
-once; cross-file scans the index) -> aggregate Violations -> fix (serial) -> emit + exit.
-The captions carry the four invariants visually: **walk once** (one walk step), **read
-each file once** (single file token per file), **facts + rules parallel** (concurrent
-tokens), **fixers serial** (one slow token). This spec exercises every schema field
-(`activate`, `dim`, `reveal` of hidden nodes/edges, single + staggered multi-token
-`flow`, chained `edges[]`, per-step `durationMs`, `variant` token styles, `waypoints`,
-every `NodeKind`) and is the reference for authoring the rest.
+Not auto-routing. Each edge draws from `from`'s `fromSide` anchor, through any
+`waypoints`, to `to`'s `toSide` anchor, as a `curve` (`smooth` = quadratic/cubic through
+the points; `orthogonal` = rounded elbows; `straight`). Default side (when a hint is
+absent) is the geometric nearest, but the author is expected to set sides on any edge that
+would otherwise cross a node. When several edges share a node side, distribute their
+anchor points along that side by index (port offset) so they do not stack. Token motion
+then follows exactly the path the author sees (3.3).
 
-### 3.8 Gotchas (established, must-honor)
+Node text does not wrap in SVG `<text>`; author labels as `string[]` for explicit
+`<tspan>` line breaks, and keep `w`/`h` sized for the longest line (a QA pass checks for
+overflow against the real terminology, e.g. ".alint.yml + extends sources").
+
+### 3.8 Worked example -- the `alint check` pipeline (Phase 0)
+
+`specs/check-pipeline.js`: ~15 nodes hand-placed (dev, alint binary, `.alint.yml`, extends
+sources, facts, rule filter, parallel walk, FileIndex, dispatch, per-file rules,
+cross-file rules, aggregate, emit, fixers, report), ~16 author-routed edges (with
+`fromSide`/`toSide`), and ~11 captioned steps mirroring `docs/design/ARCHITECTURE.md`'s
+Execution model. Captions carry the four invariants visually: **walk once** (one walk
+step), **read each file once** (single file token per file), **facts + rules parallel**
+(concurrent tokens), **fixers serial** (one slow token). This is the **Phase 0** diagram:
+build the whole engine against it, iterate on legibility, edge routing, timing, and
+authoring ergonomics, and only then freeze the schema and author the rest. Coordinates
+will need visual iteration -- they cannot be validated as readable without rendering.
+
+### 3.9 Responsive + overflow
+
+The specs use a fixed viewBox (~1000x520); SVG scales to container width, so on a phone a
+15-node diagram shrinks ~3x and labels turn illegible. Strategy: below a breakpoint wrap
+the SVG in an `overflow-x: auto` scroller that preserves a minimum legible text size (with
+a subtle "scroll to see more" affordance), rather than shrinking to fit. The transport bar
+wraps/stacks on narrow widths; the caption wraps. This is part of Phase 0 QA, on a real
+phone viewport.
+
+### 3.10 Gotchas (established, must-honor)
 
 - **Node scaling:** position the node **group** via the `transform="translate(x y)"`
-  *attribute* and scale the **inner** box via CSS with `transform-box: fill-box;
-  transform-origin: center` (a CSS transform *replaces* the presentation attribute, so use
+  attribute and scale the **inner** box via CSS with `transform-box: fill-box;
+  transform-origin: center` (a CSS transform replaces the presentation attribute, so use
   different elements).
 - **Never animate path `d`** (SMIL banned; CSS `d` support uneven). Draw an edge in via
-  `stroke-dashoffset`; move a token *along* the static path via `getPointAtLength`.
-- **Token motion:** `getTotalLength()` + `getPointAtLength()` set the token's `translate`
-  each frame. Avoid `offset-path`/`offset-distance` for the prototype (historical Safari/
-  Firefox gaps + coordinate-origin friction).
-- **rAF hygiene:** `performance.now()` deltas, clamp `dt`, pause on `visibilitychange`
-  hidden + off-screen via `IntersectionObserver`, `cancelAnimationFrame` on disconnect.
+  `stroke-dashoffset`; move a token along the static path via `getPointAtLength`.
+- **Token motion:** cache `getTotalLength()` once at render; `getPointAtLength()` per frame
+  sets the token `translate`. `getPointAtLength` is universally supported;
+  `offset-path` is avoided for coordinate-origin friction (its old browser gaps are now
+  moot, but the friction reason stands).
+- **rAF hygiene:** elapsed-time accumulation (pause freezes), clamp `dt`, pause on
+  `visibilitychange` hidden + off-screen via `IntersectionObserver`, `cancelAnimationFrame`
+  on disconnect. Wrap the rAF body so one bad frame cannot wedge the clock. For several
+  diagrams, a single shared rAF ticker iterating active instances is preferable to N
+  loops (IO-pausing offscreen ones makes either acceptable at MVP scale).
 
-## 4. The diagrams (specs)
+## 4. The diagrams (specs), staged
 
-Hand-authored specs grounded in `docs/design/ARCHITECTURE.md` prose. Aesthetic:
-monochrome line-art + accent `--sl-color-accent` (~`#93a4fd`), Cursor-style token
-variants (file/fact/violation). MVP set (3 core + 1 stretch), each teaching a distinct
-hot-path concept and mapping to an architecture-page section:
+Staged to de-risk the engine before multiplying work across specs:
 
-1. **`check-pipeline`** (hero; worked spec in 3.7) -- host section `## Execution model`.
-2. **`walker-gitignore`** -- parallel walk (WalkBuilder) -> honor `.gitignore`/
-   `.alintignore`/`ignore:` globs (files dropped) -> merge thread-local vecs +
-   deterministic sort -> build lazy indices. Host `## Execution model` (walk step,
-   currently prose-only -- net-new embed).
-3. **`dispatch-partition`** -- partition rules (`requires_full_index()` -> rule-major;
-   else per-file); file-major loop reads each file once and fans out to every applicable
-   `PerFileRule`; cross-file rules scan the index; merge + sort. Host `## Rule model` /
-   `### Dispatch flip`.
-4. *(stretch)* **`monorepo-scoping`** -- nested `.alint.yml` discovery + closest-ancestor
-   `scope_filter: has_ancestor` walk gating a rule per file. Host `### Closest-ancestor
-   scoping`.
+- **Phase 0:** engine + **`check-pipeline`** only, end-to-end (real author-routed edges,
+  tokens, chained travel, controls, reduced-motion, responsive). Iterate until the look is
+  right and authoring is ergonomic; this surfaces edge-routing, fold, and token issues
+  once, not four times. Host section `## Execution model`.
+- **Phase 1 (after freezing the schema):**
+  - `walker-gitignore` -- parallel walk -> honor `.gitignore`/`.alintignore`/`ignore:`
+    globs (files dropped) -> merge + deterministic sort -> lazy indices. Host `## Execution
+    model` (net-new embed).
+  - `dispatch-partition` -- partition rules (rule-major vs per-file); file-major loop reads
+    each file once and fans out; cross-file scans the index. Host `### Dispatch flip`.
+  - *(stretch)* `monorepo-scoping` -- nested `.alint.yml` + closest-ancestor `scope_filter`
+    walk. Host `### Closest-ancestor scoping`.
+
+Aesthetic target, stated honestly: **clean, legible, on-brand animated line diagrams**
+(monochrome + `--sl-color-text-accent`, Cursor-style token variants file/fact/violation).
+Matching Cursor's *designer-crafted* polish (custom easing, glow, token trails, bespoke
+timing) is a visual-iteration cost; budget explicit iteration cycles in Phase 0 rather
+than asserting "Cursor-grade" up front.
 
 ## 5. Dev-only embedding + QA
 
 - Add the `Head.astro` dev gate (3.1).
 - Embed `<alint-anim spec="..."></alint-anim>` in the **local**
-  `src/content/docs/docs/about/architecture.md` in the relevant sections (alongside or in
-  place of a static `<likec4-view>` where an animation teaches more). Gitignored +
-  sync-overwritten, so embeds are dev-only by construction.
-- Because that file is wiped on sync, an optional idempotent
-  `scripts/inject-anim-demos.mjs` (git-tracked dev helper) re-applies the demo embeds
-  after a sync, so QA is reproducible without hand-re-editing.
-- QA with `astro dev` (Node via nvm: `. ~/.nvm/nvm.sh && nvm use default`).
+  `src/content/docs/docs/about/architecture.md` in the relevant sections (verified present
+  locally, with the target section anchors). Gitignored + wiped by the sync-gated build, so
+  embeds are dev-only by construction; the local `astro dev` server never runs sync, so the
+  hand-added embeds simply persist between runs (the local `npm run sync` is Node-broken,
+  so nothing wipes them locally -- a dedicated re-apply helper is therefore unnecessary).
+- QA with `astro dev` under nvm (`. ~/.nvm/nvm.sh && nvm use default`; the shell's default
+  Node is too old).
 
 ## 6. Verification (end-to-end)
 
 At `astro dev`, load `/docs/about/architecture/`, per diagram confirm: renders inline SVG;
-Prev/Next/Play/Pause and progress work; captions update in the `aria-live` region; tokens
-flow; concurrent tokens read as parallel and the serial-fixer step as one slow token;
-light/dark recolors with no reflow/flash; emulated `prefers-reduced-motion` shows the
-static final-fold + numbered caption list with no autoplay; keyboard controls work; no
-console errors; the loader is inert on pages with no `<alint-anim>`.
+Prev/Next/Play/Pause and the range progress work; captions update in the `aria-live`
+region and the step `<ol>` is present + findable via Ctrl-F; tokens flow; concurrent
+tokens read as parallel and the serial-fixer step as one slow token; light/dark recolors
+with no reflow; emulated `prefers-reduced-motion` starts at step 0, no autoplay, static
+`<ol>` narrative; keyboard controls + no double-step; a bad spec id renders the fallback,
+not a broken SVG or a console-spamming dead clock; responsive on a phone viewport; no CLS
+on load; the loader is inert on pages with no `<alint-anim>`.
 
-Then confirm **production exclusion**: `npm run build:no-sync` (astro build, DEV=false) and
-grep `dist/` to prove `/anim/anim-loader.js` is NOT referenced and no `<alint-anim>`
-survives. This is the "not live" guarantee.
+**Automated tests (add now, not at graduation):** unit-test `computeFrame(spec, i)`
+status maps; a Node test that asserts **every registered spec passes `validateSpec`**; a
+headless smoke that each spec builds its SVG without throwing.
+
+**Production-exclusion test (corrected).** The prior `build:no-sync` + grep check was
+wrong: `build:no-sync` is bare `astro build` (skips sync), so it does NOT wipe the local
+embeds, and `public/anim/*.js` copy into `dist/anim/` on any build -- so the tags survive
+and the static files are always present. The correct checks:
+- **Structural (primary, no build needed):** the embeds live only in the gitignored,
+  sync-overwritten `architecture.md`, and the loader `<script>` is emitted only under
+  `import.meta.env.DEV`. Both are inspectable facts; neither reaches a production build.
+- **Full-build confirmation:** run **`npm run build`** (the sync-gated production build)
+  under nvm, then grep `dist/**/*.html` only, asserting (i) no `<alint-anim` element and
+  (ii) no `<script>` referencing `/anim/anim-loader.js`. (Sync wipes the embeds; the
+  DEV gate omits the loader.) Caveat: the full build clones the docs bundle and runs a
+  network freshness cross-check that can fail if the site's version pin is ahead of the
+  bundle -- if that blocks locally, the structural check above is authoritative. Do not use
+  `build:no-sync` for this proof; grepping all of `dist/` for the static `/anim/` files
+  will always match and is not evidence of a leak.
 
 ## 7. Scope boundaries and graduation paths (NOT in the MVP)
 
 - **Build-time deterministic-SVG variant** (graduation (a)): a `scripts/` Node script
   (mirroring `scripts/build-likec4.mjs`, already chained in `npm run build`) imports the
-  same `specs/*.js` and a shared headless render function and emits a static, fully-
-  labelled SVG (final fold + caption list) -- a no-JS/print/GitHub rendering and a
-  deterministic artifact for perf-gating. Runtime engine and build script share one render
-  core so they cannot diverge.
+  same `specs/*.js` and the shared `anim-render.js` core and emits a static, fully-labelled
+  SVG (final fold + caption list) -- a no-JS/print/GitHub rendering and a deterministic
+  artifact for perf-gating. Runtime engine and build script share one render core so they
+  cannot diverge.
 - **Live docs** (graduation (b)): move the dev gate into `astro.config.mjs` `head[]`
   (unconditional) and author embeds in the alint repo's `docs/design/ARCHITECTURE.md` so
   they flow through the docs-bundle pipeline. Caveat (already documented for LikeC4):
   GitHub strips the custom element, so the build-time static SVG from (a) is what renders
   on GitHub, while alint.org shows the animated version.
-- No auto-layout (hand-placed coordinates), no LikeC4-derived specs (the C4 steps are too
-  coarse), **no new npm dependencies** (dependency-free). Engine + specs are committed to
-  alint.org only; nothing lands in the alint repo or the live site in this prototype.
+- No auto-layout (author-routed), no LikeC4-derived specs (the C4 steps are too coarse),
+  **no new npm dependencies** (dependency-free). Engine + specs are committed to alint.org
+  only; nothing lands in the alint repo or the live site in this prototype.
 
 ## 8. Files
 
 - Create in alint.org: `public/anim/{anim-loader,anim-engine,anim-render,anim-clock,
-  anim-controls}.js`, `public/anim/anim-spec.d.ts`, `public/anim/specs/index.js`,
-  `public/anim/specs/{check-pipeline,walker-gitignore,dispatch-partition,
-  monorepo-scoping}.js`, optional `scripts/inject-anim-demos.mjs`.
-- Edit (committed): `src/components/Head.astro` (the dev-gate line).
+  anim-controls,anim-validate}.js`, `public/anim/anim-spec.d.ts`, `public/anim/specs/
+  index.js`, `public/anim/specs/{check-pipeline,walker-gitignore,dispatch-partition,
+  monorepo-scoping}.js`, plus unit tests (`*.test.mjs`).
+- Edit (committed): `src/components/Head.astro` (the `is:inline` dev-gate line).
 - Edit (local/dev-only, not committed): `src/content/docs/docs/about/architecture.md`
   (demo embeds).

--- a/docs/design/animated-diagrams-prototype.md
+++ b/docs/design/animated-diagrams-prototype.md
@@ -1,0 +1,272 @@
+# Design doc: animated-diagram prototype (engine + diagrams + dev-only QA)
+
+Status: Draft (prototype build plan). Not implemented.
+Decisions: builds on `animated-diagrams.md` (the interactive "Tier 3" track) and
+ADR-0005 (adopt LikeC4). If the prototype validates and graduates, record the
+production decision as ADR-0016. No engine/DSL/schema change to alint itself; all
+code lands in the alint.org site repo.
+
+## 1. Context
+
+`animated-diagrams.md` proposed adding Cursor-style animated diagrams to the docs and
+recommended a three-tier track. This is the build plan for a **prototype/MVP** that
+validates the most interactive tier: a reusable rendering engine plus a few real,
+educational animated diagrams, embedded on `/docs/about/architecture/` in **dev/local
+only** (never live) for hands-on QA. The point is to prove the look/feel and the
+authoring model before any production or live-docs commitment.
+
+Two facts from exploring both repos shape everything:
+
+- alint.org is Astro + Starlight with **no framework islands** (no React/Vue/Svelte).
+  Its interactivity model is **vanilla custom elements + a static loader**, exactly the
+  existing LikeC4 setup: `public/likec4-loader.js` lazily injects the heavy
+  `public/likec4-views.js` only on pages that embed `<likec4-view>`. So the engine is a
+  **framework-free web component** mirroring that pattern, not a React island.
+- Dev-only is clean, three ways over: (1) the loader is injected only under
+  `import.meta.env.DEV`, gated in the existing `src/components/Head.astro` Starlight
+  override (`public/*.js` cannot read env, so the gate lives in the `.astro` layer);
+  (2) the page `src/content/docs/docs/about/architecture.md` is **gitignored and
+  wiped+re-synced on every build** (Cloudflare runs sync first), so local embeds can
+  never reach production; (3) the tag is absent from the deployed bundle entirely.
+
+The existing LikeC4 dynamic-view steps are **coarse C4 boxes**
+(`dev -> alintBin -> dsl -> core -> rules -> output`) -- too abstract for Cursor-grade
+detail -- so the engine consumes a **new, richer, hand-authored declarative spec**, not
+the raw `.c4` steps. (Reusing the C4 steps and build-time SVG generation are graduation
+paths, not MVP; see section 7.)
+
+## 2. Approach
+
+A dependency-free web component `<alint-anim spec="...">` that renders an inline SVG from
+a declarative spec (nodes + edges + a captioned step timeline) and animates it
+Cursor-style: nodes light up as the pipeline advances, tokens (files, facts, violations)
+flow along edges, one caption per step. Transport controls (Prev / Play-Pause / Next /
+progress), full keyboard a11y, and first-class `prefers-reduced-motion`. Runtime-rendered
+like LikeC4 (gate the *spec* text, render live). Engine + specs are committed to
+alint.org (durable); the architecture-page embeds are local/dev-only (throwaway by
+construction).
+
+## 3. The engine (the rendering pipeline)
+
+All net-new under `public/anim/` (native ES modules served verbatim, no build step),
+plus one guarded line in `Head.astro`. Mirrors the LikeC4 split: a tiny static loader
+injects the heavier engine module on demand.
+
+### 3.1 File layout
+
+| Path | Role |
+|---|---|
+| `public/anim/anim-loader.js` | Static ES5 loader; verbatim mirror of `public/likec4-loader.js`. Presence-gate `if (!document.querySelector('alint-anim')) return;`, mirror `data-theme` + `MutationObserver`, inject `<script type=module src=/anim/anim-engine.js>`. |
+| `public/anim/anim-engine.js` | `class AlintAnim extends HTMLElement` + `customElements.define`. `connectedCallback` resolves the spec, attaches an **open shadow root**, renders, wires controls + clock, picks the reduced-motion path. |
+| `public/anim/anim-render.js` | Pure SVG builder (edges/nodes/tokens layers) + the `computeFrame(spec, i)` fold + `applyFrame` class application. Returns `index: Map<id,{el,kind,path?}>`. |
+| `public/anim/anim-clock.js` | The rAF clock: `seek/next/prev/play/pause`, token spawn, `getPointAtLength` motion, stagger, chained-edge travel, `dt`-clamp, visibility/IntersectionObserver pause. |
+| `public/anim/anim-controls.js` | Transport bar (native `<button>`s, `aria-pressed` Play, `role=slider` progress, `role=group`), keyboard map, `aria-live` caption, static caption `<ol>` for reduced motion. |
+| `public/anim/anim-spec.d.ts` | The TypeScript types (3.6). Types only; give the `.js` specs autocomplete via `/** @type {...} */`; never shipped. |
+| `public/anim/specs/index.js` | Registry: `export const SPECS = { 'check-pipeline': ..., ... }`. |
+| `public/anim/specs/*.js` | One hand-authored spec per diagram. |
+
+Edited (only committed edit): `src/components/Head.astro` -- after the existing appended
+tags, a dev gate mirroring how the Cloudflare beacon `<script>` is already emitted:
+
+```astro
+{import.meta.env.DEV && (
+  <script src="/anim/anim-loader.js" defer></script>
+)}
+```
+
+When the prototype graduates, this line moves into `astro.config.mjs` `head[]` beside
+`likec4-loader.js` (unconditional/production; section 7).
+
+### 3.2 Web component + lifecycle
+
+`connectedCallback`: resolve the spec (`spec="id"` -> `SPECS[id]`, or an inline
+`<script type="application/json">` child) -> attach open shadow root -> render base SVG
+-> build controls -> init the clock -> pick reduced-motion vs interactive path. Guard
+double-connect; `disconnectedCallback` tears down rAF + observers.
+
+**Open shadow DOM** encapsulates the controls CSS while CSS custom properties still
+inherit through the boundary -- so `var(--sl-color-*)` inside the shadow tree tracks the
+theme automatically. One inlined `<style>`.
+
+### 3.3 Animation model (the key decision)
+
+**One `requestAnimationFrame` scalar clock** drives token-along-path motion via
+`path.getPointAtLength()`. Discrete node/edge appearance is a **pure function of the
+current step** -- a `computeFrame(spec, i)` fold. This keeps Prev/Next/seek a clean
+"compute the frame, swap the classes" with no half-finished tweens to unwind.
+
+Chosen over the Web Animations API (unified scrub across N concurrent animations is more
+bookkeeping, and token-along-path forces `offset-path`/pre-sampled keyframes) and over
+pure CSS transitions (backward seek and per-step scrubbing fight the declarative model;
+CSS cannot interpolate a token along a path). Manual rAF wins on the four axes that
+matter: framework-free, smooth token motion, clean pause/seek/step, and a trivial
+reduced-motion path.
+
+The fold -- every element's status is derived by folding step deltas `0..i`:
+
+```js
+// status in {hidden, resting, done, active, dim}
+function computeFrame(spec, i) {
+  const status = new Map();
+  for (const n of spec.nodes) status.set(n.id, n.hidden ? 'hidden' : 'resting');
+  for (const e of spec.edges) status.set(e.id, endpointHidden(spec, e) ? 'hidden' : 'resting');
+  for (let s = 0; s <= i; s++) {
+    const step = spec.steps[s];
+    (step.reveal ?? []).forEach(id => { if (status.get(id) === 'hidden') status.set(id, 'resting'); });
+    (step.activate ?? []).forEach(id => status.set(id, s === i ? 'active' : 'done'));
+    (step.dim ?? []).forEach(id => status.set(id, 'dim'));
+  }
+  return status; // applyFrame() toggles .is-active/.is-done/.is-dim/[hidden]
+}
+```
+
+`reveal` is monotonic (hidden -> present, stays); `activate` lights the current step
+strongest and leaves the traversed path lit as `done` (the "pipeline lights up as you go"
+look); `dim` explicitly de-emphasizes a branch we are past. The clock spawns `<circle>`
+tokens into a `tokens` layer per the step's `flow`, moves them along the edge path over
+`durationMs` (`performance.now()` deltas, `dt` clamped ~64ms so a tab-away does not
+teleport them), staggers multiple tokens, chains `edges: [...]` as one continuous travel,
+then removes them on settle. Tokens are ephemeral, so a seeked/settled frame never has
+partial token state -- backward is as cheap as forward.
+
+### 3.4 Controls, a11y, reduced motion
+
+**No autoplay on connect** -- default is user-driven stepping, which satisfies WCAG 2.2.2
+(Pause/Stop/Hide, Level A) trivially. Play is an opt-in button; it never auto-starts under
+reduced motion. Controls are native `<button>`s (`aria-pressed` Play toggle), a
+`role=slider`/range progress with `aria-valuenow/min/max/text`, inside a
+`role=group aria-label`; keyboard `<-/->`, Space, Home/End, visible focus rings. The
+caption is an `aria-live="polite"` region.
+
+Under `prefers-reduced-motion: reduce`: the initial frame is the **final fold** (everything
+revealed, the whole path shown traversed, no tokens) plus a permanently-visible **numbered
+`<ol>` of every step caption** -- the full narrative without motion. Transitions are
+disabled (states snap); transport still steps instantly. This is the mandated
+static-meaningful fallback.
+
+### 3.5 Theme
+
+SVG strokes/fills use `var(--sl-color-*)` and `currentColor`; Starlight sets
+`data-theme="light|dark"` on `<html>` before first paint, so recolor on toggle is
+automatic with no per-frame JS. The loader's `data-theme` mirror is belt-and-suspenders.
+
+### 3.6 Spec schema
+
+Hand-placed coordinates (not auto-layout): dependency-free, art-directed, deterministic
+across builds; edges auto-route from node anchors, so authoring is "place ~15 nodes on a
+20px grid, add the occasional waypoint." Auto-layout can graduate in later if specs
+proliferate.
+
+```ts
+type NodeKind = 'process' | 'artifact' | 'store' | 'decision' | 'terminal' | 'group';
+interface AnimNode { id; x; y; w; h; label; kind?; sublabel?; group?; hidden?; }
+interface AnimEdge { id; from; to; label?; waypoints?; kind?: 'flow'|'dep'|'back'; curve?; }
+interface AnimFlow { edge?; edges?; count?; spread?; reverse?; variant?; }
+interface AnimStep { caption; activate?; dim?; reveal?; flow?: AnimFlow[]; durationMs?; dwellMs?; note?; }
+interface AnimSpec { id; title; width; height; nodes: AnimNode[]; edges: AnimEdge[]; steps: AnimStep[]; defaults?; }
+```
+
+Node shapes by `kind`: process (rounded rect), terminal (pill), store (cylinder),
+artifact (folded-corner note), decision (diamond), group (low-opacity backdrop).
+
+### 3.7 Worked example -- the `alint check` pipeline
+
+`specs/check-pipeline.js`: ~15 nodes hand-placed on a 20px grid (dev, alint binary,
+`.alint.yml`, extends sources, facts, rule filter, parallel walk, FileIndex, dispatch,
+per-file rules, cross-file rules, aggregate, emit, fixers, report), ~16 auto-routed edges,
+and 11 captioned steps mirroring `docs/design/ARCHITECTURE.md`'s Execution model: run ->
+load + resolve extends (cache/cycle/SRI) -> facts (parallel) -> filter by `when` -> walk
+once -> FileIndex (deterministic sort) -> partition dispatch -> evaluate (each file read
+once; cross-file scans the index) -> aggregate Violations -> fix (serial) -> emit + exit.
+The captions carry the four invariants visually: **walk once** (one walk step), **read
+each file once** (single file token per file), **facts + rules parallel** (concurrent
+tokens), **fixers serial** (one slow token). This spec exercises every schema field
+(`activate`, `dim`, `reveal` of hidden nodes/edges, single + staggered multi-token
+`flow`, chained `edges[]`, per-step `durationMs`, `variant` token styles, `waypoints`,
+every `NodeKind`) and is the reference for authoring the rest.
+
+### 3.8 Gotchas (established, must-honor)
+
+- **Node scaling:** position the node **group** via the `transform="translate(x y)"`
+  *attribute* and scale the **inner** box via CSS with `transform-box: fill-box;
+  transform-origin: center` (a CSS transform *replaces* the presentation attribute, so use
+  different elements).
+- **Never animate path `d`** (SMIL banned; CSS `d` support uneven). Draw an edge in via
+  `stroke-dashoffset`; move a token *along* the static path via `getPointAtLength`.
+- **Token motion:** `getTotalLength()` + `getPointAtLength()` set the token's `translate`
+  each frame. Avoid `offset-path`/`offset-distance` for the prototype (historical Safari/
+  Firefox gaps + coordinate-origin friction).
+- **rAF hygiene:** `performance.now()` deltas, clamp `dt`, pause on `visibilitychange`
+  hidden + off-screen via `IntersectionObserver`, `cancelAnimationFrame` on disconnect.
+
+## 4. The diagrams (specs)
+
+Hand-authored specs grounded in `docs/design/ARCHITECTURE.md` prose. Aesthetic:
+monochrome line-art + accent `--sl-color-accent` (~`#93a4fd`), Cursor-style token
+variants (file/fact/violation). MVP set (3 core + 1 stretch), each teaching a distinct
+hot-path concept and mapping to an architecture-page section:
+
+1. **`check-pipeline`** (hero; worked spec in 3.7) -- host section `## Execution model`.
+2. **`walker-gitignore`** -- parallel walk (WalkBuilder) -> honor `.gitignore`/
+   `.alintignore`/`ignore:` globs (files dropped) -> merge thread-local vecs +
+   deterministic sort -> build lazy indices. Host `## Execution model` (walk step,
+   currently prose-only -- net-new embed).
+3. **`dispatch-partition`** -- partition rules (`requires_full_index()` -> rule-major;
+   else per-file); file-major loop reads each file once and fans out to every applicable
+   `PerFileRule`; cross-file rules scan the index; merge + sort. Host `## Rule model` /
+   `### Dispatch flip`.
+4. *(stretch)* **`monorepo-scoping`** -- nested `.alint.yml` discovery + closest-ancestor
+   `scope_filter: has_ancestor` walk gating a rule per file. Host `### Closest-ancestor
+   scoping`.
+
+## 5. Dev-only embedding + QA
+
+- Add the `Head.astro` dev gate (3.1).
+- Embed `<alint-anim spec="..."></alint-anim>` in the **local**
+  `src/content/docs/docs/about/architecture.md` in the relevant sections (alongside or in
+  place of a static `<likec4-view>` where an animation teaches more). Gitignored +
+  sync-overwritten, so embeds are dev-only by construction.
+- Because that file is wiped on sync, an optional idempotent
+  `scripts/inject-anim-demos.mjs` (git-tracked dev helper) re-applies the demo embeds
+  after a sync, so QA is reproducible without hand-re-editing.
+- QA with `astro dev` (Node via nvm: `. ~/.nvm/nvm.sh && nvm use default`).
+
+## 6. Verification (end-to-end)
+
+At `astro dev`, load `/docs/about/architecture/`, per diagram confirm: renders inline SVG;
+Prev/Next/Play/Pause and progress work; captions update in the `aria-live` region; tokens
+flow; concurrent tokens read as parallel and the serial-fixer step as one slow token;
+light/dark recolors with no reflow/flash; emulated `prefers-reduced-motion` shows the
+static final-fold + numbered caption list with no autoplay; keyboard controls work; no
+console errors; the loader is inert on pages with no `<alint-anim>`.
+
+Then confirm **production exclusion**: `npm run build:no-sync` (astro build, DEV=false) and
+grep `dist/` to prove `/anim/anim-loader.js` is NOT referenced and no `<alint-anim>`
+survives. This is the "not live" guarantee.
+
+## 7. Scope boundaries and graduation paths (NOT in the MVP)
+
+- **Build-time deterministic-SVG variant** (graduation (a)): a `scripts/` Node script
+  (mirroring `scripts/build-likec4.mjs`, already chained in `npm run build`) imports the
+  same `specs/*.js` and a shared headless render function and emits a static, fully-
+  labelled SVG (final fold + caption list) -- a no-JS/print/GitHub rendering and a
+  deterministic artifact for perf-gating. Runtime engine and build script share one render
+  core so they cannot diverge.
+- **Live docs** (graduation (b)): move the dev gate into `astro.config.mjs` `head[]`
+  (unconditional) and author embeds in the alint repo's `docs/design/ARCHITECTURE.md` so
+  they flow through the docs-bundle pipeline. Caveat (already documented for LikeC4):
+  GitHub strips the custom element, so the build-time static SVG from (a) is what renders
+  on GitHub, while alint.org shows the animated version.
+- No auto-layout (hand-placed coordinates), no LikeC4-derived specs (the C4 steps are too
+  coarse), **no new npm dependencies** (dependency-free). Engine + specs are committed to
+  alint.org only; nothing lands in the alint repo or the live site in this prototype.
+
+## 8. Files
+
+- Create in alint.org: `public/anim/{anim-loader,anim-engine,anim-render,anim-clock,
+  anim-controls}.js`, `public/anim/anim-spec.d.ts`, `public/anim/specs/index.js`,
+  `public/anim/specs/{check-pipeline,walker-gitignore,dispatch-partition,
+  monorepo-scoping}.js`, optional `scripts/inject-anim-demos.mjs`.
+- Edit (committed): `src/components/Head.astro` (the dev-gate line).
+- Edit (local/dev-only, not committed): `src/content/docs/docs/about/architecture.md`
+  (demo embeds).


### PR DESCRIPTION
Companion to the #204 proposal: the build plan for the interactive animated-diagram tier, `docs/design/animated-diagrams-prototype.md`. **Hardened across two adversarial audit rounds** (independent auditors + codebase verification).

The engine is a framework-free web component `<alint-anim>` mirroring the LikeC4 loader pattern: one rAF clock + a `computeFrame(step) -> {status, text}` fold, a **string-first** render core (Node-testable + shareable with the build-time graduation), `getPointAtLength` token motion, `var(--sl-color-*)` theming, light DOM + `class="not-content"` (Starlight opt-out), no-autoplay a11y. **Dev-only by construction** (DEV-gated loader + gitignored/sync-wiped page).

**Round 1** corrected: the broken `build:no-sync` verification, hand-waved "auto-routing" (→ author-routed with `fromSide/toSide`), scope staging, wrong accent token, missing `is:inline`, shadow→light DOM, responsive/overflow, `validateSpec`, a11y.

**Round 2** corrected holes in those very fixes plus a staging problem:
- **Added a Phase -1 throwaway aesthetic spike** (1 day, standalone HTML) that *gates* the engine — the expensive "does it look good / earn its keep" question, answered first. Framed honestly as a reusable product with a11y deferred to graduation-readiness.
- **`setText` was a dead comment** → `computeFrame` returns `{status, text}` + tested; **`fromSide/toSide` created a chained-edge coupling bug** → shared `resolveAnchor()`; **`.not-content`** needed (Starlight descendant rules + cascade layers reach into light DOM); **CLS `min-height`** moved to eager `custom.css`.
- **Tests moved out of `public/`** (would ship to `dist/`, crawlable) + wired to CI; **string-first render** (no jsdom); `.d.ts` JSDoc-only; evergreen baseline; `public/` has no HMR; step-granular scrubber + `aria-valuetext`; reduced-motion Play disabled.

Design doc only; all code would land in alint.org, nothing touches the alint engine or live site.