### PR TITLE
feat: pipeline hero animated SVG (Phase 2 diagram kit)

### DIFF
--- a/docs/design/concepts-section-redesign.md
+++ b/docs/design/concepts-section-redesign.md
@@ -257,8 +257,9 @@ untouched.
   `max-width:100%`.
 - A copy-paste template in the doc + optional shared `@keyframes` hoisted into
   alint.org `src/styles/custom.css` (the same split the site already uses for the
-  LikeC4 loader). A GitHub-faithful static SVG fallback is optional per diagram
-  (GitHub strips animated SVG, exactly as it strips `<likec4-view>` today).
+  LikeC4 loader). A per-diagram GitHub fallback is optional and usually
+  unnecessary: github.com strips inline `<svg>` from Markdown entirely (animated
+  or not), exactly as it strips `<likec4-view>` today (see Appendix 14).
 
 **The diagram set.** One animated diagram per major concept page (fourteen below),
 ranked by teaching value (the concept map's "hardest concepts" ranking). Short or
@@ -424,9 +425,12 @@ concept pages (added `bundled-rulesets`; `severity-and-exit-codes` and
    the cross-file-correctness rule); keeps `the-walker-and-git` focused.
 4. **`baseline` + `the-agent-surface`: stay in Concepts.** Both teach a real
    mental model; task recipes in the Cookbook link to them.
-5. **Static-SVG fallback: hero only.** Concept pages show no diagram on GitHub (an
-   alint.org surface, as with `<likec4-view>` today); a static twin ships only for
-   the hero pipeline diagram.
+5. **GitHub static fallback: inline, no twin files.** github.com strips inline
+   `<svg>` from Markdown entirely, so concept pages show no diagram on GitHub (an
+   alint.org surface, as with `<likec4-view>` today); the numbered steps carry the
+   information. No separate static-twin files ship: the hero instead carries inline
+   presentation-attribute fallbacks (`fill`/`stroke`) that keep it a valid styled
+   diagram in any renderer that drops `<style>` but keeps `<svg>` (Appendix 14).
 6. **`@keyframes`: inline per diagram.** Self-contained and portable; hoist shared
    keyframes into alint.org `custom.css` only if real duplication emerges.
 7. **amorph: bridge now.** Ship inline SVG + CSS now; regenerate each `<svg>` via
@@ -541,3 +545,22 @@ Visual-language token kit (shared across every diagram):
 - Performance: one concept per page means one or two diagrams render per page, so
   the continuous CSS animations carry no meaningful cost; no off-screen pausing
   (which would need JS) is required.
+- Graceful degradation: put light presentation-attribute fallbacks (`fill`,
+  `stroke`) directly on the shapes. On alint.org the CSS classes win over them
+  (CSS beats presentation attributes) and animate with tokens; in any renderer
+  that keeps `<svg>` but drops the `<style>` (a common sanitizer posture) the
+  presentation attributes still render a static, styled diagram, so the file needs
+  no separate static-twin. Note that github.com's Markdown renderer strips inline
+  `<svg>` entirely, so the hero does not appear when this page is viewed on GitHub;
+  that is acceptable, because the canonical surface is the rendered alint.org page
+  and the numbered steps carry the pipeline without the diagram.
+- Uniqueness per page: the `<title>`/`<desc>` ids referenced by `aria-labelledby`,
+  and the `@keyframes` names, must not collide with another diagram on the same
+  page. Namespace them per diagram (the hero uses `pipe-*` ids and `alint-*`
+  keyframes). The token's travel distance is geometry-specific, so retune it when
+  the stage layout changes.
+
+The shipped reference implementation is the pipeline hero in
+`docs/site/concepts/how-it-works.md` (Phase 2): copy its structure for the rest.
+It is deliberately minimal (four stages, one traveling token); richer per-concept
+diagrams build on this base as each page is written.

--- a/docs/site/concepts/how-it-works.md
+++ b/docs/site/concepts/how-it-works.md
@@ -7,6 +7,39 @@ sidebar:
 
 alint reads one declarative `.alint.yml`, makes a single parallel pass over your repository, and emits one report in the format your pipeline wants. Here is the whole pipeline, end to end:
 
+<svg class="alint-pipeline" viewBox="0 0 680 120" role="img" aria-labelledby="pipe-t pipe-d" xmlns="http://www.w3.org/2000/svg">
+  <title id="pipe-t">alint's execution pipeline</title>
+  <desc id="pipe-d">One token flows left to right through four stages: config load, walk, dispatch, and report.</desc>
+  <style>
+    .alint-pipeline { max-width: 100%; height: auto; font: 600 15px system-ui, -apple-system, "Segoe UI", sans-serif; }
+    .alint-pipeline .wire { fill: none; stroke: var(--sl-color-gray-4, #9aa0b4); stroke-width: 2.5; stroke-dasharray: 7 7; animation: alint-flow 1.1s linear infinite; }
+    .alint-pipeline .stage { fill: var(--sl-color-gray-6, #eef1f8); stroke: var(--sl-color-accent, #4338ca); stroke-width: 1.5; }
+    .alint-pipeline .lbl { fill: var(--sl-color-text, #1f2233); }
+    .alint-pipeline .token { fill: var(--sl-color-accent, #4338ca); animation: alint-travel 4s cubic-bezier(.55, 0, .45, 1) infinite; }
+    @keyframes alint-flow { to { stroke-dashoffset: -14; } }
+    @keyframes alint-travel {
+      0% { transform: translateX(0); opacity: 0; }
+      6% { opacity: 1; }
+      94% { opacity: 1; }
+      100% { transform: translateX(510px); opacity: 0; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .alint-pipeline .wire { animation: none; stroke-dasharray: none; }
+      .alint-pipeline .token { animation: none; transform: translateX(510px); opacity: 1; }
+    }
+  </style>
+  <path class="wire" stroke="#9aa0b4" d="M 85 60 H 595" />
+  <g class="lbl" fill="#1f2233" text-anchor="middle">
+    <rect class="stage" fill="#eef1f8" stroke="#4338ca" x="20" y="38" width="130" height="44" rx="8" /><text x="85" y="65">config</text>
+    <rect class="stage" fill="#eef1f8" stroke="#4338ca" x="190" y="38" width="130" height="44" rx="8" /><text x="255" y="65">walk</text>
+    <rect class="stage" fill="#eef1f8" stroke="#4338ca" x="360" y="38" width="130" height="44" rx="8" /><text x="425" y="65">dispatch</text>
+    <rect class="stage" fill="#eef1f8" stroke="#4338ca" x="530" y="38" width="130" height="44" rx="8" /><text x="595" y="65">report</text>
+  </g>
+  <circle class="token" fill="#4338ca" cx="85" cy="60" r="7" />
+</svg>
+
+The numbered steps below trace each stage; the interactive model beneath them lets you explore every component and edge.
+
 <likec4-view view-id="checkFlow"></likec4-view>
 
 1. **Config load.** alint reads the `.alint.yml` at the repository root and resolves any `extends:` (local files, HTTPS sources pinned by a subresource-integrity hash, or bundled rulesets), then validates the merged config against its JSON schema.


### PR DESCRIPTION
**Phase 2** of the Concepts redesign (plan: `docs/design/concepts-section-redesign.md`): the diagram kit + the reference animated diagram.

## What lands
- **The execution-pipeline hero** in `docs/site/concepts/how-it-works.md`: an inline SVG (`config -> walk -> dispatch -> report`) with an accent token flowing through the four stages along an animated dashed wire. It is the reference the remaining concept diagrams copy.
  - Themed via Starlight tokens (`var(--sl-color-*)`), so it matches light/dark automatically.
  - **Reduced-motion guarded** -- rests at the final frame under `prefers-reduced-motion`.
  - **Presentation-attribute fallbacks** (`fill`/`stroke`) on the shapes: CSS wins over them on alint.org (themed + animated), and any renderer that keeps `<svg>` but drops `<style>` still gets a static, styled diagram, so no static-twin file is needed.
  - The interactive LikeC4 `checkFlow` view stays below it as the explorable full model.
  - No `.mdx`, no dependency, no CSS/build change -- pure inline SVG through the verbatim docs sync.
- **`concepts-section-redesign.md`**: recorded the fallback pattern (Appendix 14) and reconciled the GitHub-fallback wording across the doc.

## GitHub note (corrected in this pass)
github.com's Markdown renderer strips inline `<svg>` **entirely** (animated or not), so this page shows no diagram when viewed on GitHub, exactly as `<likec4-view>` is stripped today. That is acceptable: the canonical surface is the rendered alint.org page, and the seven numbered steps carry the pipeline without the diagram. The presentation-attribute fallbacks help the milder case of a sanitizer that keeps `<svg>` but drops `<style>`.

## Validation (end to end)
- Astro build (`build:no-sync`): rc=0, 206 pages; the built page carries the hero with its `<style>`/`@keyframes` intact (not escaped).
- LAN dev server: the page returns HTTP 200 with the hero and the `checkFlow` view present.
- Dogfood (`alint check`): rc=0 (no new violations). Doc-link gate: passes. No em-dash / smart-quote signals in the diff.
- SVG is well-formed XML.

Next: Phase 3 builds the core mental-model pages, each carrying its own diagram in this visual language.

https://claude.ai/code/session_01DY5e8zTE8XDCDsaPkJT8Ai
