### PR TITLE
fix(rulesets): exempt local ./ and digest-pinned Docker refs from gha-pin-actions-to-sha (#208)

### DIFF
--- a/.alint.yml
+++ b/.alint.yml
@@ -127,6 +127,10 @@ rules:
     message: "The Cargo build directory `target/` must not be tracked."
 
   # --- Naming -------------------------------------------------------------
+  # `rust-sources-snake-case` is a deliberately-narrowed twin of the bundled
+  # `rust@v1` rule (scoped to this workspace's `crates/**/src`; the bundled copy
+  # is repo-agnostic `**/src/**` plus compiler-fixture excludes that no-op here).
+  # The dogfood/bundled drift gate (dogfood_bundled_no_drift.rs) allowlists it.
   - id: rust-sources-snake-case
     kind: filename_case
     paths: "crates/**/src/**/*.rs"

--- a/.alint.yml
+++ b/.alint.yml
@@ -438,7 +438,7 @@ rules:
       - ".github/workflows/*.yml"
       - ".github/workflows/*.yaml"
     path: "$.jobs.*.steps[*].uses"
-    matches: '^(\./.*|[a-zA-Z0-9._/-]+@[a-f0-9]{40})$'
+    matches: '^(\./.*|docker://[^@]+@sha256:[a-f0-9]{64}|[a-zA-Z0-9._/-]+@[a-f0-9]{40})$'
     if_present: true
     level: error
     message: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- The bundled `ci/github-actions@v1` ruleset's `gha-pin-actions-to-sha` rule no
+  longer flags **local composite-action references** (`uses: ./...`). Local actions
+  live in the same repo (the same trust boundary) and cannot be SHA-pinned; the rule
+  now exempts any `./`-prefixed `uses:` value, matching the exemption alint's own
+  dogfooded copy already carried. Reported by @ivml.
+  ([#208](https://github.com/asamarts/alint/issues/208))
+
 ## [0.15.2] - 2026-08-22
 
 A release-infrastructure patch: the alint binary and rules are unchanged from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   now exempts any `./`-prefixed `uses:` value, matching the exemption alint's own
   dogfooded copy already carried. Reported by @ivml.
   ([#208](https://github.com/asamarts/alint/issues/208))
+- The same `gha-pin-actions-to-sha` rule no longer flags **digest-pinned Docker
+  actions** (`uses: docker://img@sha256:<64-hex>`). A digest is an immutable pin, so it
+  is exempt; a tag-pinned `docker://img:tag` still fires.
 
 ## [0.15.2] - 2026-08-22
 

--- a/crates/alint-dsl/rulesets/v1/ci/github-actions.yml
+++ b/crates/alint-dsl/rulesets/v1/ci/github-actions.yml
@@ -51,16 +51,20 @@ rules:
     # `@v4`, `@main`, or `@v4.1.1`. Teams that trust specific
     # publishers (e.g. `actions/*`) typically tighten or relax
     # via a follow-up rule.
+    #
+    # Local `./` composite-action references are exempt: they live in
+    # the same repo (same trust boundary) and cannot be SHA-pinned.
     kind: yaml_path_matches
     paths: [".github/workflows/*.yml", ".github/workflows/*.yaml"]
     path: "$.jobs.*.steps[*].uses"
-    matches: '^[a-zA-Z0-9._/-]+@[a-f0-9]{40}$'
+    matches: '^(\./.*|[a-zA-Z0-9._/-]+@[a-f0-9]{40})$'
     if_present: true
     level: warning
     message: >-
       Third-party action is not pinned to a commit SHA. Pin with
       `@<40-char-sha>  # v4.1.1` so a compromised tag can't
-      silently change what runs.
+      silently change what runs. Local `./` action references are
+      allowed (they share the repo's trust boundary).
     policy_url: "https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions"
 
   - id: gha-workflow-has-name

--- a/crates/alint-dsl/rulesets/v1/ci/github-actions.yml
+++ b/crates/alint-dsl/rulesets/v1/ci/github-actions.yml
@@ -54,17 +54,19 @@ rules:
     #
     # Local `./` composite-action references are exempt: they live in
     # the same repo (same trust boundary) and cannot be SHA-pinned.
+    # Digest-pinned Docker actions (`docker://img@sha256:<64-hex>`) are
+    # accepted; a tag-pinned `docker://img:tag` still fires.
     kind: yaml_path_matches
     paths: [".github/workflows/*.yml", ".github/workflows/*.yaml"]
     path: "$.jobs.*.steps[*].uses"
-    matches: '^(\./.*|[a-zA-Z0-9._/-]+@[a-f0-9]{40})$'
+    matches: '^(\./.*|docker://[^@]+@sha256:[a-f0-9]{64}|[a-zA-Z0-9._/-]+@[a-f0-9]{40})$'
     if_present: true
     level: warning
     message: >-
       Third-party action is not pinned to a commit SHA. Pin with
-      `@<40-char-sha>  # v4.1.1` so a compromised tag can't
-      silently change what runs. Local `./` action references are
-      allowed (they share the repo's trust boundary).
+      `@<40-char-sha>  # v4.1.1` (or `docker://img@sha256:...` for a
+      Docker action) so a compromised tag can't silently change what
+      runs. Local `./` action references are allowed.
     policy_url: "https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions"
 
   - id: gha-workflow-has-name

--- a/crates/alint-e2e/scenarios/check/bundled-phase-a/ci_github_actions_flags_tag_pinned_docker.yml
+++ b/crates/alint-e2e/scenarios/check/bundled-phase-a/ci_github_actions_flags_tag_pinned_docker.yml
@@ -1,0 +1,32 @@
+name: alint://bundled/ci/github-actions — tag-pinned Docker actions ARE flagged
+tags: [check, extends, bundled, ci, github-actions, regression]
+
+# A tag-pinned Docker action (`docker://img:tag`) is mutable, so
+# gha-pin-actions-to-sha must still flag it -- contrast the digest-pinned
+# scenario, which passes. The workflow is otherwise clean, so exactly one
+# gha-pin violation is expected.
+
+given:
+  tree:
+    ".github":
+      workflows:
+        "ci.yml": |
+          name: CI
+          on: push
+          permissions:
+            contents: read
+          jobs:
+            build:
+              runs-on: ubuntu-latest
+              steps:
+                - uses: docker://alpine:3.18
+  config: |
+    version: 1
+    extends:
+      - alint://bundled/ci/github-actions@v1
+
+when: [check]
+
+expect:
+  - violations:
+      - {rule: gha-pin-actions-to-sha, level: warning, path: .github/workflows/ci.yml}

--- a/crates/alint-e2e/scenarios/check/bundled/ci_github_actions_accepts_digest_pinned_docker.yml
+++ b/crates/alint-e2e/scenarios/check/bundled/ci_github_actions_accepts_digest_pinned_docker.yml
@@ -1,0 +1,32 @@
+name: alint://bundled/ci/github-actions — digest-pinned Docker actions are not flagged
+tags: [check, extends, bundled, ci, github-actions, passing, regression]
+
+# A digest-pinned Docker action (`docker://img@sha256:<64-hex>`) is immutably
+# pinned, so gha-pin-actions-to-sha must NOT flag it. (A tag-pinned
+# `docker://img:tag` still fires -- covered by the ill-formed scenario.) The
+# workflow is otherwise Scorecard-clean, so `violations: []` isolates the
+# Docker-digest case.
+
+given:
+  tree:
+    ".github":
+      workflows:
+        "ci.yml": |
+          name: CI
+          on: push
+          permissions:
+            contents: read
+          jobs:
+            build:
+              runs-on: ubuntu-latest
+              steps:
+                - uses: docker://ghcr.io/acme/tool@sha256:1111111111111111111111111111111111111111111111111111111111111111
+  config: |
+    version: 1
+    extends:
+      - alint://bundled/ci/github-actions@v1
+
+when: [check]
+
+expect:
+  - violations: []

--- a/crates/alint-e2e/scenarios/check/bundled/ci_github_actions_allows_local_action_refs.yml
+++ b/crates/alint-e2e/scenarios/check/bundled/ci_github_actions_allows_local_action_refs.yml
@@ -1,0 +1,35 @@
+name: alint://bundled/ci/github-actions — local `./` composite-action refs are not flagged (issue #208)
+tags: [check, extends, bundled, ci, github-actions, passing, regression]
+
+# Regression test for issue #208: gha-pin-actions-to-sha must NOT flag a
+# local composite-action reference (`uses: ./...`). Local refs live in the
+# same repo (same trust boundary) and cannot be SHA-pinned. The workflow is
+# otherwise Scorecard-clean (name + contents: read + a SHA-pinned third-party
+# action), so `violations: []` isolates the local-ref behavior — with the
+# pre-fix regex the `./.github/actions/printout` step raised a warning.
+
+given:
+  tree:
+    ".github":
+      workflows:
+        "ci.yml": |
+          name: CI
+          on: push
+          permissions:
+            contents: read
+          jobs:
+            test:
+              runs-on: ubuntu-latest
+              steps:
+                - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+                - uses: ./.github/actions/printout
+                - run: echo hi
+  config: |
+    version: 1
+    extends:
+      - alint://bundled/ci/github-actions@v1
+
+when: [check]
+
+expect:
+  - violations: []

--- a/crates/alint-e2e/tests/dogfood_bundled_no_drift.rs
+++ b/crates/alint-e2e/tests/dogfood_bundled_no_drift.rs
@@ -128,6 +128,21 @@ fn dogfood_rules_match_their_bundled_twins() {
         }
     }
 
+    // Guard against a vacuous pass. Read/parse errors are swallowed into empty maps
+    // (see `rules_by_id`), so if `.alint.yml` or the bundled rulesets ever fail to
+    // parse -- or the last shared rule id is renamed away -- the drift loop below
+    // would iterate nothing and pass without checking anything. Require at least one
+    // non-allowlisted twin present on both sides so the gate can't silently no-op.
+    let compared = dogfood
+        .keys()
+        .filter(|id| !ALLOWLIST.contains(&id.as_str()) && bundled.contains_key(id.as_str()))
+        .count();
+    assert!(
+        compared > 0,
+        "drift gate found zero dogfood<->bundled twins to compare -- either a config \
+         failed to parse or no shared rule id remains; the gate would pass vacuously."
+    );
+
     let mut drifts: Vec<String> = Vec::new();
     for (id, drule) in &dogfood {
         if ALLOWLIST.contains(&id.as_str()) {

--- a/crates/alint-e2e/tests/dogfood_bundled_no_drift.rs
+++ b/crates/alint-e2e/tests/dogfood_bundled_no_drift.rs
@@ -1,0 +1,165 @@
+//! Anti-drift gate for alint's dogfood config vs the shipped bundled rulesets.
+//!
+//! alint's own `.alint.yml` hand-copies a few rules that also ship in
+//! `crates/alint-dsl/rulesets/v1/**` (same `id:`), typically to enforce them at a
+//! stricter `level:` on this repo. Those copies MUST keep identical *matching
+//! semantics* -- only presentation (`level`, `message`, `policy_url`, `fix`) may
+//! differ. When they drift, external users who `extends:` the bundled ruleset get
+//! behavior the maintainers never see on their own dogfooded repo.
+//!
+//! This is the gate issue #208 lacked: the bundled `gha-pin-actions-to-sha` regex
+//! had drifted from the already-fixed dogfood copy, shipping a false positive on
+//! local `./` action references. This test fails on exactly that kind of drift.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde_yaml_ng::Value;
+
+/// Fields that may legitimately differ between a dogfood copy and its bundled
+/// twin: they change how a violation is *presented* or *fixed*, not *whether* it
+/// fires.
+const PRESENTATION: &[&str] = &["level", "message", "policy_url", "fix"];
+
+/// Shared ids whose matching semantics are intentionally different (a documented
+/// divergence), exempt from the equality check:
+///   - `rust-sources-snake-case`: the dogfood copy is deliberately narrowed to
+///     `crates/**/src/**/*.rs`, whereas the bundled `rust@v1` copy is
+///     repo-agnostic (`**/src/**` plus compiler-fixture excludes that would be
+///     no-ops in this tree). The divergence can only make the dogfood copy fire
+///     on *fewer* files, never over-fire for external users.
+const ALLOWLIST: &[&str] = &["rust-sources-snake-case"];
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root from alint-e2e CARGO_MANIFEST_DIR")
+        .to_path_buf()
+}
+
+fn walk_yaml(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(read) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in read.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if matches!(
+                path.extension().and_then(|s| s.to_str()),
+                Some("yml" | "yaml")
+            ) {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+/// Rebuild a rule mapping without the presentation-only keys.
+fn without_presentation(rule: &Value) -> Value {
+    let Some(m) = rule.as_mapping() else {
+        return rule.clone();
+    };
+    let mut out = serde_yaml_ng::Mapping::new();
+    for (k, v) in m {
+        if k.as_str().is_some_and(|key| PRESENTATION.contains(&key)) {
+            continue;
+        }
+        out.insert(k.clone(), canon(v));
+    }
+    Value::Mapping(out)
+}
+
+/// Recursively sort mapping keys so key *order* never causes a false diff;
+/// sequence order is preserved (it can be semantically meaningful).
+fn canon(v: &Value) -> Value {
+    match v {
+        Value::Mapping(m) => {
+            let mut entries: Vec<(Value, Value)> =
+                m.iter().map(|(k, val)| (k.clone(), canon(val))).collect();
+            entries.sort_by_key(|(k, _)| k.as_str().unwrap_or_default().to_string());
+            let mut out = serde_yaml_ng::Mapping::new();
+            for (k, val) in entries {
+                out.insert(k, val);
+            }
+            Value::Mapping(out)
+        }
+        Value::Sequence(s) => Value::Sequence(s.iter().map(canon).collect()),
+        other => other.clone(),
+    }
+}
+
+/// id -> canonicalized, presentation-stripped rule, for every rule in a config
+/// file's top-level `rules:` list.
+fn rules_by_id(path: &Path) -> BTreeMap<String, Value> {
+    let mut out = BTreeMap::new();
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return out;
+    };
+    let Ok(doc) = serde_yaml_ng::from_str::<Value>(&text) else {
+        return out;
+    };
+    let Some(rules) = doc.get("rules").and_then(Value::as_sequence) else {
+        return out;
+    };
+    for rule in rules {
+        let Some(id) = rule.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        out.insert(id.to_string(), without_presentation(rule));
+    }
+    out
+}
+
+#[test]
+fn dogfood_rules_match_their_bundled_twins() {
+    let root = workspace_root();
+    let dogfood = rules_by_id(&root.join(".alint.yml"));
+
+    let mut bundled: BTreeMap<String, Value> = BTreeMap::new();
+    for path in walk_yaml(&root.join("crates/alint-dsl/rulesets/v1")) {
+        for (id, rule) in rules_by_id(&path) {
+            bundled.insert(id, rule);
+        }
+    }
+
+    let mut drifts: Vec<String> = Vec::new();
+    for (id, drule) in &dogfood {
+        if ALLOWLIST.contains(&id.as_str()) {
+            continue;
+        }
+        let Some(brule) = bundled.get(id) else {
+            continue;
+        };
+        if drule != brule {
+            let d = serde_yaml_ng::to_string(drule).unwrap_or_default();
+            let b = serde_yaml_ng::to_string(brule).unwrap_or_default();
+            drifts.push(format!(
+                "  rule `{id}`:\n    .alint.yml (dogfood) matching fields:\n{}\n    bundled ruleset matching fields:\n{}",
+                indent(&d),
+                indent(&b),
+            ));
+        }
+    }
+
+    assert!(
+        drifts.is_empty(),
+        "\nDogfood <-> bundled rule drift: a rule hand-copied into `.alint.yml` no \
+         longer matches its bundled twin's matching semantics (only \
+         level/message/policy_url/fix may differ). Sync the two copies, or add the \
+         id to ALLOWLIST with a comment if the divergence is intentional.\n\n{}",
+        drifts.join("\n"),
+    );
+}
+
+fn indent(s: &str) -> String {
+    s.lines()
+        .map(|l| format!("      {l}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -939,7 +939,7 @@ Hardening for `.github/workflows/*.y{,a}ml`, guided by the two OpenSSF Scorecard
 | Rule id | Kind | Default level | Fix |
 |---|---|---|---|
 | `gha-workflow-contents-read` | `yaml_path_equals` (`$.permissions.contents == "read"`) | warning | — |
-| `gha-pin-actions-to-sha` | `yaml_path_matches` (40-hex SHA on third-party `uses:`; local `./` refs exempt) | warning | — |
+| `gha-pin-actions-to-sha` | `yaml_path_matches` (40-hex SHA on third-party `uses:`; local `./` and digest-pinned `docker://` refs exempt) | warning | — |
 | `gha-workflow-has-name` | `yaml_path_matches` (`$.name`) | info | — |
 
 ### `alint://bundled/agent-hygiene@v1`

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -939,7 +939,7 @@ Hardening for `.github/workflows/*.y{,a}ml`, guided by the two OpenSSF Scorecard
 | Rule id | Kind | Default level | Fix |
 |---|---|---|---|
 | `gha-workflow-contents-read` | `yaml_path_equals` (`$.permissions.contents == "read"`) | warning | — |
-| `gha-pin-actions-to-sha` | `yaml_path_matches` (40-hex SHA on every `uses:`) | warning | — |
+| `gha-pin-actions-to-sha` | `yaml_path_matches` (40-hex SHA on third-party `uses:`; local `./` refs exempt) | warning | — |
 | `gha-workflow-has-name` | `yaml_path_matches` (`$.name`) | info | — |
 
 ### `alint://bundled/agent-hygiene@v1`

--- a/docs/site/cookbook/index.md
+++ b/docs/site/cookbook/index.md
@@ -112,12 +112,14 @@ rules:
   # Security practice: pin third-party actions to a full commit SHA,
   # not a mutable @v4-style tag. `$.jobs.*.steps[*].uses` iterates
   # every step across every job. `if_present: true` skips workflows
-  # that have no `uses:` at all.
+  # that have no `uses:` at all. The regex also exempts local `./`
+  # actions and digest-pinned `docker://...@sha256:` refs -- both are
+  # already immutable or same-repo, so SHA-pinning doesn't apply.
   - id: pin-actions-to-sha
     kind: yaml_path_matches
     paths: ".github/workflows/*.yml"
     path: "$.jobs.*.steps[*].uses"
-    matches: '^[a-zA-Z0-9._/-]+@[a-f0-9]{40}$'
+    matches: '^(\./.*|docker://[^@]+@sha256:[a-f0-9]{64}|[a-zA-Z0-9._/-]+@[a-f0-9]{40})$'
     if_present: true
     level: warning
 ```


### PR DESCRIPTION
Closes #208.

Fixes two false positives in the bundled `ci/github-actions@v1` `gha-pin-actions-to-sha` rule — both the same class (a validly-pinned or in-repo action wrongly flagged as unpinned) — and adds the anti-drift gate #208 lacked.

## Fix 1 — local `./` composite-action refs (#208)
The rule flagged **local composite-action references** (`uses: ./...`) as unpinned third-party actions. Local actions share the repo's trust boundary and cannot be SHA-pinned (reproduced against @ivml's minimal repo).

**Root cause — dogfood ↔ bundled drift.** alint's own `.alint.yml` already exempted local refs — it had to, since `action-selftest.yml` uses `uses: ./` seven times at `error` level — but that fix never reached the shipped bundled ruleset users `extends:`. The dogfood copy's comment even claimed it "Mirrors" the bundled rule; they had silently diverged.

## Fix 2 — digest-pinned Docker actions
The same rule also flagged **digest-pinned Docker actions** (`uses: docker://img@sha256:<64-hex>`) as unpinned. A digest is an immutable pin, so it is now exempt; a tag-pinned `docker://img:tag` still fires.

## Changes
- Widen the bundled regex to `^(\./.*|docker://[^@]+@sha256:[a-f0-9]{64}|[a-zA-Z0-9._/-]+@[a-f0-9]{40})$` (matching the dogfood copy), and update the message + comment.
- **Regression scenarios**: `..._allows_local_action_refs` (local ref passes), `..._accepts_digest_pinned_docker` (digest passes), `..._flags_tag_pinned_docker` (tag still fires).
- **Anti-drift gate** — `dogfood_bundled_no_drift.rs` asserts every same-`id` dogfood/bundled twin keeps identical *matching* semantics (only `level`/`message`/`policy_url`/`fix` may differ). This is the gate #208 lacked; it keeps the two regex copies in lockstep. Allowlists the one intentional divergence (`rust-sources-snake-case`).
- Refresh `docs/rules.md` + CHANGELOG.

## Verified
- Both reporter repros now pass; a genuinely-unpinned `@v4` and a tag-pinned `docker://img:tag` still fire (no security regression).
- `cargo test --workspace`, the four xtask `--check` freshness gates, clippy (`-D warnings`), and `fmt` all green.

## Adversarial-review hardening
A second adversarial pass — a 21-case regex matrix (valid / invalid / edge pin forms; every mutable form still fires) plus mutation-testing the drift gate — confirmed the fixes hold and added two refinements:
- **The drift gate can no longer pass vacuously.** `rules_by_id` swallows parse errors into empty maps, so a parse failure or a renamed twin id would have let the comparison loop iterate nothing and pass. The gate now asserts it compared at least one twin. Both the drift-detection *and* this vacuous-guard are mutation-proven to FAIL when they should, and pass on restore.
- **Cookbook sync.** `docs/site/cookbook`'s "Lock down GitHub Actions workflows" recipe taught the naive pin regex (same FP); synced it to the corrected pattern so the docs don't propagate the bug.

## Deferred to a follow-up PR
A third same-class item — `gha-workflow-contents-read` false-firing on `permissions: read-all`, `permissions: {}`, `contents: none`, and per-job-only permissions — has **no clean config-only fix**. Distinguishing "no permissions declared" (must fire) from "per-job permissions" (must pass) needs a two-path disjunction across `$.permissions` and `$.jobs.*.permissions` that alint's current `equals`/`matches` kinds can't express. The correct fix introduces a small new `yaml_path_absent` rule kind — a public-API/contract change that deserves its own reviewable PR. Tracked for a follow-up.

https://claude.ai/code/session_01DY5e8zTE8XDCDsaPkJT8Ai
