### PR TITLE
docs: correct stale claims (shipped features documented as unbuilt)

### DIFF
--- a/docs/design/ARCHITECTURE.md
+++ b/docs/design/ARCHITECTURE.md
@@ -276,7 +276,7 @@ paths: ["src/**/*.rs", "!src/**/testdata/**"]              # array with negation
 paths: {include: ["src/**"], exclude: ["**/*.test.*"]}     # explicit pair
 ```
 
-`.gitignore` is honored by default. `.alintignore` provides alint-specific exclusions. `ignore:` in config adds to the exclusion set.
+`.gitignore` (plus `.ignore` and git exclude files) is honored by default. `ignore:` in config adds to the exclusion set.
 
 ### Facts and conditional rules
 
@@ -287,7 +287,7 @@ Fact kinds are `any_file_exists`, `all_files_exist`, `count_files`, `file_conten
 The `when` expression language is deliberately bounded:
 
 - Operators: `==`, `!=`, `<`, `<=`, `>`, `>=`, `and`, `or`, `not`, `in`, `matches`
-- Identifiers: `facts.<name>`, `vars.<name>`, `ctx.<name>`
+- Identifiers: `facts.<name>`, `vars.<name>`, `iter.<name>`, `env.<name>` (`ctx.<name>` is available in messages, not in `when:`)
 - Literals: strings, numbers, booleans, null, lists
 
 No user-defined functions, no recursion, no I/O. Examples:
@@ -340,7 +340,7 @@ The pipeline from `alint check` to output:
 <likec4-view view-id="checkFlow"></likec4-view>
 
 1. **Config load.** Read `.alint.yml`; follow `extends` with caching and cycle detection; validate against JSON Schema.
-2. **Facts.** Evaluate facts in parallel. Cache keyed on input hashes.
+2. **Facts.** Evaluate facts sequentially, once per run. Cache keyed on input hashes (reused on the LSP per-file path).
 3. **Rule filter.** Evaluate `when` clauses; drop disabled rules.
 4. **Walk.** One *parallel* pass over the filesystem via the `ignore` crate's `WalkBuilder::build_parallel` (v0.9.1). Each worker thread accumulates `FileEntry`s in a thread-local `Vec`; the engine merges them and runs a deterministic `sort_unstable_by` post-sort so downstream output is byte-identical to the pre-v0.9.1 sequential walker. The resulting `FileIndex` exposes lazy `OnceLock` indexes (`contains_file`, `children_of`, `descendants_of`, `file_basenames_of`) that turn common cross-file queries from linear scans into O(1) hash lookups (v0.9.5 + v0.9.8).
 5. **Dispatch partition.** Rules with `requires_full_index() = true` (cross-file) stay rule-major; the rest implement `PerFileRule` and join the file-major dispatch (v0.9.3, see [Rule model](#dispatch-flip--perfilerule-v093)).
@@ -350,9 +350,9 @@ The pipeline from `alint check` to output:
 9. **Fix (optional).** Apply fixers serially; re-run checks.
 10. **Emit.** Format via selected output.
 
-Invariants: the walk runs exactly once per invocation; any given file's bytes are read at most once; fact and rule evaluation are both parallelized; fixers run serially (they mutate the tree).
+Invariants: the walk runs exactly once per invocation; any given file's bytes are read at most once; rule evaluation is parallelized (facts are evaluated once, sequentially); fixers run serially (they mutate the tree).
 
-Step 2 in detail: facts are evaluated once (in parallel, cached), then gate which rules run via their `when:` conditions.
+Step 2 in detail: facts are evaluated once (sequentially, cached), then gate which rules run via their `when:` conditions.
 
 <likec4-view view-id="factsFlow"></likec4-view>
 

--- a/docs/design/architecture/DIAGRAMS.md
+++ b/docs/design/architecture/DIAGRAMS.md
@@ -169,8 +169,8 @@ graph LR
 (cache, cycle-detect, SRI)`" .-> AlintCliDsl
   AlintCliDsl -. "`reject spawning kinds in extends 
 (ADR-0004)`" .-> AlintCliDsl
-  AlintCliAlintBin -. "`evaluate facts (parallel, cached) + 
-filter rules by when`" .-> AlintCliCore
+  AlintCliAlintBin -. "`evaluate facts (once, cached) + filter 
+rules by when`" .-> AlintCliCore
   AlintCliAlintBin -. "`parallel walk -> FileIndex (sorted, 
 deterministic)`" .-> AlintCliCore
   AlintCliCore -. "`per-file dispatch: read each file once 
@@ -291,9 +291,8 @@ graph LR
   AlintCliAlintBin["alint"]
   AlintCliCore["alint-core"]
   AlintCliRules["alint-rules"]
-  AlintCliAlintBin -. "`evaluate facts in parallel 
-(any_file_exists, count_files, custom, 
-...)`" .-> AlintCliCore
+  AlintCliAlintBin -. "`evaluate facts once (any_file_exists, 
+count_files, custom, ...)`" .-> AlintCliCore
   AlintCliCore -. "`cache fact values keyed on input hashes`" .-> AlintCliCore
   AlintCliCore -. "`evaluate each rule when: clause over 
 facts / vars / ctx`" .-> AlintCliCore
@@ -329,8 +328,7 @@ graph LR
   AlintCliRules["alint-rules"]
   AlintCliAlintBin -. "`parallel walk (ignore crate 
 WalkBuilder.build_parallel)`" .-> AlintCliCore
-  AlintCliCore -. "`honor .gitignore + .alintignore + 
-ignore: globs`" .-> AlintCliCore
+  AlintCliCore -. "`honor .gitignore/.ignore + ignore: globs`" .-> AlintCliCore
   AlintCliCore -. "`merge thread-local FileEntry vecs + 
 deterministic sort`" .-> AlintCliCore
   AlintCliCore -. "`build lazy indices: path set, 

--- a/docs/design/architecture/model/alint.c4
+++ b/docs/design/architecture/model/alint.c4
@@ -145,7 +145,7 @@ views {
     dev -> alintBin 'alint check .'
     alintBin -> dsl 'load .alint.yml + resolve extends (cache, cycle-detect, SRI)'
     dsl -> dsl 'reject spawning kinds in extends (ADR-0004)'
-    alintBin -> core 'evaluate facts (parallel, cached) + filter rules by when'
+    alintBin -> core 'evaluate facts (once, cached) + filter rules by when'
     alintBin -> core 'parallel walk -> FileIndex (sorted, deterministic)'
     parallel {
       core -> rules 'per-file dispatch: read each file once -> evaluate_file'
@@ -192,7 +192,7 @@ views {
   dynamic view factsFlow {
     title 'Facts evaluation + when gating'
 
-    alintBin -> core 'evaluate facts in parallel (any_file_exists, count_files, custom, ...)'
+    alintBin -> core 'evaluate facts once (any_file_exists, count_files, custom, ...)'
     core -> core 'cache fact values keyed on input hashes'
     core -> core 'evaluate each rule when: clause over facts / vars / ctx'
     core -> core 'drop rules whose when is false'
@@ -247,7 +247,7 @@ views {
     title 'Walk + gitignore + git-tracked filtering'
 
     alintBin -> core 'parallel walk (ignore crate WalkBuilder.build_parallel)'
-    core -> core 'honor .gitignore + .alintignore + ignore: globs'
+    core -> core 'honor .gitignore/.ignore + ignore: globs'
     core -> core 'merge thread-local FileEntry vecs + deterministic sort'
     core -> core 'build lazy indices: path set, parent->children, git-tracked'
     core -> rules 'FileIndex (+ git-tracked filtered views) ready'

--- a/docs/site/about/architecture-diagrams.md
+++ b/docs/site/about/architecture-diagrams.md
@@ -105,7 +105,7 @@ filtering, and the deterministic, sorted `FileIndex`.
 
 ## Template expansion
 
-How `${...}` template variables in rule options are expanded before evaluation.
+How `{{vars.X}}` template variables in rule options are expanded before evaluation.
 
 <likec4-view view-id="templateFlow"></likec4-view>
 

--- a/docs/site/about/architecture-diagrams.md
+++ b/docs/site/about/architecture-diagrams.md
@@ -84,7 +84,7 @@ The engine's core types: how a `Rule` (or `PerFileRule`), a `Fixer`, and the
 
 ## Facts and conditional rules
 
-Facts are evaluated once (in parallel, cached), then used to filter which rules
+Facts are evaluated once (sequentially, cached), then used to filter which rules
 run via their `when:` conditions.
 
 <likec4-view view-id="factsFlow"></likec4-view>

--- a/docs/site/about/monorepos.md
+++ b/docs/site/about/monorepos.md
@@ -21,7 +21,7 @@ The diagram below shows how nested `.alint.yml` files layer by directory and how
 | pnpm / yarn / npm workspaces | Strong | Same: `node@v1` plus workspace conventions. |
 | Polyglot OSS monorepos (Rust + Node + Python + Go + Java) | Strong | Multi-ecosystem rulesets layer cleanly; each is fact-gated, so unused languages contribute nothing. |
 | Lerna / Nx / Turborepo | Good | Treat as workspaces; bundled adoption + nested configs. |
-| Bazel / Buck2 / Pants hyperscale monorepos | Partial | Tree-shape rules apply. Package-iteration rules currently iterate every directory matching a glob; a per-iteration `when:` filter ("only iterate dirs containing a `BUILD` file") is on the v0.5 roadmap. |
+| Bazel / Buck2 / Pants hyperscale monorepos | Partial | Tree-shape rules apply, and `for_each_dir` / `for_each_file` accept a per-iteration `when_iter:` filter ("only iterate dirs containing a `BUILD` file"). The design center is workspace-tier monorepos, not 1M-file Bazel scale. |
 | Custom-build kernels (Linux, Chromium, FreeBSD) | Partial | Tree-shape rules apply. Expect to write more custom rules and fewer ecosystem extends. |
 
 If your top concern is build-graph correctness, dependency resolution, or code-level safety, the [Honest limits](#honest-limits) section below is the part to read first. alint isn't the right tool for those, and we'd rather you know now than after wiring it in.
@@ -61,8 +61,7 @@ Things alint deliberately does not do, and what to use instead.
 
 - **Build graph and dependency analysis.** Bazel, Buck2, Pants, and `cargo deny` already do this well. alint reads your `BUILD` / `Cargo.toml` / `package.json` files as data, not as graphs. It can require they exist and have certain keys, but it won't tell you if your dependency graph has a cycle.
 - **Code-content linting.** ESLint, Clippy, ruff, gofmt, Prettier cover the language surface. alint checks file existence, naming, headers, and forbidden-pattern matches, not the meaning of the code.
-- **Per-package iteration with conditions on the iteration itself.** Today, `for_each_dir` iterates every directory matching a `paths:` glob; the inner rules then short-circuit if a marker file is missing. A per-iteration `when:` predicate ("iterate only directories that contain a `BUILD` file") is on the v0.5 roadmap. Until then, `every_matching_has` covers the most common case (one anchor file in a directory ⇒ another file required nearby).
-- **Tested scale ceiling.** alint's walker is fast (it honors `.gitignore` and reads files in parallel) but the design center is workspace-tier monorepos, not 1M-file Bazel monorepos. An incremental `--changed` mode that diffs against a base ref (so PR-time runs stay sub-second on large trees) is on the v0.5 roadmap; until then, plan for full-tree latency on each invocation. Published scale benchmarks are tracked as part of the same cut.
+- **Tested scale ceiling.** alint's walker is fast (it honors `.gitignore` and reads files in parallel), and `--changed` diffs against a base ref so PR-time runs stay fast on large trees. The design center is still workspace-tier monorepos, not 1M-file Bazel monorepos; plan for whole-tree runs at that scale.
 
 If a limit above describes your concern, alint isn't the right tool. Reaching for the right neighbor will save you time.
 
@@ -167,7 +166,7 @@ rules:
     level: error
 ```
 
-`every_matching_has` works well for known-shape glob patterns like `services/*` or `apps/*`. For arbitrary-depth Bazel packages (`BUILD` files anywhere in the tree), the per-iteration `when:` filter on `for_each_dir` planned for v0.5 lands the right idiom: "for every directory containing a `BUILD` file, require X."
+`every_matching_has` works well for known-shape glob patterns like `services/*` or `apps/*`. For arbitrary-depth Bazel packages (`BUILD` files anywhere in the tree), the per-iteration `when_iter:` filter on `for_each_dir` is the right idiom: "for every directory containing a `BUILD` file, require X."
 
 ### Manifest-derived scoping (v0.15+)
 

--- a/docs/site/concepts/how-it-works.md
+++ b/docs/site/concepts/how-it-works.md
@@ -10,7 +10,7 @@ alint reads one declarative `.alint.yml`, makes a single parallel pass over your
 <likec4-view view-id="checkFlow"></likec4-view>
 
 1. **Config load.** alint reads the `.alint.yml` at the repository root and resolves any `extends:` (local files, HTTPS sources pinned by a subresource-integrity hash, or bundled rulesets), then validates the merged config against its JSON schema.
-2. **Facts.** Any `facts:` you declared are evaluated once, in parallel, and cached. Facts answer questions about the repo (does a file exist, how many match a glob, what does a command print) that rules can gate on.
+2. **Facts.** Any `facts:` you declared are evaluated once, sequentially, and cached. Facts answer questions about the repo (does a file exist, how many match a glob, what does a command print) that rules can gate on.
 3. **Rule filter.** Each rule's `when:` condition is evaluated against the facts; rules whose condition is false are dropped before a single file is read.
 4. **Walk.** alint walks the repository once, in parallel, honoring `.gitignore` and your `ignore:` globs, and builds a deterministic, sorted index of the files.
 5. **Dispatch.** Rules split into two classes: cross-file rules scan the whole index, and per-file rules run against each matched file. Either way, every matched file's bytes are read at most once.

--- a/docs/site/concepts/variable-interpolation.md
+++ b/docs/site/concepts/variable-interpolation.md
@@ -82,11 +82,11 @@ rules:
 
 ## Migrating from the v0.9.21 `${VAR}` syntax
 
-v0.9.21 shipped POSIX-style `${VAR}` / `${VAR:-default}` interpolation on `git_commit_message.since:` only. That syntax still works in v0.11 but emits a deprecation warning at config load, with the canonical rewrite shown inline:
+v0.9.21 shipped POSIX-style `${VAR}` / `${VAR:-default}` interpolation on `git_commit_message.since:` only. That syntax still works but emits a deprecation warning at config load, with the canonical rewrite shown inline:
 
 ```text
 alint: warning: rule "pr-conventional-commits": `since: ${ALINT_BASE_SHA}` uses the
-  deprecated v0.9.21 `${VAR}` interpolation syntax. The canonical v0.11+ form is
+  deprecated v0.9.21 `${VAR}` interpolation syntax. The canonical form is
   `{{env.ALINT_BASE_SHA}}`; the `${VAR}` form will be removed in v1.0.
 ```
 

--- a/docs/site/concepts/walker-and-gitignore.md
+++ b/docs/site/concepts/walker-and-gitignore.md
@@ -117,7 +117,7 @@ Behaviour summary:
 
 When `alint` runs outside a git repo (no `.git/`), or when `git` isn't on `PATH`, the tracked-set is empty and absence-style rules with `git_tracked_only: true` become silent no-ops. That's the right default for "don't let X be committed": if there's no repo, there's nothing to commit. Existence rules with the flag set fail in that case (no file qualifies), which is also the correct conservative behaviour.
 
-The other roadmap'd git primitives (`git_no_denied_paths`, `git_commit_message`) are still pending.
+The git-hygiene family also ships `git_commit_message`, `git_no_denied_paths`, and other git-aware kinds; see the rule reference for the full set.
 
 ## Restricting the walk: `--changed`
 

--- a/docs/site/configuration/index.md
+++ b/docs/site/configuration/index.md
@@ -313,4 +313,4 @@ A `--baseline <path>` flag overrides this key. There is **no silent auto-detect*
 
 - [JSON Schema](https://alint.org/_alint/configuration/schema.json): authoritative source for option types.
 - [Rules](/docs/rules/): every rule kind, organised by family, with per-rule options.
-- [Concepts](/docs/concepts/): the rule model and `when:` expression language explained in depth.
+- [Concepts](/docs/concepts/): the rule model, the walker, and how alint runs, explained.


### PR DESCRIPTION
Phase-1 errata hot-fix from the Concepts-redesign audit (#227,
`docs/design/concepts-section-redesign.md`): correct docs that describe **shipped
features as unbuilt**, plus a few adjacent stale/inaccurate claims. All verified
against the current code (v0.16.1). Docs-only, independent of #227, safe to merge
now.

## User-facing pages
- `about/monorepos.md`: `--changed` and the per-iteration `when_iter:` filter were
  called "on the v0.5 roadmap" / "planned for v0.5" -- **both ship.** Removed the
  now-false "per-package iteration" non-goal bullet; corrected the scale-ceiling and
  Bazel-idiom notes.
- `concepts/walker-and-gitignore.md`: `git_commit_message` and `git_no_denied_paths`
  were called "still pending" -- **both ship** (git-hygiene family).
- `about/architecture-diagrams.md`: template syntax shown as `${...}`; it is
  `{{vars.X}}`.
- `concepts/variable-interpolation.md`: dropped the stale "v0.11" version pinning on
  the still-deprecated `${VAR}` form.
- `configuration/index.md`: the "Concepts explains `when:` in depth" cross-link
  over-promised a page that does not exist; reworded to what Concepts covers today.

## Source doc (`ARCHITECTURE.md`)
- Removed the non-existent `.alintignore` (the walker honors
  `.gitignore` / `.ignore` / git exclude + the config `ignore:` list).
- Facts are evaluated **sequentially**, once per run, not "in parallel" (three
  places).
- The `when:` identifier list wrongly included `ctx.` and omitted `iter.` / `env.`;
  `ctx.` is message-only.

https://claude.ai/code/session_01DY5e8zTE8XDCDsaPkJT8Ai
