### PR TITLE
docs: Phase 3 concepts (core mental-model pages + richer diagrams)

### DIFF
--- a/docs/design/concepts-section-redesign.md
+++ b/docs/design/concepts-section-redesign.md
@@ -384,7 +384,11 @@ whole section under the new grouping.
    Concepts sidebar (5.4).
 7. **Source-doc corrections.** Apply the ARCHITECTURE.md / model errata (section 7).
 
-**Phases 1 and 7 already shipped** in the errata hot-fix (#228, merged); phases 2-6
+**Phases 1 and 7 shipped** in the errata hot-fix (#228); **Phase 2** (diagram kit +
+hero) in #230; **Phase 3** (this PR) rewrites `how-alint-works` and adds
+`the-config-model`, `kinds-families-categories`, and `severity-and-exit-codes` (each
+with a diagram), upgrades the config-model diagram to the richer visual language
+(Appendix 14), and folds in the `vars` / `iter` documentation errata. Phases 4-6
 remain. Each phase is a reviewable PR; content lives in `alint/docs/site/`, so it syncs to
 alint.org through the normal `docs-export` + `docs-bundle` pipeline (ADR-0007). No
 release is required for doc-only pages (the docs-bundle rebuilds from a main
@@ -496,7 +500,32 @@ Worked mini-example (the pipeline page, abbreviated):
 
 ## 14. Appendix: the animated-SVG reference template
 
-The reference implementation (the pipeline hero). Pure inline SVG + inline
+**Current reference: the v3 visual language (shipped in Phases 2-3).** The diagrams on
+`how-alint-works`, `the-config-model`, `kinds-families-categories`, and
+`severity-and-exit-codes` are the living reference; copy the one closest to your
+concept. What the language settled on:
+
+- **Palette (custom vars, theme-swapped).** Each diagram's `<style>` declares
+  `--tx / --mut / --card / --bd / --ac` on its own class, with a
+  `:root[data-theme="dark"]` block and a `@media (prefers-color-scheme: dark)` block
+  so it tracks the docs theme in both directions. Semantic colors are literal and
+  read on both grounds: pass `#22c55e`, fail `#ef4444`, and the family/type hues
+  (blue `#3b82f6`, amber `#f59e0b`, cyan `#06b6d4`, violet `#7c3aed`).
+- **Vocabulary.** Rounded `card`s for entities; a colored left band or a filled badge
+  for a family/tier; small outlined `chip`s for tags; document glyphs with
+  green-check / red-cross status badges for files; a glowing `beam` that sweeps to
+  mean "scanning"; a dashed animated `flow` line between stages.
+- **Narrow and mobile-first.** Lay diagrams out vertically and cap them with
+  `width:100%; max-width:480px` so they fit a phone column and never overflow; verify
+  at 320-414px.
+- **Motion + a11y.** Reduced-motion-guarded animation; `role="img"` plus unique
+  `<title>`/`<desc>` ids and `@keyframes` names per diagram.
+- **QA by screenshot.** Render the built page and inspect the image before shipping
+  (Playwright + chromium are on the box). Test over HTTP, not `file://`: a `file://`
+  load cannot fetch the root-absolute `/_astro/*.css` stylesheets, so the page CSS is
+  absent and the result misleads (self-contained inline-SVG styling still renders).
+
+The original minimal skeleton (kept for reference) follows. The reference implementation (the pipeline hero). Pure inline SVG + inline
 `<style>`: no `.mdx`, no script, no dependency; themed via Starlight tokens with
 literal fallbacks; `prefers-reduced-motion` rests it at the final frame. Every
 concept diagram is a variation on this skeleton reusing the token kit below.

--- a/docs/site/concepts/baseline.md
+++ b/docs/site/concepts/baseline.md
@@ -1,6 +1,6 @@
 ---
 title: Baseline mode
-description: Grandfather a repo's existing violations so `alint check` gates only on new findings — the fingerprint-based baseline file, the two-command workflow, and which formats are baseline-aware.
+description: Grandfather a repo's existing violations so `alint check` gates only on new findings. Covers the fingerprint-based baseline file, the two-command workflow, and which formats are baseline-aware.
 sidebar:
   order: 9
 ---
@@ -11,7 +11,7 @@ This is the standard "ratchet": stop the bleeding now, pay the backlog down on y
 
 ## The two-command workflow
 
-**1. Record the baseline** — run once when you adopt alint (and again when you deliberately pay down or accept debt):
+**1. Record the baseline.** Run once when you adopt alint (and again when you deliberately pay down or accept debt):
 
 ```sh
 alint baseline
@@ -19,7 +19,7 @@ alint baseline
 
 This runs the same whole-tree evaluation as `check`, then writes every current violation to `.alint-baseline.json`. Commit that file.
 
-**2. Enforce the delta** — in CI and locally:
+**2. Enforce the delta.** In CI and locally:
 
 ```sh
 alint check --baseline .alint-baseline.json
@@ -33,11 +33,11 @@ Persist the path in `.alint.yml` so CI need not repeat the flag:
 baseline: .alint-baseline.json
 ```
 
-`--baseline` on the command line overrides the config key. There is **no silent auto-detect** — a baseline suppresses findings only when you opt in explicitly (the config key or the flag), never because the file merely exists. Suppression is always a reviewable, committed decision.
+`--baseline` on the command line overrides the config key. There is **no silent auto-detect**: a baseline suppresses findings only when you opt in explicitly (the config key or the flag), never because the file merely exists. Suppression is always a reviewable, committed decision.
 
 ## The baseline file
 
-`.alint-baseline.json` is **JSON Lines** — a header line, then one sorted entry per grandfathered finding:
+`.alint-baseline.json` is **JSON Lines**, one header line then one sorted entry per grandfathered finding:
 
 ```
 {"schema_version":1,"alint_version":"0.14.0"}
@@ -47,14 +47,14 @@ baseline: .alint-baseline.json
 
 One entry per line (not a single JSON array) is a deliberate choice: it is **merge-friendly**. Two PRs that each grandfather a different finding don't collide on shared array brackets. Entries are sorted, so an unchanged tree regenerates byte-for-byte identically.
 
-The `message` and `path` fields are **advisory** — they exist so a reviewer reading the baseline diff in a PR can see *what* is being grandfathered. Only the `fingerprint` is matched.
+The `message` and `path` fields are **advisory**: they exist so a reviewer reading the baseline diff in a PR can see *what* is being grandfathered. Only the `fingerprint` is matched.
 
 ## Fingerprints, not line numbers
 
-The crux of a usable baseline is a stable identity for each violation. alint fingerprints a violation as a SHA-256 over its rule, its path, and a **content discriminator** — for a line-anchored finding, the offending line's *text*, not its line *number*. So:
+The crux of a usable baseline is a stable identity for each violation. alint fingerprints a violation as a SHA-256 over its rule, its path, and a **content discriminator**: for a line-anchored finding, the offending line's *text*, not its line *number*. So:
 
 - Inserting or deleting unrelated lines elsewhere in the file **does not** churn the baseline (line numbers shift; fingerprints don't).
-- **Editing the offending line itself re-triggers** the rule — the fingerprint changes, so the finding is treated as new and the gate catches it. You can't silently mutate grandfathered-but-broken code into something else that's broken.
+- **Editing the offending line itself re-triggers** the rule: the fingerprint changes, so the finding is treated as new and the gate catches it. You can't silently mutate grandfathered-but-broken code into something else that's broken.
 
 This is why the baseline survives ordinary refactoring without a flood of stale-entry noise, yet never masks a genuinely new problem.
 
@@ -74,19 +74,19 @@ Stale entries (present in the baseline but no longer firing) warn by default; `-
 
 Suppression **marks** violations rather than deleting them, so each formatter does the right thing for its consumer:
 
-- **sarif** — suppressed results are emitted with `suppressions: [{ "kind": "external" }]` and `baselineState: "unchanged"`; new findings get `baselineState: "new"`. This keeps GitHub Code Scanning alerts *open-but-dismissed* instead of flapping fixed-then-reopened as findings resurface.
-- **json** — suppressed findings are omitted from `results` (the gate sees only new), but the envelope carries a `summary.baselined_suppressed` count.
-- **human** — suppressed findings are omitted; the count prints on stderr.
+- **sarif**: suppressed results are emitted with `suppressions: [{ "kind": "external" }]` and `baselineState: "unchanged"`; new findings get `baselineState: "new"`. This keeps GitHub Code Scanning alerts *open-but-dismissed* instead of flapping fixed-then-reopened as findings resurface.
+- **json**: suppressed findings are omitted from `results` (the gate sees only new), but the envelope carries a `summary.baselined_suppressed` count.
+- **human**: suppressed findings are omitted; the count prints on stderr.
 
 Only **sarif** and **json** are baseline-aware; the other formats receive the already-filtered live report. The global `--show-baselined` flag lists the suppressed findings in full, in any format. The exit code is gated on the live (new) findings only, always.
 
 ## What baseline mode does *not* do
 
 - **`fix` does not take `--baseline`.** Auto-fixing is orthogonal to grandfathering; run `fix` normally, then refresh the baseline.
-- **It is not `--changed`.** A baseline must be whole-tree, so `alint baseline` rejects `--changed`/`--base` — a changed-scope snapshot would capture only the diff and silently omit the rest of the legacy tree. Baseline mode and changed-file mode compose at `check` time, not at record time.
+- **It is not `--changed`.** A baseline must be whole-tree, so `alint baseline` rejects `--changed`/`--base`: a changed-scope snapshot would capture only the diff and silently omit the rest of the legacy tree. Baseline mode and changed-file mode compose at `check` time, not at record time.
 
 ## See also
 
 - [`baseline:` configuration key](/docs/configuration/#baseline)
-- [Output formats](/docs/reference/output-formats/) — the full per-format behaviour
-- [The walker and `.gitignore`](/docs/concepts/walker-and-gitignore/) — what the whole-tree evaluation sees
+- [Output formats](/docs/reference/output-formats/): the full per-format behaviour
+- [The walker and `.gitignore`](/docs/concepts/walker-and-gitignore/): what the whole-tree evaluation sees

--- a/docs/site/concepts/content-from.md
+++ b/docs/site/concepts/content-from.md
@@ -5,7 +5,7 @@ sidebar:
   order: 8
 ---
 
-The three content-providing fix ops — `file_create`, `file_prepend`, `file_append` — accept a `content_from: <path>` field as an alternative to inline `content:`. The path resolves relative to the lint root and is read when `alint fix` actually runs, so the source file's bytes flow into the target without round-tripping through YAML.
+The three content-providing fix ops (`file_create`, `file_prepend`, `file_append`) accept a `content_from: <path>` field as an alternative to inline `content:`. The path resolves relative to the lint root and is read when `alint fix` actually runs, so the source file's bytes flow into the target without round-tripping through YAML.
 
 ## When to reach for it
 
@@ -30,12 +30,12 @@ Exactly one of `content:` / `content_from:` must be set on a fix op. Both is a c
 
 ## Resolution semantics
 
-The path is **relative to the lint root** — the path you pass to `alint check` (or `alint fix`), or the current directory if you don't. Same root the rest of alint uses. Absolute paths work but reduce portability across checkouts.
+The path is **relative to the lint root**: the path you pass to `alint check` (or `alint fix`), or the current directory if you don't. Same root the rest of alint uses. Absolute paths work but reduce portability across checkouts.
 
 The source file is read at **fix-apply time**, not at config-load time. Two consequences:
 
-1. The template file doesn't need to exist when `alint check` runs — only when `alint fix` runs against a violating tree. A check-only CI workflow won't fail because the template is missing.
-2. Editing the template between `alint check` and `alint fix` is fine — the latest bytes go into the target.
+1. The template file doesn't need to exist when `alint check` runs, only when `alint fix` runs against a violating tree. A check-only CI workflow won't fail because the template is missing.
+2. Editing the template between `alint check` and `alint fix` is fine; the latest bytes go into the target.
 
 ## Missing source = `Skipped`, not `Error`
 
@@ -46,17 +46,17 @@ If the `content_from:` path doesn't exist or can't be read at fix-apply time, al
 The same `content_from:` shape works on all three:
 
 ```yaml
-# file_create — typical for missing top-level documents
+# file_create: typical for missing top-level documents
 fix:
   file_create:
     content_from: ".alint/templates/LICENSE.txt"
 
-# file_prepend — typical for SPDX / copyright headers
+# file_prepend: typical for SPDX / copyright headers
 fix:
   file_prepend:
     content_from: ".alint/templates/spdx-header.rs"
 
-# file_append — typical for trailing trailers / signoffs
+# file_append: typical for trailing trailers / signoffs
 fix:
   file_append:
     content_from: ".alint/templates/footer.md"
@@ -64,4 +64,4 @@ fix:
 
 ## Working with templates in a monorepo
 
-`content_from:` paths are resolved against the root the user invoked `alint check` from. With `nested_configs: true`, a sub-config in `packages/foo/.alint.yml` still resolves `content_from:` against the workspace root — so a single `.alint/templates/` directory at the root supplies content to every sub-package without duplication. Pair this with rule templates for "every package gets the same generated NOTICE file" patterns.
+`content_from:` paths are resolved against the root the user invoked `alint check` from. With `nested_configs: true`, a sub-config in `packages/foo/.alint.yml` still resolves `content_from:` against the workspace root, so a single `.alint/templates/` directory at the root supplies content to every sub-package without duplication. Pair this with rule templates for "every package gets the same generated NOTICE file" patterns.

--- a/docs/site/concepts/drop-ins.md
+++ b/docs/site/concepts/drop-ins.md
@@ -1,11 +1,11 @@
 ---
 title: 'Drop-in configs (.alint.d/*.yml)'
-description: Auto-discovered alongside the top-level `.alint.yml`, merged alphabetically. The `/etc/*.d/` shape applied to alint configs — stage `00-base.yml` for ops defaults, `99-local.yml` for developer overrides.
+description: Auto-discovered alongside the top-level `.alint.yml`, merged alphabetically. The `/etc/*.d/` shape applied to alint configs. Stage `00-base.yml` for ops defaults, `99-local.yml` for developer overrides.
 sidebar:
   order: 7
 ---
 
-When `.alint.yml` lives alongside a `.alint.d/` directory at the same path, alint discovers every `*.yml` (or `*.yaml`) file inside that directory and merges them into the effective config. Merge order is alphabetical by filename — the **last drop-in wins** on field-level conflict, mirroring the `/etc/*.d/` convention. Non-yaml files (`.gitkeep`, `README.md`) are silently skipped.
+When `.alint.yml` lives alongside a `.alint.d/` directory at the same path, alint discovers every `*.yml` (or `*.yaml`) file inside that directory and merges them into the effective config. Merge order is alphabetical by filename: the **last drop-in wins** on field-level conflict, mirroring the `/etc/*.d/` convention. Non-yaml files (`.gitkeep`, `README.md`) are silently skipped.
 
 ## Layout
 
@@ -21,7 +21,7 @@ Each drop-in is a complete alint config (with its own `version: 1`) that contrib
 
 ## Trust posture
 
-Drop-ins are **trust-equivalent to the main `.alint.yml`** — they live in the same workspace under the user's control, so they CAN declare `custom:` facts and `kind: command` rules without the trust gate that protects HTTPS-fetched and `alint://bundled/` extends. The mental model: anything you'd put in your own `.alint.yml`, you can put in a drop-in.
+Drop-ins are **trust-equivalent to the main `.alint.yml`**: they live in the same workspace under the user's control, so they CAN declare `custom:` facts and `kind: command` rules without the trust gate that protects HTTPS-fetched and `alint://bundled/` extends. The mental model: anything you'd put in your own `.alint.yml`, you can put in a drop-in.
 
 ## Use cases
 
@@ -59,6 +59,6 @@ After merge: `my-custom-rule` has `level: error` (drop-in won the field override
 
 ## Limits
 
-- **Top-level only.** Only the root config gets `.alint.d/` discovery. Sub-extended configs (anything reached via `extends:`) don't get their own drop-ins — that would compound merge complexity beyond reason.
+- **Top-level only.** Only the root config gets `.alint.d/` discovery. Sub-extended configs (anything reached via `extends:`) don't get their own drop-ins. That would compound merge complexity beyond reason.
 - **Alphabetical order is the only knob.** No explicit priority field, no "before this file" hooks. Use the `00-`, `50-`, `99-` convention to reserve ranges; that's how `/etc/*.d/` does it and it's enough.
-- **Merge isn't recursive into nested fields.** Override semantics match `extends:` exactly — top-level keys on a rule mapping merge by id, but nested structures (`fix:` blocks, `paths:` `include`/`exclude` pairs) replace wholesale. Surprising in theory; the right call in practice (overriding `fix.file_create.content` partially is rarely what you actually want).
+- **Merge isn't recursive into nested fields.** Override semantics match `extends:` exactly: top-level keys on a rule mapping merge by id, but nested structures (`fix:` blocks, `paths:` `include`/`exclude` pairs) replace wholesale. Surprising in theory; the right call in practice (overriding `fix.file_create.content` partially is rarely what you actually want).

--- a/docs/site/concepts/how-it-works.md
+++ b/docs/site/concepts/how-it-works.md
@@ -22,9 +22,9 @@ alint reads one declarative config, makes a single parallel pass over your repos
   .alint-check .accent-card { fill:var(--card); stroke:var(--ac); stroke-width:1.6; }
   .alint-check .flow { fill:none; stroke:var(--ac); stroke-width:2; stroke-dasharray:6 6; opacity:.75; animation:chkf 1s linear infinite; }
   .alint-check .scan { animation:chks 6s ease-in-out infinite; }
-  .alint-check .glow { fill:var(--ac); opacity:.10; }
-  .alint-check .beam { fill:var(--ac); opacity:.16; }
-  .alint-check .head { fill:var(--ac); }
+  .alint-check .glow { fill:var(--ac); opacity:.16; }
+  .alint-check .small { font:600 11px system-ui, -apple-system, sans-serif; }
+  .alint-check .exit { font:700 17px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
   .alint-check .off { opacity:.45; }
   @keyframes chkf { to { stroke-dashoffset:-12; } }
   @keyframes chks { 0%{transform:translateY(0);opacity:0} 5%{opacity:1} 92%{transform:translateY(220px);opacity:1} 100%{transform:translateY(220px);opacity:0} }
@@ -37,21 +37,18 @@ alint reads one declarative config, makes a single parallel pass over your repos
 <text class="mono ac" x="34" y="88">.alint.yml</text>
 <text class="mono mut" x="34" y="107" font-size="12">extends: rust@v1</text>
 <rect x="30" y="114" width="182" height="20" rx="10" fill="#ef4444" opacity=".14"/>
-<text class="ui" x="40" y="128" fill="#ef4444" font-size="11">spawn-gate blocks command &#10007;</text>
+<text class="small" x="40" y="128" fill="#ef4444">spawn-gate blocks command &#10007;</text>
 <text class="ui mut" x="34" y="151">facts once &#183; when filters rules</text>
 <text class="ui ac" x="20" y="180">active rules</text>
 <rect class="card" x="20" y="188" width="84" height="24" rx="12" style="stroke:var(--ac)"/><text class="mono tx" x="31" y="204" font-size="12">no_bidi</text>
 <rect class="card" x="112" y="188" width="126" height="24" rx="12" style="stroke:var(--ac)"/><text class="mono tx" x="124" y="204" font-size="12">filename_case</text>
 <rect class="card" x="20" y="220" width="64" height="24" rx="12" style="stroke:#7c3aed"/><text class="mono" x="31" y="236" font-size="12" fill="#7c3aed">pair</text>
 <rect class="card off" x="92" y="220" width="150" height="24" rx="12"/><text class="mono mut off" x="103" y="236" font-size="11">win (when: false)</text>
-<path class="flow" d="M 230 250 V 268"/><text class="ui mut" x="242" y="263">walk</text>
-<rect class="repo" x="20" y="268" width="130" height="14" rx="4"/>
+<path class="flow" d="M 230 250 V 278"/><text class="ui mut" x="242" y="263">walk</text>
 <rect class="repo" x="20" y="280" width="420" height="344" rx="14"/>
 <text class="ui ac" x="34" y="303">repository</text><text class="ui mut" x="116" y="303">walked once, sorted</text>
 <g class="scan">
-  <rect class="glow" x="28" y="306" width="384" height="52" rx="10"/>
-  <rect class="beam" x="32" y="312" width="376" height="40" rx="8"/>
-  <path class="head" d="M 32 322 l 12 10 l -12 10 z"/>
+  <rect class="glow" x="28" y="308" width="384" height="48" rx="10"/>
 </g>
 <rect class="card" x="34" y="312" width="372" height="40" rx="7"/><rect x="34" y="312" width="6" height="40" rx="2" fill="#3b82f6"/><text class="mono tx" x="56" y="337">README.md</text><circle cx="388" cy="332" r="10" fill="#22c55e"/><path d="M383 332 l3.5 3.5 l6 -7" stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
 <rect class="card" x="34" y="356" width="372" height="40" rx="7"/><rect x="34" y="356" width="6" height="40" rx="2" fill="#f59e0b"/><text class="mono tx" x="56" y="381">Cargo.toml</text><circle cx="388" cy="376" r="10" fill="#22c55e"/><path d="M383 376 l3.5 3.5 l6 -7" stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
@@ -74,7 +71,7 @@ alint reads one declarative config, makes a single parallel pass over your repos
 <text class="mono tx" x="60" y="764" font-size="12">filename_case</text>
 <text class="mono mut" x="60" y="781" font-size="11">src/Utils.rs</text>
 <line x1="34" y1="788" x2="426" y2="788" stroke="var(--bd)" stroke-width="1"/>
-<text class="mono" x="34" y="822" fill="#ef4444" font-size="18" font-weight="700">exit 1</text>
+<text class="exit" x="34" y="822" fill="#ef4444">exit 1</text>
 <rect class="card" x="120" y="808" width="60" height="20" rx="10"/><text class="ui mut" x="130" y="822">human</text>
 <rect class="card" x="186" y="808" width="46" height="20" rx="10"/><text class="ui mut" x="194" y="822">json</text>
 <text class="ui mut" x="34" y="848">SARIF, GitHub, and 5 more formats</text>

--- a/docs/site/concepts/how-it-works.md
+++ b/docs/site/concepts/how-it-works.md
@@ -25,7 +25,6 @@ alint reads one declarative config, makes a single parallel pass over your repos
   .alint-check .glow { fill:var(--ac); opacity:.16; }
   .alint-check .small { font:600 11px system-ui, -apple-system, sans-serif; }
   .alint-check .exit { font:700 17px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-  .alint-check .off { opacity:.45; }
   @keyframes chkf { to { stroke-dashoffset:-12; } }
   @keyframes chks { 0%{transform:translateY(0);opacity:0} 5%{opacity:1} 92%{transform:translateY(220px);opacity:1} 100%{transform:translateY(220px);opacity:0} }
   @media (prefers-reduced-motion:reduce){ .alint-check .flow{animation:none;stroke-dasharray:none} .alint-check .scan{animation:none;transform:translateY(88px)} }
@@ -43,7 +42,7 @@ alint reads one declarative config, makes a single parallel pass over your repos
 <rect class="card" x="20" y="188" width="84" height="24" rx="12" style="stroke:var(--ac)"/><text class="mono tx" x="31" y="204" font-size="12">no_bidi</text>
 <rect class="card" x="112" y="188" width="126" height="24" rx="12" style="stroke:var(--ac)"/><text class="mono tx" x="124" y="204" font-size="12">filename_case</text>
 <rect class="card" x="20" y="220" width="64" height="24" rx="12" style="stroke:#7c3aed"/><text class="mono" x="31" y="236" font-size="12" fill="#7c3aed">pair</text>
-<rect class="card off" x="92" y="220" width="150" height="24" rx="12"/><text class="mono mut off" x="103" y="236" font-size="11">win (when: false)</text>
+<rect class="card" x="92" y="220" width="150" height="24" rx="12" stroke-dasharray="4 3"/><text class="mono mut" x="103" y="236" font-size="11">win (when: false)</text>
 <path class="flow" d="M 230 250 V 278"/><text class="ui mut" x="242" y="263">walk</text>
 <rect class="repo" x="20" y="280" width="420" height="344" rx="14"/>
 <text class="ui ac" x="34" y="303">repository</text><text class="ui mut" x="116" y="303">walked once, sorted</text>

--- a/docs/site/concepts/how-it-works.md
+++ b/docs/site/concepts/how-it-works.md
@@ -1,58 +1,122 @@
 ---
 title: How alint works
-description: "A technical overview of alint's execution pipeline: one declarative config, one parallel pass over the repository, one report in your pipeline's format."
+description: "A deep look at alint's execution pipeline: assemble one config, evaluate facts once, filter rules, walk the repository in parallel, dispatch per-file and cross-file rules over a single read of each file, and emit one report."
 sidebar:
   order: 2
 ---
 
-alint reads one declarative `.alint.yml`, makes a single parallel pass over your repository, and emits one report in the format your pipeline wants. Here is the whole pipeline, end to end:
+alint reads one declarative config, makes a single parallel pass over your repository, and emits one report in the format your pipeline wants. The diagram below traces the whole run top to bottom: the command, the config it assembles, the facts and `when:` filter that decide which rules survive, the walk that indexes the repository, the scanner that reads each file once, and the report that comes back with an exit code.
 
-<svg class="alint-pipeline" viewBox="0 0 680 120" role="img" aria-labelledby="pipe-t pipe-d" xmlns="http://www.w3.org/2000/svg">
-  <title id="pipe-t">alint's execution pipeline</title>
-  <desc id="pipe-d">One token flows left to right through four stages: config load, walk, dispatch, and report.</desc>
-  <style>
-    .alint-pipeline { max-width: 100%; height: auto; font: 600 15px system-ui, -apple-system, "Segoe UI", sans-serif; }
-    .alint-pipeline .wire { fill: none; stroke: var(--sl-color-gray-4, #9aa0b4); stroke-width: 2.5; stroke-dasharray: 7 7; animation: alint-flow 1.1s linear infinite; }
-    .alint-pipeline .stage { fill: var(--sl-color-gray-6, #eef1f8); stroke: var(--sl-color-accent, #4338ca); stroke-width: 1.5; }
-    .alint-pipeline .lbl { fill: var(--sl-color-text, #1f2233); }
-    .alint-pipeline .token { fill: var(--sl-color-accent, #4338ca); animation: alint-travel 4s cubic-bezier(.55, 0, .45, 1) infinite; }
-    @keyframes alint-flow { to { stroke-dashoffset: -14; } }
-    @keyframes alint-travel {
-      0% { transform: translateX(0); opacity: 0; }
-      6% { opacity: 1; }
-      94% { opacity: 1; }
-      100% { transform: translateX(510px); opacity: 0; }
-    }
-    @media (prefers-reduced-motion: reduce) {
-      .alint-pipeline .wire { animation: none; stroke-dasharray: none; }
-      .alint-pipeline .token { animation: none; transform: translateX(510px); opacity: 1; }
-    }
-  </style>
-  <path class="wire" stroke="#9aa0b4" d="M 85 60 H 595" />
-  <g class="lbl" fill="#1f2233" text-anchor="middle">
-    <rect class="stage" fill="#eef1f8" stroke="#4338ca" x="20" y="38" width="130" height="44" rx="8" /><text x="85" y="65">config</text>
-    <rect class="stage" fill="#eef1f8" stroke="#4338ca" x="190" y="38" width="130" height="44" rx="8" /><text x="255" y="65">walk</text>
-    <rect class="stage" fill="#eef1f8" stroke="#4338ca" x="360" y="38" width="130" height="44" rx="8" /><text x="425" y="65">dispatch</text>
-    <rect class="stage" fill="#eef1f8" stroke="#4338ca" x="530" y="38" width="130" height="44" rx="8" /><text x="595" y="65">report</text>
-  </g>
-  <circle class="token" fill="#4338ca" cx="85" cy="60" r="7" />
+<svg class="alint-check" viewBox="0 0 460 876" role="img" aria-labelledby="chk-t chk-d" xmlns="http://www.w3.org/2000/svg">
+<title id="chk-t">alint check: the execution pipeline</title>
+<desc id="chk-d">A vertical pipeline. The command runs alint check. The config assembles from .alint.yml and its extends, with a spawn-gate blocking process-spawning rules from extended configs, facts evaluated once, and rules filtered by when. Four active rules survive. The repository is walked once into a sorted index, then scanned file by file: a glowing scanner reads each file once, marking four passes with green checks and two failures with red crosses, while a cross-file rule scans the whole index. The report shows four passed, two failed, and exit code 1 in any of eight formats.</desc>
+<style>
+  .alint-check { --tx:#1e1b4b; --mut:#64748b; --card:#ffffff; --repo:#eaeefb; --bd:#c7cfe0; --ac:#4f46e5; --term:#1e1b3a; width:100%; max-width:480px; height:auto; font:600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  :root[data-theme="dark"] .alint-check { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --repo:#1c2130; --bd:#3b4254; --ac:#8b93f8; --term:#0f1120; }
+  @media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) .alint-check { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --repo:#1c2130; --bd:#3b4254; --ac:#8b93f8; --term:#0f1120; } }
+  .alint-check .mono { font:600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .alint-check .ui   { font:600 12px system-ui, -apple-system, sans-serif; }
+  .alint-check .tx { fill:var(--tx); } .alint-check .mut { fill:var(--mut); } .alint-check .ac { fill:var(--ac); }
+  .alint-check .card { fill:var(--card); stroke:var(--bd); stroke-width:1.3; }
+  .alint-check .repo { fill:var(--repo); stroke:var(--bd); stroke-width:1.4; }
+  .alint-check .accent-card { fill:var(--card); stroke:var(--ac); stroke-width:1.6; }
+  .alint-check .flow { fill:none; stroke:var(--ac); stroke-width:2; stroke-dasharray:6 6; opacity:.75; animation:chkf 1s linear infinite; }
+  .alint-check .scan { animation:chks 6s ease-in-out infinite; }
+  .alint-check .glow { fill:var(--ac); opacity:.10; }
+  .alint-check .beam { fill:var(--ac); opacity:.16; }
+  .alint-check .head { fill:var(--ac); }
+  .alint-check .off { opacity:.45; }
+  @keyframes chkf { to { stroke-dashoffset:-12; } }
+  @keyframes chks { 0%{transform:translateY(0);opacity:0} 5%{opacity:1} 92%{transform:translateY(220px);opacity:1} 100%{transform:translateY(220px);opacity:0} }
+  @media (prefers-reduced-motion:reduce){ .alint-check .flow{animation:none;stroke-dasharray:none} .alint-check .scan{animation:none;transform:translateY(88px)} }
+</style>
+<rect class="card" x="20" y="18" width="420" height="34" rx="6" style="fill:var(--term);stroke:var(--term)"/>
+<text class="mono" x="34" y="40" fill="#22c55e">$</text><text class="mono" x="48" y="40" fill="#e6e8ef">alint check .</text>
+<path class="flow" d="M 230 52 V 66"/>
+<rect class="accent-card" x="20" y="66" width="420" height="94" rx="9"/>
+<text class="mono ac" x="34" y="88">.alint.yml</text>
+<text class="mono mut" x="34" y="107" font-size="12">extends: rust@v1</text>
+<rect x="30" y="114" width="182" height="20" rx="10" fill="#ef4444" opacity=".14"/>
+<text class="ui" x="40" y="128" fill="#ef4444" font-size="11">spawn-gate blocks command &#10007;</text>
+<text class="ui mut" x="34" y="151">facts once &#183; when filters rules</text>
+<text class="ui ac" x="20" y="180">active rules</text>
+<rect class="card" x="20" y="188" width="84" height="24" rx="12" style="stroke:var(--ac)"/><text class="mono tx" x="31" y="204" font-size="12">no_bidi</text>
+<rect class="card" x="112" y="188" width="126" height="24" rx="12" style="stroke:var(--ac)"/><text class="mono tx" x="124" y="204" font-size="12">filename_case</text>
+<rect class="card" x="20" y="220" width="64" height="24" rx="12" style="stroke:#7c3aed"/><text class="mono" x="31" y="236" font-size="12" fill="#7c3aed">pair</text>
+<rect class="card off" x="92" y="220" width="150" height="24" rx="12"/><text class="mono mut off" x="103" y="236" font-size="11">win (when: false)</text>
+<path class="flow" d="M 230 250 V 268"/><text class="ui mut" x="242" y="263">walk</text>
+<rect class="repo" x="20" y="268" width="130" height="14" rx="4"/>
+<rect class="repo" x="20" y="280" width="420" height="344" rx="14"/>
+<text class="ui ac" x="34" y="303">repository</text><text class="ui mut" x="116" y="303">walked once, sorted</text>
+<g class="scan">
+  <rect class="glow" x="28" y="306" width="384" height="52" rx="10"/>
+  <rect class="beam" x="32" y="312" width="376" height="40" rx="8"/>
+  <path class="head" d="M 32 322 l 12 10 l -12 10 z"/>
+</g>
+<rect class="card" x="34" y="312" width="372" height="40" rx="7"/><rect x="34" y="312" width="6" height="40" rx="2" fill="#3b82f6"/><text class="mono tx" x="56" y="337">README.md</text><circle cx="388" cy="332" r="10" fill="#22c55e"/><path d="M383 332 l3.5 3.5 l6 -7" stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+<rect class="card" x="34" y="356" width="372" height="40" rx="7"/><rect x="34" y="356" width="6" height="40" rx="2" fill="#f59e0b"/><text class="mono tx" x="56" y="381">Cargo.toml</text><circle cx="388" cy="376" r="10" fill="#22c55e"/><path d="M383 376 l3.5 3.5 l6 -7" stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+<rect class="card" x="34" y="400" width="372" height="40" rx="7"/><rect x="34" y="400" width="6" height="40" rx="2" fill="#f97316"/><text class="mono tx" x="56" y="425">src/main.rs</text><circle cx="388" cy="420" r="10" fill="#ef4444"/><path d="M384 416 l8 8 M392 416 l-8 8" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+<rect class="card" x="34" y="444" width="372" height="40" rx="7"/><rect x="34" y="444" width="6" height="40" rx="2" fill="#f97316"/><text class="mono tx" x="56" y="469">src/Utils.rs</text><circle cx="388" cy="464" r="10" fill="#ef4444"/><path d="M384 460 l8 8 M392 460 l-8 8" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+<rect class="card" x="34" y="488" width="372" height="40" rx="7"/><rect x="34" y="488" width="6" height="40" rx="2" fill="#06b6d4"/><text class="mono tx" x="56" y="513">ci.yml</text><circle cx="388" cy="508" r="10" fill="#22c55e"/><path d="M383 508 l3.5 3.5 l6 -7" stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+<rect class="card" x="34" y="532" width="372" height="40" rx="7"/><rect x="34" y="532" width="6" height="40" rx="2" fill="#94a3b8"/><text class="mono tx" x="56" y="557">LICENSE</text><circle cx="388" cy="552" r="10" fill="#22c55e"/><path d="M383 552 l3.5 3.5 l6 -7" stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+<line x1="34" y1="584" x2="426" y2="584" stroke="var(--bd)" stroke-width="1" opacity=".5"/>
+<path d="M 40 600 h -6 v 14 h 6" fill="none" stroke="#7c3aed" stroke-width="2"/>
+<text class="ui" x="50" y="611"><tspan fill="#7c3aed">cross-file</tspan><tspan class="mut"> rules scan the whole index (pair)</tspan></text>
+<path class="flow" d="M 230 624 V 640"/><text class="ui mut" x="242" y="635">aggregate</text>
+<rect class="accent-card" x="20" y="640" width="420" height="220" rx="12"/>
+<text class="ui ac" x="34" y="663">report</text>
+<rect x="34" y="672" width="258" height="14" rx="7" fill="#22c55e"/><rect x="296" y="672" width="130" height="14" rx="7" fill="#ef4444"/>
+<text class="ui" x="34" y="704" fill="#22c55e">4 passed</text><text class="ui" x="426" y="704" fill="#ef4444" text-anchor="end">2 failed</text>
+<circle cx="44" cy="720" r="8" fill="#ef4444"/><path d="M40.5 716.5 l7 7 M47.5 716.5 l-7 7" stroke="#fff" stroke-width="1.7" stroke-linecap="round"/>
+<text class="mono tx" x="60" y="724" font-size="12">no_bidi</text>
+<text class="mono mut" x="60" y="741" font-size="11">src/main.rs:12</text>
+<circle cx="44" cy="760" r="8" fill="#ef4444"/><path d="M40.5 756.5 l7 7 M47.5 756.5 l-7 7" stroke="#fff" stroke-width="1.7" stroke-linecap="round"/>
+<text class="mono tx" x="60" y="764" font-size="12">filename_case</text>
+<text class="mono mut" x="60" y="781" font-size="11">src/Utils.rs</text>
+<line x1="34" y1="788" x2="426" y2="788" stroke="var(--bd)" stroke-width="1"/>
+<text class="mono" x="34" y="822" fill="#ef4444" font-size="18" font-weight="700">exit 1</text>
+<rect class="card" x="120" y="808" width="60" height="20" rx="10"/><text class="ui mut" x="130" y="822">human</text>
+<rect class="card" x="186" y="808" width="46" height="20" rx="10"/><text class="ui mut" x="194" y="822">json</text>
+<text class="ui mut" x="34" y="848">SARIF, GitHub, and 5 more formats</text>
 </svg>
 
-The numbered steps below trace each stage; the interactive model beneath them lets you explore every component and edge.
+The design goal is one config, one pass, one report: predictable, fast, and easy to wire into CI. The stages below trace the run in order.
 
-<likec4-view view-id="checkFlow"></likec4-view>
+## 1. Assemble the config
 
-1. **Config load.** alint reads the `.alint.yml` at the repository root and resolves any `extends:` (local files, HTTPS sources pinned by a subresource-integrity hash, or bundled rulesets), then validates the merged config against its JSON schema.
-2. **Facts.** Any `facts:` you declared are evaluated once, sequentially, and cached. Facts answer questions about the repo (does a file exist, how many match a glob, what does a command print) that rules can gate on.
-3. **Rule filter.** Each rule's `when:` condition is evaluated against the facts; rules whose condition is false are dropped before a single file is read.
-4. **Walk.** alint walks the repository once, in parallel, honoring `.gitignore` and your `ignore:` globs, and builds a deterministic, sorted index of the files.
-5. **Dispatch.** Rules split into two classes: cross-file rules scan the whole index, and per-file rules run against each matched file. Either way, every matched file's bytes are read at most once.
-6. **Evaluate and aggregate.** Rules produce violations, which are collected into one report. With `alint fix`, auto-fixable violations are applied to the working tree and the check is re-run.
-7. **Emit.** The report is rendered in your chosen format (human, JSON, SARIF, and the rest) with an exit code your pipeline can gate on.
+alint discovers the `.alint.yml` at the repository root and builds the **effective config**: it resolves every `extends:` source (a local file, an `https://` URL pinned by a SHA-256 hash, or a bundled ruleset resolved offline), caches and cycle-checks them, and field-merges each layer by rule `id`. This is also the trust boundary: a process-spawning rule (`kind: command` and its siblings) or a `custom:` fact that arrives through `extends:` is rejected at load, so adopting someone else's ruleset can never make your machine run their commands. The [config model](/docs/concepts/the-config-model/) covers assembly and precedence in full.
 
-The design goal is one config, one pass, one report: predictable, fast, and easy to wire into CI.
+## 2. Evaluate facts, once
+
+Any `facts:` you declared are evaluated a single time, in order, before any rule runs, and the results are reused for the rest of the run. Facts answer questions about the repository (does a file exist, how many match a glob, what does a command print) that rules gate on.
+
+## 3. Filter rules by `when:`
+
+Each rule's `when:` expression is evaluated against the facts. A rule whose condition is false is dropped **before a single file is read**, so a config that layers in the Rust, Node, Python, and Go rulesets costs almost nothing in a repository that is only one of them.
+
+## 4. Walk the repository
+
+alint walks the tree once, in parallel, honoring `.gitignore` (and `.ignore`, git excludes, and your `ignore:` globs), and builds one deterministic, sorted `FileIndex`. Sorting the index up front is what makes a run reproducible: the same repository produces byte-identical output every time.
+
+## 5. Dispatch: scan each file once
+
+Rules split into two classes, and both run over that single index:
+
+- **Per-file rules** run file-major. alint reads each matched file's bytes **at most once**, no matter how many rules apply to it, and hands that one read to every matching rule (`no_bidi`, `filename_case`, and the rest). This read-coalescing is why adding more per-file rules barely changes a run's cost.
+- **Cross-file rules** run rule-major: each one scans the whole index itself to assert a relationship no single file can (every crate has a README, no two manifests disagree, a reference graph is acyclic).
+
+Both classes run in parallel across cores; their violations are merged and re-sorted so the output stays deterministic.
+
+## 6. Aggregate and emit
+
+The violations collect into one `Report`. alint renders it in your chosen format (human, JSON, SARIF, and five more) and returns an exit code your pipeline can gate on. With `alint fix`, auto-fixable violations are applied to the working tree, serially, and the check re-runs.
 
 ## Going deeper
 
-- [Architecture](/docs/about/architecture/) covers the engine and crate-level design, the dispatch model, and the security boundaries.
+- [The config model](/docs/concepts/the-config-model/) is the language this pipeline evaluates.
+- The interactive model below lets you explore every component and edge of the run:
+
+<likec4-view view-id="checkFlow"></likec4-view>
+
+- [Architecture](/docs/about/architecture/) covers the engine, the crate-level design, and the security boundaries.
 - [Architecture diagrams](/docs/about/architecture-diagrams/) is the interactive gallery of every flow: config load, fix, facts, the walker, the LSP, CI, and more.

--- a/docs/site/concepts/index.md
+++ b/docs/site/concepts/index.md
@@ -52,7 +52,7 @@ Rules reference facts in `when:` to gate themselves conditionally:
   level: error
 ```
 
-The `when:` grammar supports boolean logic (`and` / `or` / `not`), comparison (`==` `!=` `<` `<=` `>` `>=`), `in` (list / substring), `matches` (regex), literal types, and `facts.X` / `vars.X` identifiers. It's deliberately bounded — no arbitrary code, no dynamic evaluation.
+The `when:` grammar supports boolean logic (`and` / `or` / `not`), comparison (`==` `!=` `<` `<=` `>` `>=`), `in` (list / substring), `matches` (regex), literal types, and `facts.X` / `vars.X` / `iter.X` / `env.X` identifiers. It's deliberately bounded — no arbitrary code, no dynamic evaluation.
 
 ## Auto-fix
 

--- a/docs/site/concepts/index.md
+++ b/docs/site/concepts/index.md
@@ -9,25 +9,25 @@ The Concepts section is the conceptual foundation that the rest of the docs assu
 
 ## What alint is
 
-alint is a static Rust binary that lints the *shape* of a repository. Where ESLint lints code and Semgrep lints semantics, alint lints the things in between — required files (READMEs, LICENSEs, SECURITY.md), filename conventions, content patterns, the values inside `package.json` / `Cargo.toml` / GitHub workflows, and cross-file relationships like "every package has a README" or "every header has a matching source file."
+alint is a static Rust binary that lints the *shape* of a repository. Where ESLint lints code and Semgrep lints semantics, alint lints the things in between: required files (READMEs, LICENSEs, SECURITY.md), filename conventions, content patterns, the values inside `package.json` / `Cargo.toml` / GitHub workflows, and cross-file relationships like "every package has a README" or "every header has a matching source file."
 
 ## The rule model
 
 Every rule has:
 
-- **`id`** — a stable, kebab-case identifier. Required. Used to override or disable the rule from a child config.
-- **`kind`** — which built-in rule implementation to invoke (e.g. `file_exists`, `json_path_equals`, `for_each_dir`). Required.
-- **`level`** — `error`, `warning`, `info`, or `off`. Required.
-- **`paths`** — a glob, list of globs, or `{include, exclude}` pair selecting which files the rule applies to. Required for most kinds.
-- **`when`** — an expression gating the rule on facts or vars. Optional.
-- **`fix`** — a fix-op declaration that turns this rule into an auto-fixable one. Optional.
-- **`message`** / **`policy_url`** — display fields shown when the rule fires. Optional.
+- **`id`**: a stable, kebab-case identifier. Required. Used to override or disable the rule from a child config.
+- **`kind`**: which built-in rule implementation to invoke (e.g. `file_exists`, `json_path_equals`, `for_each_dir`). Required.
+- **`level`**: `error`, `warning`, `info`, or `off`. Required.
+- **`paths`**: a glob, list of globs, or `{include, exclude}` pair selecting which files the rule applies to. Required for most kinds.
+- **`when`**: an expression gating the rule on facts or vars. Optional.
+- **`fix`**: a fix-op declaration that turns this rule into an auto-fixable one. Optional.
+- **`message`** / **`policy_url`**: display fields shown when the rule fires. Optional.
 
 Plus kind-specific options. For example, `file_min_lines` takes `min_lines: <int>`; `json_path_matches` takes `path` (a JSONPath) and `matches` (a regex).
 
 ## Composition
 
-alint configs compose via `extends:`. A config can inherit from local files, HTTPS URLs (with SRI hashes), or `alint://bundled/<name>@<rev>`. Children override inherited rules **field-by-field** by id — you only declare the fields that change. `only:` / `except:` filters narrow the inherited rule set further. `nested_configs: true` opts in to discovering `.alint.yml` files in subdirectories and auto-scoping their rules to the subtree they live in.
+alint configs compose via `extends:`. A config can inherit from local files, HTTPS URLs (with SRI hashes), or `alint://bundled/<name>@<rev>`. Children override inherited rules **field-by-field** by id. You only declare the fields that change. `only:` / `except:` filters narrow the inherited rule set further. `nested_configs: true` opts in to discovering `.alint.yml` files in subdirectories and auto-scoping their rules to the subtree they live in.
 
 See the [Cookbook](/docs/cookbook/) for composition patterns in practice.
 
@@ -52,7 +52,7 @@ Rules reference facts in `when:` to gate themselves conditionally:
   level: error
 ```
 
-The `when:` grammar supports boolean logic (`and` / `or` / `not`), comparison (`==` `!=` `<` `<=` `>` `>=`), `in` (list / substring), `matches` (regex), literal types, and `facts.X` / `vars.X` / `iter.X` / `env.X` identifiers. It's deliberately bounded — no arbitrary code, no dynamic evaluation.
+The `when:` grammar supports boolean logic (`and` / `or` / `not`), comparison (`==` `!=` `<` `<=` `>` `>=`), `in` (list / substring), `matches` (regex), literal types, and `facts.X` / `vars.X` / `iter.X` / `env.X` identifiers. It's deliberately bounded: no arbitrary code, no dynamic evaluation.
 
 ## Auto-fix
 

--- a/docs/site/concepts/kinds-families-categories.md
+++ b/docs/site/concepts/kinds-families-categories.md
@@ -1,0 +1,79 @@
+---
+title: Kinds, families, and categories
+description: "alint ships 94 rule kinds (105 with aliases), grouped one way by family (one home each) and another way by category (cross-cutting tags you can filter on)."
+sidebar:
+  order: 4
+---
+
+Every rule names a `kind`: the built-in check it runs. alint ships **94 distinct kinds** (105 counting aliases), and it organizes them two ways at once. Each kind has one home **family**, and each kind is tagged into one or more **categories**. Same thirteen names, two different relationships.
+
+<svg class="alint-kinds" viewBox="0 0 460 440" role="img" aria-labelledby="kfc-t kfc-d" xmlns="http://www.w3.org/2000/svg">
+<title id="kfc-t">Kinds, families, and categories</title>
+<desc id="kfc-d">Each rule kind belongs to exactly one family (its colored home group) but can be tagged into several categories. file_exists is in the Existence family and the existence category. no_bidi_controls is in the Security family, tagged security and encoding. dir_contains is in the Cross-file family, tagged cross-file and structure. filename_case is in the Naming family and the naming category. 105 kinds, 13 families, 13 categories.</desc>
+<style>
+  .alint-kinds { --tx:#1e1b4b; --mut:#64748b; --card:#ffffff; --bd:#c7cfe0; --ac:#4f46e5; width:100%; max-width:480px; height:auto; font:600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  :root[data-theme="dark"] .alint-kinds { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; }
+  @media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) .alint-kinds { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; } }
+  .alint-kinds .mono { font:600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .alint-kinds .ui { font:600 12px system-ui, -apple-system, sans-serif; }
+  .alint-kinds .tx { fill:var(--tx); } .alint-kinds .mut { fill:var(--mut); } .alint-kinds .ac { fill:var(--ac); }
+  .alint-kinds .card { fill:var(--card); stroke:var(--bd); stroke-width:1.3; }
+  .alint-kinds .chip { fill:none; stroke:var(--bd); stroke-width:1.1; }
+  .alint-kinds .extra { animation:kpulse 2.6s ease-in-out infinite; }
+  @keyframes kpulse { 0%,100% { opacity:.55; } 50% { opacity:1; } }
+  @media (prefers-reduced-motion:reduce){ .alint-kinds .extra { animation:none; opacity:1; } }
+</style>
+<text class="ui ac" x="18" y="15">one family, many categories</text>
+<text class="ui mut" x="18" y="33">105 kinds &#183; 13 families &#183; 13 categories</text>
+<rect class="card" x="20" y="46" width="420" height="58" rx="8"/><rect x="20" y="46" width="6" height="58" rx="2" fill="#3b82f6"/>
+<text class="mono tx" x="38" y="72" font-size="14">file_exists</text>
+<rect x="330" y="56" width="92" height="22" rx="11" fill="#3b82f6"/><text class="ui" x="376" y="71" text-anchor="middle" fill="#fff">Existence</text>
+<rect class="chip" x="38" y="82" width="76" height="18" rx="9"/><text class="mono mut" x="48" y="95" font-size="10">existence</text>
+<rect class="card" x="20" y="116" width="420" height="58" rx="8"/><rect x="20" y="116" width="6" height="58" rx="2" fill="#ef4444"/>
+<text class="mono tx" x="38" y="142" font-size="14">no_bidi_controls</text>
+<rect x="336" y="126" width="86" height="22" rx="11" fill="#ef4444"/><text class="ui" x="379" y="141" text-anchor="middle" fill="#fff">Security</text>
+<rect class="chip" x="38" y="152" width="70" height="18" rx="9"/><text class="mono mut" x="48" y="165" font-size="10">security</text>
+<g class="extra"><rect class="chip" x="114" y="152" width="72" height="18" rx="9"/><text class="mono mut" x="124" y="165" font-size="10">encoding</text></g>
+<rect class="card" x="20" y="186" width="420" height="58" rx="8"/><rect x="20" y="186" width="6" height="58" rx="2" fill="#7c3aed"/>
+<text class="mono tx" x="38" y="212" font-size="14">dir_contains</text>
+<rect x="330" y="196" width="92" height="22" rx="11" fill="#7c3aed"/><text class="ui" x="376" y="211" text-anchor="middle" fill="#fff">Cross-file</text>
+<rect class="chip" x="38" y="222" width="78" height="18" rx="9"/><text class="mono mut" x="48" y="235" font-size="10">cross-file</text>
+<g class="extra"><rect class="chip" x="126" y="222" width="74" height="18" rx="9"/><text class="mono mut" x="136" y="235" font-size="10">structure</text></g>
+<rect class="card" x="20" y="256" width="420" height="58" rx="8"/><rect x="20" y="256" width="6" height="58" rx="2" fill="#06b6d4"/>
+<text class="mono tx" x="38" y="282" font-size="14">filename_case</text>
+<rect x="346" y="266" width="76" height="22" rx="11" fill="#06b6d4"/><text class="ui" x="384" y="281" text-anchor="middle" fill="#fff">Naming</text>
+<rect class="chip" x="38" y="292" width="64" height="18" rx="9"/><text class="mono mut" x="48" y="305" font-size="10">naming</text>
+<line x1="20" y1="336" x2="440" y2="336" stroke="var(--bd)" stroke-width="1" opacity=".5"/>
+<rect x="20" y="352" width="14" height="14" rx="3" fill="#7c3aed"/><text class="ui tx" x="42" y="363">colored band = the one family a kind belongs to</text>
+<rect class="chip" x="20" y="380" width="14" height="14" rx="7"/><text class="ui tx" x="42" y="391">chips = its categories; 32 kinds carry more than one,</text>
+<text class="ui mut" x="42" y="410">so categories cross-cut the families</text>
+</svg>
+
+## Kinds are the checks
+
+A `kind` is the built-in implementation a rule invokes: `file_exists`, `no_bidi_controls`, `filename_case`, `json_schema_passes`, and 90 more. Every rule declares exactly one, and the `kind` is what decides which extra fields the rule accepts (a `file_header` takes a `pattern`, a `file_max_size` takes a byte limit). A handful of kinds have **aliases**, second names for the same implementation, which is why the catalog counts 105 entries for 94 distinct checks.
+
+## Families are the home group
+
+The 94 kinds are partitioned into **13 families** by mechanism: Existence, Content, Naming, Structure, Cross-file, Security / Unicode sanity, Text hygiene, Encoding, Portable metadata, Unix metadata, Git hygiene, Structured query, and Plugin. Every kind belongs to **exactly one** family, so the families are a clean table of contents for the catalog. `alint rules list` prints the kinds grouped this way.
+
+## Categories are cross-cutting tags
+
+The **13 categories** carry the same thirteen names, but the relationship is many-to-many: a kind can be tagged with several. A kind's home family is always its primary category, and **32 kinds carry extra tags** on top. `no_bidi_controls` lives in the Security family but is also tagged `encoding`; `dir_contains` lives in Cross-file but is also tagged `structure`. That is the whole distinction: **family answers "where does this kind live?" (one answer), category answers "what concerns does it touch?" (often several).** Categories are what you filter on when you want every check that bears on, say, security, regardless of which family implements it.
+
+## In practice
+
+Browse the catalog by family, or filter it by category:
+
+```
+alint rules list                       # every kind alint ships, grouped by family
+alint rules list --category security   # only the kinds tagged "security"
+alint list --category security         # only YOUR configured rules that are "security"
+```
+
+An unknown category slug fails fast with the list of the thirteen valid ones, so a typo never silently returns nothing.
+
+## Going deeper
+
+- [Rules](/docs/rules/) is the full reference for every kind, grouped by family, with each kind's fields and examples.
+- [The config model](/docs/concepts/the-config-model/) shows how a `kind` sits inside the rule record.

--- a/docs/site/concepts/kinds-families-categories.md
+++ b/docs/site/concepts/kinds-families-categories.md
@@ -19,30 +19,31 @@ Every rule names a `kind`: the built-in check it runs. alint ships **94 distinct
   .alint-kinds .tx { fill:var(--tx); } .alint-kinds .mut { fill:var(--mut); } .alint-kinds .ac { fill:var(--ac); }
   .alint-kinds .card { fill:var(--card); stroke:var(--bd); stroke-width:1.3; }
   .alint-kinds .chip { fill:none; stroke:var(--bd); stroke-width:1.1; }
-  .alint-kinds .extra { animation:kpulse 2.6s ease-in-out infinite; }
-  @keyframes kpulse { 0%,100% { opacity:.55; } 50% { opacity:1; } }
-  @media (prefers-reduced-motion:reduce){ .alint-kinds .extra { animation:none; opacity:1; } }
+  .alint-kinds .tag { font:600 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; fill:var(--mut); }
+  .alint-kinds .extra { animation:kpulse 2.8s ease-in-out infinite; }
+  @keyframes kpulse { 0%,100% { stroke:var(--bd); } 50% { stroke:var(--ac); } }
+  @media (prefers-reduced-motion:reduce){ .alint-kinds .extra { animation:none; } }
 </style>
 <text class="ui ac" x="18" y="15">one family, many categories</text>
 <text class="ui mut" x="18" y="33">105 kinds &#183; 13 families &#183; 13 categories</text>
 <rect class="card" x="20" y="46" width="420" height="58" rx="8"/><rect x="20" y="46" width="6" height="58" rx="2" fill="#3b82f6"/>
 <text class="mono tx" x="38" y="72" font-size="14">file_exists</text>
 <rect x="330" y="56" width="92" height="22" rx="11" fill="#3b82f6"/><text class="ui" x="376" y="71" text-anchor="middle" fill="#fff">Existence</text>
-<rect class="chip" x="38" y="82" width="76" height="18" rx="9"/><text class="mono mut" x="48" y="95" font-size="10">existence</text>
+<rect class="chip" x="38" y="82" width="82" height="18" rx="9"/><text class="tag" x="49" y="95">existence</text>
 <rect class="card" x="20" y="116" width="420" height="58" rx="8"/><rect x="20" y="116" width="6" height="58" rx="2" fill="#ef4444"/>
 <text class="mono tx" x="38" y="142" font-size="14">no_bidi_controls</text>
 <rect x="336" y="126" width="86" height="22" rx="11" fill="#ef4444"/><text class="ui" x="379" y="141" text-anchor="middle" fill="#fff">Security</text>
-<rect class="chip" x="38" y="152" width="70" height="18" rx="9"/><text class="mono mut" x="48" y="165" font-size="10">security</text>
-<g class="extra"><rect class="chip" x="114" y="152" width="72" height="18" rx="9"/><text class="mono mut" x="124" y="165" font-size="10">encoding</text></g>
+<rect class="chip" x="38" y="152" width="76" height="18" rx="9"/><text class="tag" x="49" y="165">security</text>
+<rect class="chip extra" x="122" y="152" width="76" height="18" rx="9"/><text class="tag" x="133" y="165">encoding</text>
 <rect class="card" x="20" y="186" width="420" height="58" rx="8"/><rect x="20" y="186" width="6" height="58" rx="2" fill="#7c3aed"/>
 <text class="mono tx" x="38" y="212" font-size="14">dir_contains</text>
 <rect x="330" y="196" width="92" height="22" rx="11" fill="#7c3aed"/><text class="ui" x="376" y="211" text-anchor="middle" fill="#fff">Cross-file</text>
-<rect class="chip" x="38" y="222" width="78" height="18" rx="9"/><text class="mono mut" x="48" y="235" font-size="10">cross-file</text>
-<g class="extra"><rect class="chip" x="126" y="222" width="74" height="18" rx="9"/><text class="mono mut" x="136" y="235" font-size="10">structure</text></g>
+<rect class="chip" x="38" y="222" width="90" height="18" rx="9"/><text class="tag" x="49" y="235">cross-file</text>
+<rect class="chip extra" x="136" y="222" width="82" height="18" rx="9"/><text class="tag" x="147" y="235">structure</text>
 <rect class="card" x="20" y="256" width="420" height="58" rx="8"/><rect x="20" y="256" width="6" height="58" rx="2" fill="#06b6d4"/>
 <text class="mono tx" x="38" y="282" font-size="14">filename_case</text>
 <rect x="346" y="266" width="76" height="22" rx="11" fill="#06b6d4"/><text class="ui" x="384" y="281" text-anchor="middle" fill="#fff">Naming</text>
-<rect class="chip" x="38" y="292" width="64" height="18" rx="9"/><text class="mono mut" x="48" y="305" font-size="10">naming</text>
+<rect class="chip" x="38" y="292" width="62" height="18" rx="9"/><text class="tag" x="49" y="305">naming</text>
 <line x1="20" y1="336" x2="440" y2="336" stroke="var(--bd)" stroke-width="1" opacity=".5"/>
 <rect x="20" y="352" width="14" height="14" rx="3" fill="#7c3aed"/><text class="ui tx" x="42" y="363">colored band = the one family a kind belongs to</text>
 <rect class="chip" x="20" y="380" width="14" height="14" rx="7"/><text class="ui tx" x="42" y="391">chips = its categories; 32 kinds carry more than one,</text>

--- a/docs/site/concepts/severity-and-exit-codes.md
+++ b/docs/site/concepts/severity-and-exit-codes.md
@@ -1,0 +1,70 @@
+---
+title: Severity and exit codes
+description: "How a rule's level (error, warning, info, off) maps to alint's process exit code, and how --fail-on-warning tightens the gate for CI."
+sidebar:
+  order: 5
+---
+
+Every rule carries a `level`, and every `alint check` returns an exit code. The level decides how loud a finding is; the exit code is what your CI gates on. The mapping is small and fixed.
+
+<svg class="alint-sev" viewBox="0 0 460 292" role="img" aria-labelledby="sev-t sev-d" xmlns="http://www.w3.org/2000/svg">
+<title id="sev-t">Severity levels mapped to exit codes</title>
+<desc id="sev-d">A rule's level maps to an exit code. error exits 1 and fails the run. warning exits 0 by default, or 1 with the --fail-on-warning flag. info exits 0 and is reported only. off means the rule is skipped. A bad config or usage exits 2; an internal error exits 3.</desc>
+<style>
+  .alint-sev { --tx:#1e1b4b; --mut:#64748b; --card:#ffffff; --bd:#c7cfe0; --ac:#4f46e5; width:100%; max-width:480px; height:auto; font:600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  :root[data-theme="dark"] .alint-sev { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; }
+  @media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) .alint-sev { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; } }
+  .alint-sev .mono { font:600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .alint-sev .ui { font:600 12px system-ui, -apple-system, sans-serif; }
+  .alint-sev .tx { fill:var(--tx); } .alint-sev .mut { fill:var(--mut); } .alint-sev .ac { fill:var(--ac); }
+</style>
+<text class="ui ac" x="18" y="16">a level maps to an exit code</text>
+<rect x="20" y="42" width="90" height="28" rx="14" fill="#ef4444"/><text class="ui" x="65" y="61" text-anchor="middle" fill="#fff">error</text>
+<text class="mono mut" x="122" y="61">&#8594;</text><text class="mono" x="146" y="61" fill="#ef4444" font-weight="700">exit 1</text><text class="mono mut" x="212" y="61" font-size="12">fails the run</text>
+<rect x="20" y="86" width="90" height="28" rx="14" fill="#f59e0b"/><text class="ui" x="65" y="105" text-anchor="middle" fill="#fff">warning</text>
+<text class="mono mut" x="122" y="105">&#8594;</text><text class="mono tx" x="146" y="105">exit 0</text><text class="mono mut" x="212" y="105" font-size="12">or 1 with --fail-on-warning</text>
+<rect x="20" y="130" width="90" height="28" rx="14" fill="#3b82f6"/><text class="ui" x="65" y="149" text-anchor="middle" fill="#fff">info</text>
+<text class="mono mut" x="122" y="149">&#8594;</text><text class="mono tx" x="146" y="149">exit 0</text><text class="mono mut" x="212" y="149" font-size="12">reported only</text>
+<rect x="20" y="174" width="90" height="28" rx="14" fill="#94a3b8"/><text class="ui" x="65" y="193" text-anchor="middle" fill="#fff">off</text>
+<text class="mono mut" x="122" y="193">&#8594;</text><text class="mono mut" x="146" y="193">skipped</text><text class="mono mut" x="230" y="193" font-size="12">rule never runs</text>
+<line x1="20" y1="224" x2="440" y2="224" stroke="var(--bd)" stroke-width="1" opacity=".5"/>
+<text class="mono mut" x="20" y="250" font-size="12">exit 2 = bad config or usage</text>
+<text class="mono mut" x="20" y="272" font-size="12">exit 3 = internal error</text>
+</svg>
+
+## The four levels
+
+- **`error`** is a hard failure. Any error-level violation makes `alint check` exit non-zero, which is what fails a CI job or blocks a commit.
+- **`warning`** is reported but does not fail the run by default. Pass `--fail-on-warning` to promote warnings into failures when you want a stricter gate.
+- **`info`** is advisory. It shows in the report and never affects the exit code.
+- **`off`** disables the rule entirely: it is dropped at config load and never runs. Setting `level: off` on an inherited rule is how you switch off something a ruleset you `extends:` turned on.
+
+## The exit codes
+
+`alint check` returns one of four codes, so a pipeline can tell "clean" from "found problems" from "misconfigured":
+
+- **`0`** clean: no errors, and no warnings under `--fail-on-warning`.
+- **`1`** findings: at least one error, or a warning while `--fail-on-warning` is set.
+- **`2`** a bad config or bad usage (an unknown field, a malformed `.alint.yml`, an invalid flag).
+- **`3`** an internal error (a bug). Distinct from `2` so CI can tell "your config is wrong" apart from "alint fell over."
+
+## In practice
+
+A CI step that blocks on errors is just `alint check` (a non-zero exit fails the job). To also block on warnings during a hardening push:
+
+```
+alint check --fail-on-warning
+```
+
+And to keep a rule in the config but stop it from firing, without deleting it:
+
+```yaml
+rules:
+  - id: legacy-header
+    level: off      # inherited from a ruleset; silenced here
+```
+
+## Going deeper
+
+- [The config model](/docs/concepts/the-config-model/) covers where `level` sits in the rule record and how a child config overrides it.
+- [How alint works](/docs/concepts/how-it-works/) shows where the report and its exit code are produced.

--- a/docs/site/concepts/severity-and-exit-codes.md
+++ b/docs/site/concepts/severity-and-exit-codes.md
@@ -17,16 +17,19 @@ Every rule carries a `level`, and every `alint check` returns an exit code. The 
   .alint-sev .mono { font:600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
   .alint-sev .ui { font:600 12px system-ui, -apple-system, sans-serif; }
   .alint-sev .tx { fill:var(--tx); } .alint-sev .mut { fill:var(--mut); } .alint-sev .ac { fill:var(--ac); }
+  .alint-sev .flow { fill:none; stroke:var(--ac); stroke-width:2; stroke-dasharray:5 5; opacity:.7; animation:sflow 1s linear infinite; }
+  @keyframes sflow { to { stroke-dashoffset:-10; } }
+  @media (prefers-reduced-motion:reduce){ .alint-sev .flow { animation:none; stroke-dasharray:none; } }
 </style>
 <text class="ui ac" x="18" y="16">a level maps to an exit code</text>
 <rect x="20" y="42" width="90" height="28" rx="14" fill="#ef4444"/><text class="ui" x="65" y="61" text-anchor="middle" fill="#fff">error</text>
-<text class="mono mut" x="122" y="61">&#8594;</text><text class="mono" x="146" y="61" fill="#ef4444" font-weight="700">exit 1</text><text class="mono mut" x="212" y="61" font-size="12">fails the run</text>
+<path class="flow" d="M 116 56 H 138"/><path fill="var(--ac)" d="M 138 52 L 145 56 L 138 60 Z"/><text class="mono" x="146" y="61" fill="#ef4444" font-weight="700">exit 1</text><text class="mono mut" x="212" y="61" font-size="12">fails the run</text>
 <rect x="20" y="86" width="90" height="28" rx="14" fill="#f59e0b"/><text class="ui" x="65" y="105" text-anchor="middle" fill="#fff">warning</text>
-<text class="mono mut" x="122" y="105">&#8594;</text><text class="mono tx" x="146" y="105">exit 0</text><text class="mono mut" x="212" y="105" font-size="12">or 1 with --fail-on-warning</text>
+<path class="flow" d="M 116 100 H 138"/><path fill="var(--ac)" d="M 138 96 L 145 100 L 138 104 Z"/><text class="mono tx" x="146" y="105">exit 0</text><text class="mono mut" x="212" y="105" font-size="12">or 1 with --fail-on-warning</text>
 <rect x="20" y="130" width="90" height="28" rx="14" fill="#3b82f6"/><text class="ui" x="65" y="149" text-anchor="middle" fill="#fff">info</text>
-<text class="mono mut" x="122" y="149">&#8594;</text><text class="mono tx" x="146" y="149">exit 0</text><text class="mono mut" x="212" y="149" font-size="12">reported only</text>
+<path class="flow" d="M 116 144 H 138"/><path fill="var(--ac)" d="M 138 140 L 145 144 L 138 148 Z"/><text class="mono tx" x="146" y="149">exit 0</text><text class="mono mut" x="212" y="149" font-size="12">reported only</text>
 <rect x="20" y="174" width="90" height="28" rx="14" fill="#94a3b8"/><text class="ui" x="65" y="193" text-anchor="middle" fill="#fff">off</text>
-<text class="mono mut" x="122" y="193">&#8594;</text><text class="mono mut" x="146" y="193">skipped</text><text class="mono mut" x="230" y="193" font-size="12">rule never runs</text>
+<path class="flow" d="M 116 188 H 138"/><path fill="var(--ac)" d="M 138 184 L 145 188 L 138 192 Z"/><text class="mono mut" x="146" y="193">skipped</text><text class="mono mut" x="230" y="193" font-size="12">rule never runs</text>
 <line x1="20" y1="224" x2="440" y2="224" stroke="var(--bd)" stroke-width="1" opacity=".5"/>
 <text class="mono mut" x="20" y="250" font-size="12">exit 2 = bad config or usage</text>
 <text class="mono mut" x="20" y="272" font-size="12">exit 3 = internal error</text>

--- a/docs/site/concepts/suggest.md
+++ b/docs/site/concepts/suggest.md
@@ -1,11 +1,11 @@
 ---
 title: Suggesting rules
-description: How `alint suggest` scans a repo for antipatterns and existing tooling, then proposes bundled rulesets and rule entries to adopt — the signals, confidence levels, and review-only output.
+description: How `alint suggest` scans a repo for antipatterns and existing tooling, then proposes bundled rulesets and rule entries to adopt. Covers the signals, confidence levels, and review-only output.
 sidebar:
   order: 10
 ---
 
-The bundled rulesets cover the common ground, but every repo has conventions no generic ruleset knows about. `alint suggest` closes that gap: it scans your working tree for evidence that a rule *would* have caught something, and proposes the bundled rulesets and rule entries that fit. It is **review-only** — it never edits your `.alint.yml`; you copy across what you agree with.
+The bundled rulesets cover the common ground, but every repo has conventions no generic ruleset knows about. `alint suggest` closes that gap: it scans your working tree for evidence that a rule *would* have caught something, and proposes the bundled rulesets and rule entries that fit. It is **review-only**: it never edits your `.alint.yml`; you copy across what you agree with.
 
 Think of it as the counterpart to `alint init`: `init` scaffolds from ecosystem *markers* (a `Cargo.toml` → the Rust ruleset), while `suggest` reasons from *evidence in the tree* (three `console.log` calls in `src/` → a rule to forbid them).
 
@@ -15,7 +15,7 @@ Think of it as the counterpart to `alint init`: `init` scaffolds from ecosystem 
 alint suggest              # human-readable proposal table
 ```
 
-Read the proposals, then adopt the ones you want — either by hand, or by piping the paste-ready snippet into your config and editing it down:
+Read the proposals, then adopt the ones you want, either by hand or by piping the paste-ready snippet into your config and editing it down:
 
 ```sh
 alint suggest --format yaml >> .alint.yml   # then trim to what you accept
@@ -27,7 +27,7 @@ Re-run it periodically, or after onboarding a new area of the codebase, to catch
 
 Two kinds of signal, each shipping at a different confidence:
 
-- **Ecosystem markers → bundled rulesets** (HIGH). A manifest or lockfile that maps to a bundled ruleset you don't already extend — e.g. a `go.mod` pointing at the `go` ruleset. Deduplicated against your existing `extends:` unless you pass `--include-bundled`.
+- **Ecosystem markers → bundled rulesets** (HIGH). A manifest or lockfile that maps to a bundled ruleset you don't already extend, e.g. a `go.mod` pointing at the `go` ruleset. Deduplicated against your existing `extends:` unless you pass `--include-bundled`.
 - **Antipatterns in the tree → specific rules** (MEDIUM). Concrete residue a rule would catch, for example:
   - `console.log` / `console.debug` calls in production source → a rule that forbids them.
   - `.bak` files and scratch docs sitting at the repo root → `file_absent` rules.
@@ -44,24 +44,24 @@ alint suggest --confidence high   # only the strongest signals (ecosystem-marker
 alint suggest --confidence low    # broadest; useful when prospecting, but noisier
 ```
 
-The default floor is **medium** — low-confidence hits are prospecting aids, not recommendations, so they stay hidden unless you ask. Proposals print in deterministic order (by confidence, then id), so the same tree always yields the same output.
+The default floor is **medium**: low-confidence hits are prospecting aids, not recommendations, so they stay hidden unless you ask. Proposals print in deterministic order (by confidence, then id), so the same tree always yields the same output.
 
 ## Output
 
-- **human** (default) — a grouped, colorized proposal table.
-- **`--format yaml`** — a paste-ready `.alint.yml` snippet, header-commented with the scan timestamp and a "review each rule before adopting" reminder.
-- **`--format json`** — a stable `{ proposals: [{ id, kind, evidence, confidence }, … ] }` shape for agent consumption.
-- **`--explain`** — print one-line, file-level evidence under each proposal so a reviewer can decide quickly.
-- **`--include-bundled`** — also suggest bundled rulesets you already extend (off by default, since you presumably adopted those deliberately).
+- **human** (default): a grouped, colorized proposal table.
+- **`--format yaml`**: a paste-ready `.alint.yml` snippet, header-commented with the scan timestamp and a "review each rule before adopting" reminder.
+- **`--format json`**: a stable `{ proposals: [{ id, kind, evidence, confidence }, ... ] }` shape for agent consumption.
+- **`--explain`**: print one-line, file-level evidence under each proposal so a reviewer can decide quickly.
+- **`--include-bundled`**: also suggest bundled rulesets you already extend (off by default, since you presumably adopted those deliberately).
 
 Progress on a large tree renders on stderr (`--progress` / `--quiet` control it); a `--format json` payload on stdout stays byte-clean.
 
 ## What it does *not* do
 
-`suggest` **never writes to your config** — every output is review-only, so a scan can't surprise you with a rule you didn't vet. It also doesn't *run* the proposed rules against your tree; it proposes what would help, and you decide. Once you've adopted rules on an established repo, pair it with [baseline mode](/docs/concepts/baseline/) to grandfather the existing violations and gate only on new ones.
+`suggest` **never writes to your config**: every output is review-only, so a scan can't surprise you with a rule you didn't vet. It also doesn't *run* the proposed rules against your tree; it proposes what would help, and you decide. Once you've adopted rules on an established repo, pair it with [baseline mode](/docs/concepts/baseline/) to grandfather the existing violations and gate only on new ones.
 
 ## See also
 
-- [`alint suggest` CLI reference](/docs/cli/suggest/) — every flag, captured from the binary
-- [Baseline mode](/docs/concepts/baseline/) — adopting on a repo with existing debt
-- [Rules](/docs/rules/) — the bundled rulesets and rule kinds `suggest` proposes
+- [`alint suggest` CLI reference](/docs/cli/suggest/): every flag, captured from the binary
+- [Baseline mode](/docs/concepts/baseline/): adopting on a repo with existing debt
+- [Rules](/docs/rules/): the bundled rulesets and rule kinds `suggest` proposes

--- a/docs/site/concepts/templates.md
+++ b/docs/site/concepts/templates.md
@@ -35,7 +35,7 @@ rules:
     vars: { dir: apps }
 ```
 
-That config produces three independent rules — `packages-have-readme`, `services-have-readme`, `apps-have-readme` — each scoped to the right directory, each with its own substituted message.
+That config produces three independent rules (`packages-have-readme`, `services-have-readme`, `apps-have-readme`), each scoped to the right directory, each with its own substituted message.
 
 ## Substitution
 
@@ -55,7 +55,7 @@ templates:
         content_from: "templates/{{vars.lang}}.Cargo.toml"
 ```
 
-Unknown placeholders are preserved literally — a typo in `{{vars.languge}}` shows up in the rule's output rather than silently blanking out a field.
+Unknown placeholders are preserved literally: a typo in `{{vars.languge}}` shows up in the rule's output rather than silently blanking out a field.
 
 ## Field-level overrides on instances
 
@@ -69,7 +69,7 @@ rules:
     vars: { dir: services }
 ```
 
-The instance's `id:` is required (templates don't carry an id into the instance — each instance owns its own); `vars:` and `extends_template:` are template-control fields that get stripped during expansion.
+The instance's `id:` is required (templates don't carry an id into the instance, so each instance owns its own); `vars:` and `extends_template:` are template-control fields that get stripped during expansion.
 
 ## Composition with extends
 
@@ -77,7 +77,7 @@ Templates merge through the `extends:` chain by id, the same way rules and facts
 
 ## Leaf-only
 
-A template can't itself reference `extends_template:` — the schema rejects it at config-load time with a clear "templates are leaf-only" error. This mirrors the bundled-rulesets restriction (which can't `extends:` themselves either): chained templates would invite cycles and silent depth explosions, both of which are awful to debug. If you need template hierarchies, build a thin pass-through rule that calls the inner template instead.
+A template can't itself reference `extends_template:`. The schema rejects it at config-load time with a clear "templates are leaf-only" error. This mirrors the bundled-rulesets restriction (which can't `extends:` themselves either): chained templates would invite cycles and silent depth explosions, both of which are awful to debug. If you need template hierarchies, build a thin pass-through rule that calls the inner template instead.
 
 ## When to reach for templates
 
@@ -87,4 +87,4 @@ Use templates when you'd otherwise write the same rule N times with one field va
 - Per-language hygiene overlays driven by language facts
 - Per-customer / per-environment config that swaps a name or URL
 
-Don't reach for templates when only a single instance exists today — instantiating once is just indirection. And templates are no substitute for `extends:` for whole-config composition; they're for intra-config repetition.
+Don't reach for templates when only a single instance exists today; instantiating once is just indirection. And templates are no substitute for `extends:` for whole-config composition; they're for intra-config repetition.

--- a/docs/site/concepts/the-config-model.md
+++ b/docs/site/concepts/the-config-model.md
@@ -1,0 +1,119 @@
+---
+title: The config model
+description: "How alint turns one .alint.yml, plus the configs it extends, drops in, and nests, into a single effective config, and then into a report."
+sidebar:
+  order: 3
+---
+
+alint is driven by a small declarative language. You describe the checks you want as **rules**; alint merges them with every other config source in play into one **effective config**, and then reads your repository to turn that config into a report. The root `.alint.yml` is the entry point, not the whole story: alint also reads the configs it `extends:`, any `.alint.d/` drop-ins, per-directory nested configs, and of course every repository file each rule checks.
+
+<svg class="alint-config" viewBox="0 0 460 470" role="img" aria-labelledby="cfg-t cfg-d" xmlns="http://www.w3.org/2000/svg">
+<title id="cfg-t">alint assembles one effective config from many sources</title>
+<desc id="cfg-d">Four config sources (bundled, extends, root, drop-in) merge by rule id from low to high precedence into one effective config. The bundled ruleset sets readme-exists to warning; the drop-in overrides it to error, which wins. Nested configs add subtree-scoped rules.</desc>
+<style>
+  .alint-config { --tx:#1e1b4b; --mut:#64748b; --card:#ffffff; --bd:#c7cfe0; --ac:#4f46e5; width:100%; max-width:480px; height:auto; font:600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  :root[data-theme="dark"] .alint-config { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; }
+  @media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) .alint-config { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; } }
+  .alint-config .mono { font:600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .alint-config .ui { font:600 12px system-ui, -apple-system, sans-serif; }
+  .alint-config .tx { fill:var(--tx); } .alint-config .mut { fill:var(--mut); } .alint-config .ac { fill:var(--ac); }
+  .alint-config .card { fill:var(--card); stroke:var(--bd); stroke-width:1.3; }
+  .alint-config .eff { fill:var(--card); stroke:var(--ac); stroke-width:1.7; }
+  .alint-config .old { fill:var(--mut); text-decoration:line-through; }
+  .alint-config .flow { fill:none; stroke:var(--ac); stroke-width:2; stroke-dasharray:6 6; opacity:.75; animation:cfgf 1s linear infinite; }
+  @keyframes cfgf { to { stroke-dashoffset:-12; } }
+  @media (prefers-reduced-motion:reduce){ .alint-config .flow{animation:none;stroke-dasharray:none} }
+</style>
+<text class="ui ac" x="18" y="15">one effective config, from many sources</text>
+<text class="ui mut" x="18" y="32">low to high precedence &#8595;</text>
+<rect class="card" x="20" y="42"  width="420" height="44" rx="8"/><rect x="20" y="42"  width="6" height="44" rx="2" fill="#3b82f6"/>
+<text class="ui" x="36" y="60" fill="#3b82f6">bundled</text><text class="mono tx" x="36" y="78">oss-baseline@v1</text><text class="mono mut" x="424" y="69" font-size="11" text-anchor="end">readme-exists: warning</text>
+<rect class="card" x="20" y="98"  width="420" height="44" rx="8"/><rect x="20" y="98"  width="6" height="44" rx="2" fill="#f59e0b"/>
+<text class="ui" x="36" y="116" fill="#f59e0b">extends</text><text class="mono tx" x="36" y="134">./team.yml</text><text class="mono mut" x="424" y="125" font-size="11" text-anchor="end">+ team rules</text>
+<rect class="card" x="20" y="154" width="420" height="44" rx="8"/><rect x="20" y="154" width="6" height="44" rx="2" fill="#4f46e5"/>
+<text class="ui ac" x="36" y="172">root</text><text class="mono tx" x="36" y="190">.alint.yml</text><text class="mono mut" x="424" y="181" font-size="11" text-anchor="end">+ your rules</text>
+<rect class="card" x="20" y="210" width="420" height="44" rx="8"/><rect x="20" y="210" width="6" height="44" rx="2" fill="#7c3aed"/>
+<text class="ui" x="36" y="228" fill="#7c3aed">drop-in</text><text class="mono tx" x="36" y="246">99-local.yml</text><text class="mono" x="424" y="237" font-size="11" text-anchor="end" fill="#7c3aed">readme-exists: error</text>
+<path class="flow" d="M 230 254 V 272"/><text class="ui mut" x="242" y="267">merge by id</text>
+<text class="ui ac" x="20" y="290">effective config</text>
+<rect class="eff" x="20" y="298" width="420" height="156" rx="12"/>
+<text class="mono ac" x="36" y="326" font-weight="700">readme-exists</text>
+<text class="mono tx" x="36" y="352">kind: file_exists</text>
+<text class="mono tx" x="36" y="378">level: <tspan class="old">warning</tspan> <tspan class="tx">&#8594;</tspan> <tspan class="ac" font-weight="700">error</tspan></text>
+<line x1="36" y1="396" x2="424" y2="396" stroke="var(--bd)" stroke-width="1" opacity=".5"/>
+<text class="ui mut" x="36" y="418">drop-in wins (highest precedence)</text>
+<text class="ui mut" x="36" y="440">+ nested configs add subtree-scoped rules</text>
+</svg>
+
+## A rule is a record
+
+The atom of the language is the rule record. Three fields are always required: `id` (a stable kebab-case name), `kind` (which built-in check to run), and `level` (`error`, `warning`, `info`, or `off`). The rest are optional: `paths` (which files, as a glob, a list, or an `{include, exclude}` pair), `when` (an expression that gates the rule on facts), `fix` (one of twelve repair ops), `message`, `scope_filter`, and any fields specific to the `kind`.
+
+```yaml
+- id: readme-exists      # names it (stable; used to override or disable)
+  kind: file_exists      # which built-in check
+  when: facts.has_rust   # gate: only in a Rust project
+  paths: [README.md]     # which path the rule is about
+  level: error           # severity
+  message: "README.md is required at the repo root"
+```
+
+alint reads those fields in a fixed order, and that order is the pipeline in miniature. `when` is checked first, against facts computed once per run, so a gated-out rule is dropped before a single file is read. `paths` then selects the files, `kind` runs its check, and `level` and `message` shape what lands in the report. The `when:` expression is a deliberately bounded little language, with boolean logic, comparisons, `in`, and `matches` over four namespaces (`facts.`, `vars.`, `iter.`, `env.`) and no arbitrary code; a missing fact reads as `null` (falsy), so a rule gated on an absent fact simply never runs.
+
+Around the rules sit the rest of the top-level fields: `extends:` inherits other configs, `vars:` and `facts:` supply values the rules gate and interpolate on, `ignore:` and `respect_gitignore:` shape the walk, `templates:` factor out repeated rule shapes, and a few knobs (`fix_size_limit`, `nested_configs`, `allow_out_of_root`, `baseline`) tune a run. Only `version: 1` is strictly required.
+
+## Many sources, one effective config
+
+Most repositories never write every rule by hand. A config is *assembled* from several sources, and alint merges them into one effective config before anything runs:
+
+- **`extends:`** inherits from other configs, each entry a local file, an `https://` URL pinned by a SHA-256 hash, or a bundled ruleset resolved offline from the binary (`alint://bundled/...`). Entries resolve left to right, each overriding the ones before it, and your own file overrides everything it extends. Fetched and bundled configs are leaf nodes: they cannot themselves declare `extends:`.
+- **Drop-ins** (`.alint.d/*.yml`) are discovered next to the root config and merged alphabetically; the last one wins. It is the `/etc/*.d/` pattern for alint: ops layer `50-policy.yml`, a developer gitignores `99-local.yml`.
+- **Nested configs** (opt in with `nested_configs: true`) let a subdirectory carry its own `.alint.yml`. Its rules are *added*, with their path scopes automatically prefixed with that subtree, so a rule in `packages/web/.alint.yml` only ever looks at `packages/web/`.
+
+Overrides happen **by rule `id`, field by field**: a later layer that re-declares `readme-exists` with `level: error` changes only that field and inherits `kind`, `paths`, and `message` from below. (Nested structures like a whole `fix:` block replace wholesale rather than deep-merging, so you re-state a `fix:` to change part of it.) The precedence, lowest to highest, is: extended configs (left to right), then your root config, then drop-ins. Nested configs are not an override layer at all: their rules are new, subtree-scoped additions, and a duplicate `id` anywhere is a load error, never a silent override.
+
+Sources are not equally trusted. Your own `.alint.yml` and its drop-ins are trust-equivalent: they may declare `custom:` facts and process-spawning rules (`kind: command` and its siblings). A config reached through `extends:`, especially a fetched or bundled one, cannot: spawning rules, custom facts, `allow_out_of_root`, and `baseline` are all rejected at load if they arrive that way. Adopting someone else's ruleset can tighten your checks; it can never make your machine run their commands.
+
+## From config to verdicts
+
+Assembling the config is only the first half. Once the effective config exists, alint validates it against the schema, then evaluates it: it computes your `facts:` once, in order; drops every rule whose `when:` is false; walks the repository a single time (honoring `.gitignore` and your `ignore:` globs) into one deterministic, sorted index; and dispatches each rule. Cross-file rules scan the whole index; per-file rules run against each matched file, and every file's bytes are read at most once no matter how many rules match it. The violations aggregate into one report. See [How alint works](/docs/concepts/how-it-works/) for that evaluation pipeline in full.
+
+Three interpolation layers thread through both halves, each resolving at a different time: `{{env.X}}` at config load (from the process environment, in local configs only), `{{vars.X}}` when a `templates:` body expands, and `{{ctx.X}}` per violation, inside a rule's `message`.
+
+## In practice
+
+A root config sets a rule at `warning`; a drop-in bumps just its severity:
+
+```yaml
+# .alint.yml  (root)
+version: 1
+rules:
+  - id: readme-exists
+    kind: file_exists
+    paths: [README.md]
+    level: warning
+    message: "README.md is required at the repo root"
+```
+
+```yaml
+# .alint.d/99-local.yml  (merged after the root; last layer wins)
+version: 1
+rules:
+  - id: readme-exists
+    level: error          # same id, so this re-declares just one field
+```
+
+In a repo with no README, `alint check` reports the merged rule:
+
+```
+error  readme-exists  README.md is required at the repo root
+```
+
+The drop-in supplied only `level`; `kind`, `paths`, and `message` came from the root config, and the drop-in's `error` won because it is the highest-precedence layer.
+
+## Going deeper
+
+- [Configuration](/docs/configuration/) is the field-by-field reference for all twelve top-level fields, every rule field, and the JSON Schema.
+- [Drop-in configs](/docs/concepts/drop-ins/) covers `.alint.d/` layering and its trust posture in depth.
+- [Variable interpolation](/docs/concepts/variable-interpolation/) details the three interpolation timings and `{{env.X | default(...)}}`.
+- [How alint works](/docs/concepts/how-it-works/) traces the assembly-then-evaluation pipeline end to end.

--- a/docs/site/concepts/the-config-model.md
+++ b/docs/site/concepts/the-config-model.md
@@ -20,6 +20,7 @@ alint is driven by a small declarative language. You describe the checks you wan
   .alint-config .card { fill:var(--card); stroke:var(--bd); stroke-width:1.3; }
   .alint-config .eff { fill:var(--card); stroke:var(--ac); stroke-width:1.7; }
   .alint-config .old { fill:var(--mut); text-decoration:line-through; }
+  .alint-config .tag { font:600 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
   .alint-config .flow { fill:none; stroke:var(--ac); stroke-width:2; stroke-dasharray:6 6; opacity:.75; animation:cfgf 1s linear infinite; }
   @keyframes cfgf { to { stroke-dashoffset:-12; } }
   @media (prefers-reduced-motion:reduce){ .alint-config .flow{animation:none;stroke-dasharray:none} }
@@ -27,13 +28,13 @@ alint is driven by a small declarative language. You describe the checks you wan
 <text class="ui ac" x="18" y="15">one effective config, from many sources</text>
 <text class="ui mut" x="18" y="32">low to high precedence &#8595;</text>
 <rect class="card" x="20" y="42"  width="420" height="44" rx="8"/><rect x="20" y="42"  width="6" height="44" rx="2" fill="#3b82f6"/>
-<text class="ui" x="36" y="60" fill="#3b82f6">bundled</text><text class="mono tx" x="36" y="78">oss-baseline@v1</text><text class="mono mut" x="424" y="69" font-size="11" text-anchor="end">readme-exists: warning</text>
+<text class="ui" x="36" y="60" fill="#3b82f6">bundled</text><text class="mono tx" x="36" y="78">oss-baseline@v1</text><text class="tag mut" x="424" y="69" text-anchor="end">readme-exists: warning</text>
 <rect class="card" x="20" y="98"  width="420" height="44" rx="8"/><rect x="20" y="98"  width="6" height="44" rx="2" fill="#f59e0b"/>
-<text class="ui" x="36" y="116" fill="#f59e0b">extends</text><text class="mono tx" x="36" y="134">./team.yml</text><text class="mono mut" x="424" y="125" font-size="11" text-anchor="end">+ team rules</text>
+<text class="ui" x="36" y="116" fill="#f59e0b">extends</text><text class="mono tx" x="36" y="134">./team.yml</text><text class="tag mut" x="424" y="125" text-anchor="end">+ team rules</text>
 <rect class="card" x="20" y="154" width="420" height="44" rx="8"/><rect x="20" y="154" width="6" height="44" rx="2" fill="#4f46e5"/>
-<text class="ui ac" x="36" y="172">root</text><text class="mono tx" x="36" y="190">.alint.yml</text><text class="mono mut" x="424" y="181" font-size="11" text-anchor="end">+ your rules</text>
+<text class="ui ac" x="36" y="172">root</text><text class="mono tx" x="36" y="190">.alint.yml</text><text class="tag mut" x="424" y="181" text-anchor="end">+ your rules</text>
 <rect class="card" x="20" y="210" width="420" height="44" rx="8"/><rect x="20" y="210" width="6" height="44" rx="2" fill="#7c3aed"/>
-<text class="ui" x="36" y="228" fill="#7c3aed">drop-in</text><text class="mono tx" x="36" y="246">99-local.yml</text><text class="mono" x="424" y="237" font-size="11" text-anchor="end" fill="#7c3aed">readme-exists: error</text>
+<text class="ui" x="36" y="228" fill="#7c3aed">drop-in</text><text class="mono tx" x="36" y="246">99-local.yml</text><text class="tag" x="424" y="237" text-anchor="end" fill="#7c3aed">readme-exists: error</text>
 <path class="flow" d="M 230 254 V 272"/><text class="ui mut" x="242" y="267">merge by id</text>
 <text class="ui ac" x="20" y="290">effective config</text>
 <rect class="eff" x="20" y="298" width="420" height="156" rx="12"/>

--- a/docs/site/concepts/variable-interpolation.md
+++ b/docs/site/concepts/variable-interpolation.md
@@ -36,7 +36,7 @@ Every string-typed **value** field is interpolated at load:
 | `pattern:` regex | yes | environment-driven matcher |
 | `since:`, `changed_since:` | yes | the motivating case |
 | `policy_url:` | yes | per-team policy URLs |
-| `message:` | yes | adds `{{env.X}}` alongside `{{vars.X}}` / `{{ctx.X}}` |
+| `message:` | yes | `{{env.X}}` at load; `{{ctx.X}}` fills per violation (`{{vars.X}}` substitutes only inside `templates:`) |
 | `content:`, `content_from:` | yes | templated fix bodies |
 | `vars:` values | yes | lets `vars` themselves be env-driven |
 | `id:`, `kind:`, `level:` | **no** | identity / type / severity must be stable across environments — env-driven values break audit trails and reproducibility |
@@ -55,7 +55,7 @@ A consequence: a string-typed field whose env value is bare-numeric (`"72"`) or 
 
 ## `env.X` in `when:` expressions
 
-The `when:` expression language gains `env` as a third namespace alongside `facts` and `vars`:
+The `when:` expression reads four namespaces: `facts`, `vars`, `env`, and `iter` (the last only inside iteration contexts, such as a `for_each_*` rule's `when_iter:`). `env` exposes environment variables:
 
 ```yaml
 - id: ci-only-rule

--- a/docs/site/concepts/variable-interpolation.md
+++ b/docs/site/concepts/variable-interpolation.md
@@ -5,7 +5,7 @@ sidebar:
   order: 9
 ---
 
-alint resolves `{{env.NAME}}` references in your `.alint.yml` against the environment at config-load time. This lets one committed config adapt to its environment — a PR base SHA, a per-team registry host, an environment-driven path root — without templating the YAML file externally.
+alint resolves `{{env.NAME}}` references in your `.alint.yml` against the environment at config-load time. This lets one committed config adapt to its environment (a PR base SHA, a per-team registry host, an environment-driven path root) without templating the YAML file externally.
 
 ```yaml
 rules:
@@ -19,8 +19,8 @@ rules:
 
 ## Syntax
 
-- `{{env.NAME}}` — substitute the value of environment variable `NAME`. If `NAME` is unset (or empty) and there is no default, config load fails with an error naming the field.
-- `{{env.NAME | default('fallback')}}` — substitute `NAME`, or the quoted fallback when `NAME` is unset/empty. Single or double quotes are accepted.
+- `{{env.NAME}}`: substitute the value of environment variable `NAME`. If `NAME` is unset (or empty) and there is no default, config load fails with an error naming the field.
+- `{{env.NAME | default('fallback')}}`: substitute `NAME`, or the quoted fallback when `NAME` is unset/empty. Single or double quotes are accepted.
 - Interpolation composes with surrounding text: `"https://policy.{{env.TEAM}}.example.com/v1.yml"`.
 
 The `| default(...)` filter follows the Jinja / Liquid / Nunjucks convention. It is the only filter in this release.
@@ -31,7 +31,7 @@ Every string-typed **value** field is interpolated at load:
 
 | Field | Interpolated | Why |
 |---|---|---|
-| `extends:` entry (URL `#sha256-…`) | yes | per-environment / per-team registry |
+| `extends:` entry (URL `#sha256-...`) | yes | per-environment / per-team registry |
 | `paths:` glob | yes | per-environment path roots |
 | `pattern:` regex | yes | environment-driven matcher |
 | `since:`, `changed_since:` | yes | the motivating case |
@@ -39,9 +39,9 @@ Every string-typed **value** field is interpolated at load:
 | `message:` | yes | `{{env.X}}` at load; `{{ctx.X}}` fills per violation (`{{vars.X}}` substitutes only inside `templates:`) |
 | `content:`, `content_from:` | yes | templated fix bodies |
 | `vars:` values | yes | lets `vars` themselves be env-driven |
-| `id:`, `kind:`, `level:` | **no** | identity / type / severity must be stable across environments — env-driven values break audit trails and reproducibility |
+| `id:`, `kind:`, `level:` | **no** | identity / type / severity must be stable across environments. Env-driven values break audit trails and reproducibility |
 
-Interpolation only happens for **local config files** — the ones you author. Bundled rulesets are static, and a remote `extends:` ruleset is never interpolated against *your* environment.
+Interpolation only happens for **local config files**, the ones you author. Bundled rulesets are static, and a remote `extends:` ruleset is never interpolated against *your* environment.
 
 ## Type coercion
 
@@ -65,19 +65,19 @@ The `when:` expression reads four namespaces: `facts`, `vars`, `env`, and `iter`
   level: warning
 ```
 
-Unlike string interpolation (load-time), `when: env.X` resolves at **evaluation time** — but since the environment is constant during a run, the result is the same. An unset variable evaluates to `null` (falsy), matching the "missing fact is falsy" rule. `env` is value-only — there are no callable methods on it.
+Unlike string interpolation (load-time), `when: env.X` resolves at **evaluation time**, but since the environment is constant during a run, the result is the same. An unset variable evaluates to `null` (falsy), matching the "missing fact is falsy" rule. `env` is value-only: there are no callable methods on it.
 
 **env values are always strings.** Compare against string literals: `when: env.PORT == "8080"`, not `== 8080`. A bare-integer comparison is a type mismatch that evaluates silently to `false` (the rule then never applies), so quote the right-hand side.
 
-## `{{...}}` is shared — foreign templates pass through
+## `{{...}}` is shared: foreign templates pass through
 
-alint does not own the `{{...}}` namespace. Go templates (`{{json .}}`, `{{end}}`), cookiecutter (`{{cookiecutter.slug}}`), Jinja, and others appear legitimately in `command:` args and `pattern:` regexes. alint only acts on spans it is confident are its own — `env.`, `vars.`, `ctx.` (and close typos of `env`/`vars`, which it flags). Everything else passes through verbatim:
+alint does not own the `{{...}}` namespace. Go templates (`{{json .}}`, `{{end}}`), cookiecutter (`{{cookiecutter.slug}}`), Jinja, and others appear legitimately in `command:` args and `pattern:` regexes. alint only acts on spans it is confident are its own: `env.`, `vars.`, `ctx.` (and close typos of `env`/`vars`, which it flags). Everything else passes through verbatim:
 
 ```yaml
 rules:
   - id: lint-workflows
     kind: command
-    command: ["actionlint", "-format", "{{json .}}"]   # Go template — left untouched
+    command: ["actionlint", "-format", "{{json .}}"]   # Go template, left untouched
 ```
 
 ## Migrating from the v0.9.21 `${VAR}` syntax
@@ -94,6 +94,6 @@ Rewrite `${VAR}` → `{{env.VAR}}` and `${VAR:-default}` → `{{env.VAR | defaul
 
 ## Security
 
-`{{env.X}}` reads via the standard environment lookup — no shell evaluation, no `system()`. The `extends:` case is the one to be aware of: an env var referenced in an `extends:` entry could change where a config load fetches from. Interpolation covers the whole entry string (including any `#sha256-…` hash), so it does **not** by itself pin the host.
+`{{env.X}}` reads via the standard environment lookup: no shell evaluation, no `system()`. The `extends:` case is the one to be aware of: an env var referenced in an `extends:` entry could change where a config load fetches from. Interpolation covers the whole entry string (including any `#sha256-...` hash), so it does **not** by itself pin the host.
 
-The real trust boundary is your local `.alint.yml`: it is trusted source. Influencing an `extends:` URL through interpolation requires the ability to (a) write `{{env.X}}` into your config **and** (b) control the environment — and (a) alone is already a full compromise (an attacker who can edit your config can just write the malicious URL directly). For configs whose `extends:` URLs are *not* env-driven, the author-fixed `#sha256-…` hash continues to pin the content exactly as before.
+The real trust boundary is your local `.alint.yml`: it is trusted source. Influencing an `extends:` URL through interpolation requires the ability to (a) write `{{env.X}}` into your config **and** (b) control the environment; (a) alone is already a full compromise (an attacker who can edit your config can just write the malicious URL directly). For configs whose `extends:` URLs are *not* env-driven, the author-fixed `#sha256-...` hash continues to pin the content exactly as before.

--- a/docs/site/configuration/index.md
+++ b/docs/site/configuration/index.md
@@ -91,18 +91,18 @@ The full implications (including how absence-style rules interpret "tracked" vs 
 
 ### `vars`
 
-Free-form string variables referenced from rule messages as `{{vars.<name>}}` and from `when:` clauses as `vars.<name>`.
+Free-form string variables, referenced from `when:` clauses as bare `vars.<name>`. To substitute a variable into a rule's own fields (a `pattern`, a `message`), use a [`templates:`](/docs/concepts/templates/) block, whose `{{vars.<name>}}` placeholders are filled per instance; a plain, non-template rule does not expand `{{vars.<name>}}` in its fields.
 
 ```yaml
 vars:
-  copyright_year: "2026"
-  org_name: "Acme"
+  enforce_headers: "true"
 
 rules:
-  - id: copyright-header
+  - id: spdx-header
     kind: file_header
     paths: "src/**/*.rs"
-    pattern: '^// Copyright \\(c\\) {{vars.copyright_year}} {{vars.org_name}}'
+    pattern: '^// SPDX-License-Identifier:'
+    when: vars.enforce_headers == "true"   # top-level vars feed when: as bare vars.X
     level: error
 ```
 

--- a/docs/site/configuration/index.md
+++ b/docs/site/configuration/index.md
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-`.alint.yml` is the only file alint reads. It declares the rules, the rule sources, the facts they're gated on, and a handful of run-time knobs.
+`.alint.yml` is alint's entry point. It declares the rules, the rule sources, the facts they're gated on, and a handful of run-time knobs. alint also reads the configs it `extends:`, any `.alint.d/` drop-ins, per-directory nested configs, and every repository file each rule checks.
 
 The entities of a config and how they relate:
 
@@ -32,7 +32,7 @@ Schema version. Always `1` for the current schema. Required.
 version: 1
 ```
 
-A future schema bump (`version: 2`, …) would be an explicit migration; v1 is stable.
+A future schema bump (to `version: 2`) would be an explicit migration; v1 is stable.
 
 ### `extends`
 
@@ -46,7 +46,7 @@ extends:
   - ./shared/team-defaults.yml
 
   # HTTPS URL with required SHA-256 SRI:
-  - https://example.com/rules.yml#sha256-abc123…
+  - https://example.com/rules.yml#sha256-abc123...
 
   # Bundled ruleset, resolved offline from the binary:
   - alint://bundled/oss-baseline@v1
@@ -161,7 +161,7 @@ Common per-rule fields:
 - **`level`** *(required)*: `error`, `warning`, `info`, or `off`. `off` disables the rule entirely.
 - **`paths`**: glob, list of globs, or `{include, exclude}` pair. Required for most kinds.
 - **`when`**: bounded expression gating the rule on facts / vars.
-- **`scope_filter`**: extra per-file scoping — by ancestor manifest presence, git diff, or membership in a manifest-declared path set (see below). Cross-file rules reject this field at build time.
+- **`scope_filter`**: extra per-file scoping by ancestor manifest presence, git diff, or membership in a manifest-declared path set (see below). Cross-file rules reject this field at build time.
 - **`fix`**: fix-op declaration (e.g. `file_trim_trailing_whitespace: {}`).
 - **`message`**: override the rule's display message.
 - **`policy_url`**: link surfaced when the rule fires.
@@ -183,7 +183,7 @@ rules:
 
 `has_ancestor:` accepts a literal filename or a list of filenames; path separators and glob metacharacters are rejected at build time. The bundled ecosystem rulesets (`rust@v1`, `node@v1`, `python@v1`, `go@v1`, `java@v1`) use this to scope per-file content rules to their ecosystem's package subtrees in polyglot monorepos.
 
-`changed_since: <git-ref>` (v0.11+) narrows a per-file rule to files in the `<ref>...HEAD` diff — the same merge-base diff as `alint check --changed`. Use it to grandfather pre-existing files in a PR (e.g. require an SPDX header only on files the PR touched):
+`changed_since: <git-ref>` (v0.11+) narrows a per-file rule to files in the `<ref>...HEAD` diff, the same merge-base diff as `alint check --changed`. Use it to grandfather pre-existing files in a PR (e.g. require an SPDX header only on files the PR touched):
 
 ```yaml
 rules:
@@ -200,7 +200,7 @@ It accepts the `{{env.X}}` interpolation, resolves the diff once per run, matche
 
 `include_manifest_paths:` / `exclude_manifest_paths:` (v0.15+) scope a per-file rule by membership in a path set a **manifest** declares, so the manifest that owns the truth and the rule that depends on it stay in one place instead of a hand-maintained `paths.exclude` that drifts. `exclude_manifest_paths:` drops files in the set; `include_manifest_paths:` keeps only files in it.
 
-Exempt the `package.json` `bin` entrypoints from a `no-console` rule — even though `bin` names the *build output* (`dist/cli.js`), `derive_target:` maps it back to source:
+Exempt the `package.json` `bin` entrypoints from a `no-console` rule. Even though `bin` names the *build output* (`dist/cli.js`), `derive_target:` maps it back to source:
 
 ```yaml
 rules:
@@ -232,11 +232,11 @@ rules:
     level: warning
 ```
 
-Each predicate takes a **`source:`** (the manifest file, always repo-root-confined; its declared paths resolve relative to its own directory), an **`extract:`** (the shared `{ json | toml | yaml: <JSONPath> }` / `{ lines }` / `{ regex }` extractor `registry_paths_resolve` and `file_graph` also use; non-literal entries are dropped), an optional **`derive_target: { from, to }`** regex mapping applied to each extracted path (a path that does not match `from` is dropped), and, for `include_manifest_paths:` only, **`expect_nonempty:`** (default `true`) to warn when the set is empty — an empty include set would otherwise silently no-op the whole rule. This guards the *declared* set: a member that resolves but matches no file on disk (a glob with no matching directory, or a literal pointing at an absent path) still scopes nothing silently, so use `alint explain` to confirm a rule's resolved scope.
+Each predicate takes a **`source:`** (the manifest file, always repo-root-confined; its declared paths resolve relative to its own directory), an **`extract:`** (the shared `{ json | toml | yaml: <JSONPath> }` / `{ lines }` / `{ regex }` extractor `registry_paths_resolve` and `file_graph` also use; non-literal entries are dropped), an optional **`derive_target: { from, to }`** regex mapping applied to each extracted path (a path that does not match `from` is dropped), and, for `include_manifest_paths:` only, **`expect_nonempty:`** (default `true`) to warn when the set is empty, since an empty include set would otherwise silently no-op the whole rule. This guards the *declared* set: a member that resolves but matches no file on disk (a glob with no matching directory, or a literal pointing at an absent path) still scopes nothing silently, so use `alint explain` to confirm a rule's resolved scope.
 
-Membership is **directory-aware**: a declared file matches itself; a declared directory (a workspace member) matches every file under it, respecting component boundaries (`crates/a` does not match `crates/ab`). A **glob** member is expanded — a `members = ["crates/*"]` entry (the form a real `Cargo.toml` / `package.json` declares) scopes every file under each matching `crates/<x>` directory. The set is extracted once per run and cached, like `changed_since:`. A manifest that is absent or unreadable contributes nothing — the rule runs full-scope for `exclude`, matches nothing for `include`. A manifest **value** gates *which* files a rule sees, never *what* it decides about a file: content rules never read the manifest, extraction is pure-parse (no spawn, safe inside an `extends:`'d ruleset), and `alint explain <rule>` prints the resolved set.
+Membership is **directory-aware**: a declared file matches itself; a declared directory (a workspace member) matches every file under it, respecting component boundaries (`crates/a` does not match `crates/ab`). A **glob** member is expanded: a `members = ["crates/*"]` entry (the form a real `Cargo.toml` / `package.json` declares) scopes every file under each matching `crates/<x>` directory. The set is extracted once per run and cached, like `changed_since:`. A manifest that is absent or unreadable contributes nothing: the rule runs full-scope for `exclude`, matches nothing for `include`. A manifest **value** gates *which* files a rule sees, never *what* it decides about a file: content rules never read the manifest, extraction is pure-parse (no spawn, safe inside an `extends:`'d ruleset), and `alint explain <rule>` prints the resolved set.
 
-Cross-file rules (`pair`, `for_each_dir`, `file_exists`, etc.) reject `scope_filter:` at build time with a pointer to the `for_each_dir + when_iter:` pattern. Rule-major kinds — `filename_case`, `filename_regex`, `file_max_size`, `file_min_size`, `executable_bit`, `no_empty_files`, `json_schema_passes`, and their siblings — honor `scope_filter:` too as of v0.15. (Before v0.15 they applied their own `paths:` glob but silently ignored a `changed_since:` predicate, so a scope that depended on it matched nothing on them.)
+Cross-file rules (`pair`, `for_each_dir`, `file_exists`, etc.) reject `scope_filter:` at build time with a pointer to the `for_each_dir + when_iter:` pattern. Rule-major kinds (`filename_case`, `filename_regex`, `file_max_size`, `file_min_size`, `executable_bit`, `no_empty_files`, `json_schema_passes`, and their siblings) honor `scope_filter:` too as of v0.15. (Before v0.15 they applied their own `paths:` glob but silently ignored a `changed_since:` predicate, so a scope that depended on it matched nothing on them.)
 
 ### `fix_size_limit`
 
@@ -281,13 +281,13 @@ Only the user's top-level config may set `nested_configs: true`. Nested configs 
 
 ### `allow_out_of_root`
 
-By default alint confines every config-declared path to the repository root: a rule can never read or resolve a path outside the tree it was pointed at. `allow_out_of_root:` is a deliberate, top-level-only opt-in to relax that for *reads* — when a trusted config needs to reference an external file (a shared JSON schema, a manifest in a sibling checkout).
+By default alint confines every config-declared path to the repository root: a rule can never read or resolve a path outside the tree it was pointed at. `allow_out_of_root:` is a deliberate, top-level-only opt-in to relax that for *reads*, when a trusted config needs to reference an external file (a shared JSON schema, a manifest in a sibling checkout).
 
 ```yaml
 allow_out_of_root: true            # every rule may read out-of-root paths
 ```
 
-Or scope it to specific rule kinds and/or ids — a rule is permitted if its `kind` is in `kinds` **or** its `id` is in `rules`:
+Or scope it to specific rule kinds and/or ids: a rule is permitted if its `kind` is in `kinds` **or** its `id` is in `rules`:
 
 ```yaml
 allow_out_of_root:
@@ -297,7 +297,7 @@ allow_out_of_root:
 
 Absent or `false` keeps the secure default (full confinement).
 
-**Security.** Like the spawning-rule trust gate, `allow_out_of_root:` is honored **only** from your own top-level config — any `extends:`'d ruleset that declares it is a load-time error, so adopting a published ruleset can never grant it out-of-tree reads. It currently applies to the read kinds `json_schema_passes` (`schema_path:`), `pair_hash` (`target:`), and `registry_paths_resolve` (`source:`); a permitted read emits an informational note so the escape is never silent. Resolve/index existence checks stay confined regardless.
+**Security.** Like the spawning-rule trust gate, `allow_out_of_root:` is honored **only** from your own top-level config: any `extends:`'d ruleset that declares it is a load-time error, so adopting a published ruleset can never grant it out-of-tree reads. It currently applies to the read kinds `json_schema_passes` (`schema_path:`), `pair_hash` (`target:`), and `registry_paths_resolve` (`source:`); a permitted read emits an informational note so the escape is never silent. Resolve/index existence checks stay confined regardless.
 
 ### `baseline`
 


### PR DESCRIPTION
**Phase 3** of the Concepts redesign (plan: `docs/design/concepts-section-redesign.md`): the core mental-model pages, at the richer visual bar set during review.

## Pages
- **How alint works** (rewrite): six detailed stages (config assembly + the trust boundary, facts-once, the `when:` filter, the deterministic walk, per-file vs cross-file dispatch with read-coalescing, aggregate + emit). The simple hero is replaced by a comprehensive vertical pipeline diagram: a repository of colored files, a scanning beam reading each once, pass/fail badges, the cross-file rule, and the report with `exit 1`.
- **The config model** (rewrite): its assembly diagram is upgraded to the richer colored-source-tier style.
- **Kinds, families, and categories** (new): 94 kinds (105 with aliases) / 13 families (one home each, a partition) / 13 categories (cross-cutting; 32 kinds carry more than one), with a diagram contrasting the 1:1 family with the M:N categories. Grounded in `facts.json`.
- **Severity and exit codes** (new): the `error`/`warning`/`info`/`off` to exit-code (`0`/`1`/`2`/`3`) mapping and `--fail-on-warning`, with a compact mapping diagram. Grounded in the CLI's exit-code logic.

## Diagrams
Every diagram is inline SVG + CSS (no dependency, no `.mdx`): theme-aware via a `data-theme` block, reduced-motion-guarded, and **narrow / mobile-first** (capped at 480px). Each was rendered in the built Starlight page with Playwright and screenshot-verified in both themes and at 320-414px mobile widths (no horizontal overflow). Appendix 14 of the design doc records the visual language.

## Errata folded in
- Top-level `vars:` are now documented accurately: referenced from `when:` as bare `vars.X`, and substituted as `{{vars.X}}` only inside `templates:` bodies (a plain rule `message`/`pattern` does not expand `{{vars.X}}`, verified empirically). Fixed the `vars:` field description and its previously broken example in `configuration`, plus the `message:` interpolation row.
- The `when:` grammar summary now lists all four namespaces (`facts` / `vars` / `iter` / `env`).

## Verification
Astro build rc=0; doc-link gate passes; dogfood rc=0; no em-dash / smart-quote signals in the diff; all four SVGs well-formed; every diagram screenshot-verified over HTTP.

Next: Phase 4 (targeting + composition pages).

https://claude.ai/code/session_01DY5e8zTE8XDCDsaPkJT8Ai
