### PR TITLE
fix(bench): mark small changed-mode cells regression-advisory + document the v0.16 artifact

### DIFF
--- a/docs/benchmarks/METHODOLOGY.md
+++ b/docs/benchmarks/METHODOLOGY.md
@@ -103,6 +103,20 @@ statistic, publish the full distribution. Cross-machine and
 cross-hyperfine-version comparisons still require a like-for-like
 fingerprint.
 
+**Caveat on the small `changed`-mode cells (added 2026-09).** The `changed`/1k and
+`changed`/10k cells are unreliable for the `min_ms` REGRESSION gate too, not just for
+CV. `changed` mode spawns `git` single-threaded to find the changed subset, then
+dispatches the rule `par_iter` over a *tiny* subset, so these cells are dominated by
+the cost of waking the other cores for that brief parallel burst - which is highly
+sensitive to the host's C-state / frequency behavior and drifts across baseline
+captures independent of any code change. v0.16.0's bench-record flagged them +40-92%,
+yet the same v0.15.0 binary re-measured on the same host moved 43 -> 117 ms on
+`changed`/10k (with `full` flat, and `RAYON_NUM_THREADS=1` pinned at the old 43 ms for
+both versions), so it was a version-independent environment artifact
+([`investigations/2026-09-v0.16-changed-mode-bench-artifact/`](investigations/2026-09-v0.16-changed-mode-bench-artifact/)).
+Treat small `changed` cells as regression-advisory (as they already are for CV); the
+deterministic gate stays the authoritative regression signal.
+
 ### Why hyperfine and not a custom Rust harness
 
 hyperfine measures wall-time of an external command from

--- a/docs/benchmarks/METHODOLOGY.md
+++ b/docs/benchmarks/METHODOLOGY.md
@@ -114,8 +114,10 @@ yet the same v0.15.0 binary re-measured on the same host moved 43 -> 117 ms on
 `changed`/10k (with `full` flat, and `RAYON_NUM_THREADS=1` pinned at the old 43 ms for
 both versions), so it was a version-independent environment artifact
 ([`investigations/2026-09-v0.16-changed-mode-bench-artifact/`](investigations/2026-09-v0.16-changed-mode-bench-artifact/)).
-Treat small `changed` cells as regression-advisory (as they already are for CV); the
-deterministic gate stays the authoritative regression signal.
+`xtask bench-gate` now treats small `changed` cells (1k/10k) as regression-advisory as
+well as CV-advisory (`gate.rs` `CHANGED_REGRESSION_ADVISORY_SIZES`): they report their
+`min_ms` delta as `ADV` but do not fail the gate, while `full`/10k and all 100k/1m cells
+still gate. The deterministic gate stays the authoritative regression signal.
 
 ### Why hyperfine and not a custom Rust harness
 

--- a/docs/benchmarks/investigations/2026-09-v0.16-changed-mode-bench-artifact/README.md
+++ b/docs/benchmarks/investigations/2026-09-v0.16-changed-mode-bench-artifact/README.md
@@ -1,0 +1,120 @@
+# 2026-09 - v0.16.0 changed-mode small-cell "regression": a bench artifact, not code
+
+Status: **Resolved (no code change).** v0.16.0's `bench-record` failed the regression
+gate with the small `changed`-mode cells inflated **+40 to +92%** vs the committed
+v0.15.0 baseline (`S1..S12 1k/10k changed`), while every `full` cell and the large
+`changed`/100k + `changed`/1m cells were flat. A tight, same-host, same-conditions A/B
+proved **v0.16.0 is indistinguishable from v0.15.0** on these cells; the flag is a
+baseline-vs-current-environment artifact on the floor-level `changed`-mode small cells,
+which are dominated by the multi-core wakeup cost of a tiny parallel burst and are
+version-independent. Do not treat it as a v0.16.0 code regression.
+
+## Symptom
+
+`bench-record` for v0.16.0 (run twice) flagged, both times, only the small `changed`
+cells against `docs/benchmarks/macro/results/linux-x86_64/v0.15.0/results.json`:
+
+| mode / size | delta vs committed v0.15.0 |
+|---|---|
+| `full` (1k/10k/100k/1m) | ~0% (flat) |
+| `changed` / 100k, / 1m | +0.2%, +0.4% (flat) |
+| `changed` / 10k | +49.6% (run 1), +92.0% (run 2) |
+| `changed` / 1k | +40.1%, +43.3% |
+
+The re-run being *worse* while kbench was idle broke the first hypothesis (below).
+
+## Hypotheses tested
+
+1. **Runner contamination (WRONG).** First call: the release-day bench overlapped
+   CI + docs-bundle + bench-docker on the shared host. Refuted: `uptime` on kbench
+   showed load 0.03, no co-tenant processes; and a reproducible, same-signed +40-92%
+   across two idle-box runs is the opposite of random contamination.
+2. **A `with_worker_pool` rayon regression (WRONG).** v0.16.0 (PR #223) replaced the
+   bare `self.entries.par_iter().collect()` at both engine dispatch sites with
+   `with_worker_pool(|| ...)` -> `pool.install(job)` on an explicitly-built cached
+   pool. Hypothesis: `install()` blocks the caller and hands the tiny changed-mode
+   workload to cold worker threads (a C-state-exit + clock-ramp penalty), which would
+   hit only small `changed` cells and be worse on an idler box. A noisy lean A/B
+   (single-run mins) seemed to support it (+13% default, 3x faster at 1 thread).
+   **Refuted by tight measurement** (see below): at 30 runs / CV ~1%, v0.16.0 and
+   v0.15.0 are identical, and the 3x single-thread effect is present in *both*
+   versions equally. The `with_worker_pool` change is perf-neutral.
+
+## The measurement that settled it
+
+`S1 10k changed`, `xtask bench-scale --runs 30`, both binaries built from their tags
+on kbench and measured back-to-back on the idle box:
+
+| condition | min | median | mean | stddev | CV% |
+|---|--:|--:|--:|--:|--:|
+| v0.15.0 default (8 threads) | 114.68 | 116.95 | 116.94 | 1.13 | 1.0 |
+| v0.16.0 default (8 threads) | 115.02 | 116.84 | 117.16 | 1.45 | 1.2 |
+| v0.15.0 `RAYON_NUM_THREADS=1` | 41.30 | 43.60 | 43.57 | 1.08 | 2.5 |
+| v0.16.0 `RAYON_NUM_THREADS=1` | 41.37 | 43.16 | 43.28 | 0.96 | 2.2 |
+
+v0.16.0 == v0.15.0 (within 0.1% at 8 threads, 1% at 1 thread). **No regression.**
+
+## Root cause: a version-independent environment artifact on the floor cells
+
+The same v0.15.0 binary, on the same i7-6700HQ, measures differently now than when the
+baseline was recorded:
+
+| S1 10k | committed v0.15.0 baseline | fresh v0.15.0 on kbench now |
+|---|--:|--:|
+| `full` | 25.4 ms | 23.7 ms (flat) |
+| `changed` | **43.2 ms** | **109-117 ms** (2.5x) |
+
+Two facts localize it:
+
+- `full` mode is unchanged, so it is not a broad slowdown (clock, kernel, binary size).
+- `RAYON_NUM_THREADS=1` today gives **43 ms** - matching the old baseline - while the
+  default 8-thread run gives 117 ms, **for both versions**.
+
+So the 43 -> 117 drift is entirely the **multi-core wakeup cost of the tiny
+changed-mode parallel burst**. `changed` mode spawns `git` (single-threaded) to find
+the changed subset, idling the other cores, then dispatches the rule `par_iter` over a
+*tiny* subset - which must wake 7 cores out of deep idle. On current kbench those cores
+sit at 800 MHz in deep C-states (C6-C10) with turbo disabled (`no_turbo=1`), so the
+wake + ramp dominates a workload whose actual work is ~43 ms. Large `changed` cells
+(100k/1m) and all `full` cells keep the cores saturated, so they never pay a per-burst
+cold-wake and stay flat. The committed v0.15.0 baseline (43 ms) was captured when this
+cost was negligible - the small `changed` cell ran warm inside the full back-to-back
+matrix, and/or kbench's idle/C-state behavior differed from its current state (52-day
+uptime; no historical power data to pin the exact trigger). The gate then compared
+fresh v0.16.0 against that stale-cheap number and reported the environment shift as a
+code regression.
+
+This is the same class as the sibling investigations, with the twist that the
+"artifact" call was correct here (unlike [`../2026-07-v0.14-s2-harness-artifact/`](../2026-07-v0.14-s2-harness-artifact/),
+where an artifact call was *overturned* into a real regression): the discipline is to
+verify either way with a same-host, same-conditions, tight-N A/B before concluding.
+
+## Methodology lessons (reusable)
+
+- **Single-run `min_ms` on floor-level cells is noise.** The lean A/B's single mins
+  showed a phantom +13% / 3x asymmetry that vanished at 30 runs (CV ~1%). Use tight-N
+  medians before asserting a delta on cells under ~50 ms.
+- **Reproduce on the ACTUAL bench host and power state.** An earlier A/B ran on a
+  24-core contended box and found "flat"; it could not see an effect that only appears
+  when 7 of 8 kbench cores wake from deep C-states. Wrong core count *and* wrong power
+  state.
+- **Compare fresh-vs-fresh, not fresh-vs-committed-baseline, when the environment may
+  have drifted.** The committed baseline is a point-in-time capture; a same-host
+  re-measure of the *baseline binary* is the only valid regression control (see also
+  [`../2026-05-bench-runner-instability/`](../2026-05-bench-runner-instability/)).
+- **`RAYON_NUM_THREADS=1` is a cheap isolation knob** - it removes the multi-core
+  wakeup, so if a small-cell delta collapses at 1 thread the cost is thread-dispatch /
+  core-wake, not the analysis.
+- **A quiet box can be *worse* for floor-level parallel-burst cells**, not better -
+  idler cores are in deeper C-states, so waking them costs more. "Quiet" is not the
+  same as "fast" for these cells.
+
+## Resolution
+
+No alint code change. The `changed`-mode `1k`/`10k` cells are environment-sensitive
+floor cells and should not gate cross-version comparisons - they are already advisory
+for the CV quality gate and should be advisory for the `min_ms` regression gate too
+(tracked against [`../../../design/deterministic-perf-gating.md`](../../../design/deterministic-perf-gating.md);
+the load-immune deterministic gate remains the authoritative regression signal). The
+v0.16.0 bench numbers reflect current-kbench environment on those cells, not a
+regression; the `full` and large-`changed` numbers are sound and comparable.

--- a/docs/benchmarks/investigations/2026-09-v0.16-changed-mode-bench-artifact/README.md
+++ b/docs/benchmarks/investigations/2026-09-v0.16-changed-mode-bench-artifact/README.md
@@ -1,6 +1,7 @@
 # 2026-09 - v0.16.0 changed-mode small-cell "regression": a bench artifact, not code
 
-Status: **Resolved (no code change).** v0.16.0's `bench-record` failed the regression
+Status: **Resolved (no engine change; `xtask bench-gate` now marks small `changed`
+cells regression-advisory).** v0.16.0's `bench-record` failed the regression
 gate with the small `changed`-mode cells inflated **+40 to +92%** vs the committed
 v0.15.0 baseline (`S1..S12 1k/10k changed`), while every `full` cell and the large
 `changed`/100k + `changed`/1m cells were flat. A tight, same-host, same-conditions A/B
@@ -111,10 +112,13 @@ verify either way with a same-host, same-conditions, tight-N A/B before concludi
 
 ## Resolution
 
-No alint code change. The `changed`-mode `1k`/`10k` cells are environment-sensitive
-floor cells and should not gate cross-version comparisons - they are already advisory
-for the CV quality gate and should be advisory for the `min_ms` regression gate too
-(tracked against [`../../../design/deterministic-perf-gating.md`](../../../design/deterministic-perf-gating.md);
-the load-immune deterministic gate remains the authoritative regression signal). The
-v0.16.0 bench numbers reflect current-kbench environment on those cells, not a
-regression; the `full` and large-`changed` numbers are sound and comparable.
+No alint engine change. The `changed`-mode `1k`/`10k` cells are environment-sensitive
+floor cells that should not gate cross-version comparisons - they were already advisory
+for the CV quality gate, and `xtask bench-gate` now makes them advisory for the `min_ms`
+regression gate too (`gate.rs` `CHANGED_REGRESSION_ADVISORY_SIZES`; they report their
+delta as `ADV` but no longer fail the gate, with `full`/10k and all 100k/1m cells still
+gating). The load-immune deterministic gate
+([`../../../design/deterministic-perf-gating.md`](../../../design/deterministic-perf-gating.md))
+remains the authoritative regression signal. With this change the v0.16.0 numbers pass
+the gate: those cells reflect current-kbench environment, not a regression, and the
+`full` and large-`changed` numbers are sound and comparable.

--- a/docs/benchmarks/investigations/README.md
+++ b/docs/benchmarks/investigations/README.md
@@ -37,6 +37,15 @@ Each investigation directory ships:
 
 ## Existing investigations
 
+### [`2026-05-bench-runner-instability/`](2026-05-bench-runner-instability/)
+
+The v0.9.23 CV-gate failures that turned out to be **gate miscalibration, not a
+degraded host**. A full cross-version corpus analysis showed the fingerprint
+(kernel / rustc / RAM / fs / hyperfine / CPU) byte-identical across releases and the
+`RELEASING.md` CV>10% rule never met by any shipped release; it produced the
+programmatic `xtask bench-gate` (quality CV on 100k+ only; regression `min_ms` vs the
+previous release). Dir name kept so the PR #32 backlink stays valid.
+
 ### [`2026-05-cross-file-rules/`](2026-05-cross-file-rules/)
 
 The v0.9.4 1M S3 cliff investigation that produced the cross-file
@@ -55,6 +64,31 @@ for the *same* binary and look for rules whose `elapsed_us` grows
 super-linearly in file count. Functions whose share grows
 monotonically are super-linear suspects, even when the wall-time
 absolute number doesn't yet flag them as a regression.
+
+### [`2026-05-scope-filter-baseline-drift/`](2026-05-scope-filter-baseline-drift/)
+
+v0.9.6 `scope_filter` Phase 2: a `bench-compare` flagged three >10% regressions
+(`single_file_file_hash`, a junit formatter cell) that were **baseline drift, not an
+engine regression** - the published floor was recorded under different conditions. An
+apples-to-apples same-box re-measure cleared it. An early instance of the recurring
+"stale baseline reads as a regression" trap.
+
+### [`2026-05-v0.10-s13-100k-margin/`](2026-05-v0.10-s13-100k-margin/)
+
+v0.10.0 bench-record: `S13 100k full` marginal CV failures across three runs on the
+(then 3900X `kbox`) host - **host-side contention** from sister runners / dev stacks,
+not code. The two busy runs failed on *different* cells each; a quiescent run passed
+with one residual borderline cell accepted with a note. Motivates measuring only on a
+quiescent host.
+
+### [`2026-06-v0.12-perf-validation/`](2026-06-v0.12-perf-validation/)
+
+v0.12's apparent wall-clock regression proven to be **co-tenant contamination, not
+code**, via the deterministic Valgrind `Ir` gate (flat -> compute path unchanged).
+This is the investigation that established the load-immune deterministic gate as the
+authoritative regression signal - with the later caveat (added 2026-07) that `Ir` is
+**I/O-blind**: it rules out compute/cache regressions but not syscall / read-path ones
+(see the v0.14-S2 sibling).
 
 ### [`2026-07-1m-writeback-contention/`](2026-07-1m-writeback-contention/)
 
@@ -111,6 +145,19 @@ control before concluding "no regression." A real CI bug fell out on the way:
 `det-perf-gate.sh` pins `gungraun-runner` older than the `gungraun` library, so the
 deterministic gate mis-reports a tooling failure as an Ir regression on any
 post-bump PR.
+
+### [`2026-09-v0.16-changed-mode-bench-artifact/`](2026-09-v0.16-changed-mode-bench-artifact/)
+
+v0.16.0's `bench-record` flagged the small `changed`-mode cells +40-92%; a tight,
+same-host, same-conditions 30-run A/B proved **v0.16.0 == v0.15.0 (no code
+regression)**. The flag is a version-independent environment artifact: the same
+v0.15.0 binary measures `changed/10k` at 43 ms (committed baseline) vs 117 ms (fresh
+kbench) while `full` is flat, and `RAYON_NUM_THREADS=1` returns 43 ms for both
+versions - the floor-level `changed` cells are dominated by the multi-core wakeup cost
+of a tiny parallel burst, which grew on current kbench (idle cores at 800 MHz, deep
+C-states, turbo off). Two wrong hypotheses (runner contamination; a `with_worker_pool`
+rayon regression) were refuted along the way. Recommends the small `changed` cells be
+regression-advisory, as they already are for the CV gate.
 
 ## Tooling
 

--- a/xtask/src/bench/gate.rs
+++ b/xtask/src/bench/gate.rs
@@ -22,7 +22,11 @@
 //!   `min_ms` delta vs baseline must not exceed +15 %. `min_ms`
 //!   is the robust cross-version statistic (corpus
 //!   reproducibility ~2.7 % at ≥10k vs ~8.8 % for `mean_ms`).
-//!   Improvements never gate.
+//!   Improvements never gate. The small `changed`-mode cells
+//!   (1k/10k) are *advisory* here too, not just for CV: they are
+//!   dominated by the multi-core wakeup cost of a tiny parallel
+//!   burst and drift with the host's C-state / power state
+//!   independent of code (see the 2026-09 v0.16 investigation).
 //!
 //! Exit is non-zero iff a *gating* check fails; advisory notices
 //! never affect it.
@@ -45,6 +49,18 @@ const ADVISORY_SIZES: &[&str] = &["1k", "10k"];
 /// Sizes the cross-version regression check applies to (`min_ms`
 /// is reproducible here; 1k is not, at any statistic).
 const REGRESSION_SIZES: &[&str] = &["10k", "100k", "1m"];
+/// `changed`-mode cells at these sizes are advisory for the REGRESSION check,
+/// not just CV. They are dominated by the multi-core wakeup cost of a tiny
+/// parallel burst (git-diff runs single-threaded, then the rule `par_iter` runs
+/// over a tiny changed subset), which drifts with the host's C-state / frequency
+/// behavior independent of any code change. See
+/// docs/benchmarks/investigations/2026-09-v0.16-changed-mode-bench-artifact/.
+const CHANGED_REGRESSION_ADVISORY_SIZES: &[&str] = &["1k", "10k"];
+
+/// A `changed`-mode small cell reports its regression delta but does not gate.
+fn regression_advisory_only(r: &Row) -> bool {
+    r.mode == "changed" && CHANGED_REGRESSION_ADVISORY_SIZES.contains(&r.size_label.as_str())
+}
 
 fn cv(r: &Row) -> f64 {
     if r.mean_ms == 0.0 {
@@ -133,10 +149,10 @@ pub fn evaluate(rows: &[Row], baseline: Option<&[Row]>) -> Outcome {
         Some(base) => {
             let bmap: HashMap<_, _> = base.iter().map(|r| (key(r), r)).collect();
             o.lines.push(format!(
-                "[regression] min_ms vs baseline (gate: ≥10k, +{:.0}%)",
+                "[regression] min_ms vs baseline (gate: ≥10k, +{:.0}%; small changed cells advisory)",
                 REGRESSION_MAX * 100.0
             ));
-            let mut deltas: Vec<(f64, String)> = Vec::new();
+            let mut deltas: Vec<(f64, String, bool)> = Vec::new();
             let mut r_fail = 0usize;
             for r in rows {
                 if !REGRESSION_SIZES.contains(&r.size_label.as_str()) {
@@ -149,21 +165,30 @@ pub fn evaluate(rows: &[Row], baseline: Option<&[Row]>) -> Outcome {
                     continue;
                 }
                 let d = (r.min_ms - b.min_ms) / b.min_ms;
+                let advisory = regression_advisory_only(r);
                 if d > REGRESSION_MAX {
-                    r_fail += 1;
-                    o.gating_failures += 1;
+                    if advisory {
+                        o.advisories += 1;
+                    } else {
+                        r_fail += 1;
+                        o.gating_failures += 1;
+                    }
                 }
-                deltas.push((d, cell(r)));
+                deltas.push((d, cell(r), advisory));
             }
             deltas.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-            for (d, c) in deltas.iter().take(6) {
-                let tag = if *d > REGRESSION_MAX { "FAIL" } else { "ok  " };
+            for (d, c, advisory) in deltas.iter().take(8) {
+                let tag = if *d > REGRESSION_MAX {
+                    if *advisory { "ADV " } else { "FAIL" }
+                } else {
+                    "ok  "
+                };
                 o.lines
                     .push(format!("  {tag} {:34} min_ms {:+.1}%", c, d * 100.0));
             }
             if r_fail == 0 {
                 o.lines.push(format!(
-                    "  regression: PASS (max min_ms delta ≤ +{:.0}%)",
+                    "  regression: PASS (max gating min_ms delta ≤ +{:.0}%)",
                     REGRESSION_MAX * 100.0
                 ));
             }
@@ -284,5 +309,37 @@ mod tests {
         let after = vec![row("S9", "1k", "changed", 15.0, 1.0, 14.0)]; // -32%, 1k
         let o = evaluate(&after, Some(&base));
         assert_eq!(o.gating_failures, 0);
+    }
+
+    #[test]
+    fn changed_small_cell_regression_is_advisory_not_gating() {
+        // The v0.16.0 finding: small `changed` cells are floor-level and
+        // environment-sensitive (multi-core wakeup on a tiny burst), so a large
+        // min_ms delta there is advisory, not a gate failure. 1k is excluded from
+        // the regression check entirely; the 10k changed cell reports as advisory.
+        let base = vec![
+            row("S1", "10k", "changed", 43.0, 1.0, 43.0),
+            row("S1", "1k", "changed", 10.0, 1.0, 10.0),
+        ];
+        let after = vec![
+            row("S1", "10k", "changed", 117.0, 2.0, 117.0), // +172% min
+            row("S1", "1k", "changed", 17.0, 1.0, 17.0),    // +70% min
+        ];
+        let o = evaluate(&after, Some(&base));
+        assert_eq!(
+            o.gating_failures, 0,
+            "small changed cells must not gate: {:#?}",
+            o.lines
+        );
+        assert_eq!(o.advisories, 1, "the 10k changed cell is an advisory");
+    }
+
+    #[test]
+    fn full_10k_regression_still_gates() {
+        // The advisory carve-out is scoped to `changed` mode: `full`/10k still gates.
+        let base = vec![row("S1", "10k", "full", 24.0, 0.5, 24.0)];
+        let after = vec![row("S1", "10k", "full", 30.0, 0.5, 30.0)]; // +25% min
+        let o = evaluate(&after, Some(&base));
+        assert_eq!(o.gating_failures, 1, "full/10k regression must still gate");
     }
 }


### PR DESCRIPTION
Documents the v0.16.0 `bench-record` small-`changed`-cell "regression" as a
version-independent environment artifact (not a code change), and fixes the drifted
investigations index.

## What this contains
- **New investigation** `docs/benchmarks/investigations/2026-09-v0.16-changed-mode-bench-artifact/README.md`:
  the full arc, including two hypotheses that were refuted (runner contamination; a
  `with_worker_pool` rayon regression) and the tight same-host 30-run A/B that settled
  it: **v0.16.0 == v0.15.0** (CV ~1%). The flag is a floor-level environment artifact.
  The same v0.15.0 binary measures `changed/10k` at 43ms (committed baseline) vs 117ms
  fresh on current kbench while `full` is flat, and `RAYON_NUM_THREADS=1` returns 43ms
  for both versions, isolating it to the multi-core wakeup cost of a tiny parallel burst.
- **Index backfill**: `investigations/README.md` had drifted to listing only 3 of the 7
  existing investigation dirs; it now lists all 8 in chronological order.
- **METHODOLOGY.md**: notes the small `changed` cells warrant regression-advisory
  treatment (as they already have for the CV quality gate).

Docs-only; no engine or code change (binary byte-identical). Implication: PR #224's
bench numbers are sound for `full` and large `changed` cells and are not a v0.16.0
regression.

https://claude.ai/code/session_01DY5e8zTE8XDCDsaPkJT8Ai

## Update: the recommended gate fix is included
Also makes the floor-level `changed`/1k+10k cells regression-**advisory** in
`xtask bench-gate` (`gate.rs` `CHANGED_REGRESSION_ADVISORY_SIZES`): they report their
`min_ms` delta as `ADV` instead of failing the gate, matching how they are already
CV-advisory; `full`/10k and all 100k/1m cells still gate. Two gate unit tests lock the
invariant. With this, v0.16.0's bench numbers pass the gate. This is the resolution the
investigation recommends, so it ships with the writeup.
