### PR TITLE
docs: Phase 4 concepts (targeting and composition pages)

### DIFF
--- a/docs/site/concepts/changed-mode.md
+++ b/docs/site/concepts/changed-mode.md
@@ -69,8 +69,8 @@ The three-dot `<base>...HEAD` form diffs against the merge-base of `<base>` and 
 
 The filter narrows the file set for **per-file rules** only. Two families opt out, on purpose:
 
-- **Cross-file rules** (`pair`, `for_each_dir`, `every_matching_has`, `unique_by`, `dir_contains`, `dir_only_contains`) always evaluate against the whole tree. A `pair` rule that requires every `api.h` to have an `api.c` must still fire when you delete `api.c`, even though the surviving `api.h` is not itself in your diff.
-- **Existence rules** (`file_exists`, `file_absent`, `dir_exists`, `dir_absent`) also evaluate whole-tree, but the engine **skips a rule entirely when its `paths:` scope does not intersect the diff**. So a missing `LICENSE` does not fail every PR; it fails only the PRs that touch a `LICENSE`-shaped path. This keeps whole-tree correctness without re-reporting the same unchanged-tree finding on every unrelated PR.
+- **Whole-tree rules** always evaluate against the whole tree, because their verdict depends on files outside your diff: the relational rules (`pair`, `for_each_dir`, `every_matching_has`, `unique_by`, `dir_contains`, `dir_only_contains`), the manifest and graph rules (`cross_file`, `file_graph`, `registry_paths_resolve`, `pair_hash`), and the single-shot rules (`generated_file_fresh`, `command_idempotent`). A `pair` rule that requires every `api.h` to have an `api.c` must still fire when you delete `api.c`, even though the surviving `api.h` is not itself in your diff.
+- **Existence rules** also consult the whole tree, but the two file-existence rules (`file_exists`, `file_absent`) are **skipped when their `paths:` scope does not intersect the diff**, so a missing `LICENSE` fails only the PRs that touch a `LICENSE`-shaped path. The two directory-existence rules (`dir_exists`, `dir_absent`) always evaluate, since a directory scope never intersects a file-path diff.
 
 ## Edge cases
 
@@ -91,7 +91,7 @@ alint check --changed --base=origin/main
 If the branch added a trailing-whitespace line to `src/parser.rs` and deleted `api.c` (leaving `api.h` orphaned), one report carries both a per-file finding and a whole-tree one:
 
 ```
-warning  no-trailing-whitespace  src/parser.rs:42 trailing whitespace
+warning  no-trailing-whitespace  trailing whitespace
 error    header-source-pair      api.h has no matching api.c
 ```
 

--- a/docs/site/concepts/changed-mode.md
+++ b/docs/site/concepts/changed-mode.md
@@ -1,0 +1,104 @@
+---
+title: Changed mode
+description: "How alint check --changed restricts a run to the files in a diff for per-file rules, while cross-file and existence rules keep evaluating the whole tree so they stay correct."
+sidebar:
+  order: 7
+---
+
+`alint check --changed` layers a diff filter on top of the walk so a per-file rule sees only the files you touched, which is what a pre-commit hook or a PR check wants. Cross-file and existence rules deliberately opt out and keep evaluating the whole tree, because an invariant they enforce can be broken by a file you changed even when its partner did not.
+
+<svg class="alint-chg" viewBox="0 0 460 424" role="img" aria-labelledby="chg-t chg-d" xmlns="http://www.w3.org/2000/svg">
+<title id="chg-t">--changed filters per-file rules to the diff while cross-file and existence rules stay whole-tree</title>
+<desc id="chg-d">A repository of four files has two changed. Per-file rules receive only the two changed files. Cross-file and existence rules receive all four files, so a whole-tree invariant is still checked.</desc>
+<style>
+  .alint-chg { --tx:#1e1b4b; --mut:#64748b; --card:#ffffff; --bd:#c7cfe0; --ac:#4f46e5; width:100%; max-width:480px; height:auto; font:600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  :root[data-theme="dark"] .alint-chg { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; }
+  @media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) .alint-chg { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; } }
+  .alint-chg .ui { font:600 12px system-ui, -apple-system, sans-serif; }
+  .alint-chg .tag { font:600 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .alint-chg .tx { fill:var(--tx); } .alint-chg .mut { fill:var(--mut); } .alint-chg .ac { fill:var(--ac); }
+  .alint-chg .card { fill:var(--card); stroke:var(--bd); stroke-width:1.3; }
+  .alint-chg .chip { fill:var(--card); stroke:var(--bd); stroke-width:1.2; }
+  .alint-chg .off { opacity:.45; }
+  .alint-chg .flow { fill:none; stroke:var(--ac); stroke-width:2; stroke-dasharray:6 6; opacity:.7; animation:chgflow 1s linear infinite; }
+  .alint-chg .pulse { animation:chgpulse 2.4s ease-in-out infinite; }
+  @keyframes chgflow { to { stroke-dashoffset:-12; } }
+  @keyframes chgpulse { 0%,100%{opacity:1} 50%{opacity:.55} }
+  @media (prefers-reduced-motion:reduce){ .alint-chg .flow{animation:none;stroke-dasharray:none} .alint-chg .pulse{animation:none} }
+</style>
+<rect class="card" x="30" y="28" width="400" height="128" rx="10"/>
+<text class="ui mut" x="44" y="48">repository</text>
+<text class="tag mut" x="416" y="48" text-anchor="end">2 of 4 files changed</text>
+<rect class="chip pulse" x="44" y="56" width="372" height="22" rx="6"/><rect x="44" y="56" width="5" height="22" rx="2" fill="#4f46e5"/><text class="tag tx" x="58" y="71">src/parser.rs</text><text class="tag ac" x="404" y="71" text-anchor="end">changed</text>
+<rect class="chip pulse" x="44" y="82" width="372" height="22" rx="6"/><rect x="44" y="82" width="5" height="22" rx="2" fill="#4f46e5"/><text class="tag tx" x="58" y="97">docs/guide.md</text><text class="tag ac" x="404" y="97" text-anchor="end">changed</text>
+<rect class="chip off" x="44" y="108" width="372" height="22" rx="6"/><text class="tag mut" x="58" y="123">src/lib.rs</text><text class="tag mut" x="404" y="123" text-anchor="end">unchanged</text>
+<rect class="chip off" x="44" y="134" width="372" height="22" rx="6"/><text class="tag mut" x="58" y="149">api.h</text><text class="tag mut" x="404" y="149" text-anchor="end">unchanged</text>
+<path class="flow" d="M 180 156 C 180 186, 120 186, 120 210"/>
+<path class="flow" d="M 280 156 C 280 186, 340 186, 340 210"/>
+<rect class="card" x="20" y="214" width="200" height="176" rx="10"/>
+<text class="ui ac" x="34" y="236">per-file rules</text>
+<text class="tag mut" x="34" y="252">see the changed set</text>
+<rect class="chip" x="34" y="262" width="172" height="22" rx="6"/><rect x="34" y="262" width="5" height="22" rx="2" fill="#4f46e5"/><text class="tag tx" x="48" y="277">src/parser.rs</text>
+<rect class="chip" x="34" y="290" width="172" height="22" rx="6"/><rect x="34" y="290" width="5" height="22" rx="2" fill="#4f46e5"/><text class="tag tx" x="48" y="305">docs/guide.md</text>
+<text class="tag mut" x="34" y="338">2 of 4 evaluated</text>
+<text class="tag mut" x="34" y="358">no_trailing_whitespace,</text>
+<text class="tag mut" x="34" y="374">file_header, filename_case</text>
+<rect class="card" x="240" y="214" width="200" height="176" rx="10"/>
+<text class="ui ac" x="254" y="236">cross-file + existence</text>
+<text class="tag mut" x="254" y="252">see the whole tree</text>
+<rect class="chip" x="254" y="262" width="172" height="20" rx="5"/><rect x="254" y="262" width="5" height="20" rx="2" fill="#4f46e5"/><text class="tag tx" x="268" y="276">src/parser.rs</text>
+<rect class="chip" x="254" y="286" width="172" height="20" rx="5"/><rect x="254" y="286" width="5" height="20" rx="2" fill="#4f46e5"/><text class="tag tx" x="268" y="300">docs/guide.md</text>
+<rect class="chip off" x="254" y="310" width="172" height="20" rx="5"/><text class="tag mut" x="268" y="324">src/lib.rs</text>
+<rect class="chip off" x="254" y="334" width="172" height="20" rx="5"/><text class="tag mut" x="268" y="348">api.h</text>
+<text class="tag mut" x="254" y="374">pair, file_exists</text>
+<text class="tag mut" x="230" y="410" text-anchor="middle">cross-file and existence rules stay whole-tree for correctness</text>
+</svg>
+
+## The two diff modes
+
+`--changed` picks its diff from git in one of two shapes:
+
+| Invocation | Diff source | Fits |
+|---|---|---|
+| `alint check --changed` | working tree: modified plus untracked, `--exclude-standard` | pre-commit, local dev |
+| `alint check --changed --base=main` | `main...HEAD` (three-dot, merge-base) | PR checks |
+
+The three-dot `<base>...HEAD` form diffs against the merge-base of `<base>` and `HEAD`, which is exactly what a GitHub PR calls "your changes." `--base=<ref>` implies `--changed`, so the ref is the verb's argument; you never pass both `--changed` and a bare `--base` awkwardly. The same flags work on `alint fix --changed`.
+
+## Which rules stay whole-tree
+
+The filter narrows the file set for **per-file rules** only. Two families opt out, on purpose:
+
+- **Cross-file rules** (`pair`, `for_each_dir`, `every_matching_has`, `unique_by`, `dir_contains`, `dir_only_contains`) always evaluate against the whole tree. A `pair` rule that requires every `api.h` to have an `api.c` must still fire when you delete `api.c`, even though the surviving `api.h` is not itself in your diff.
+- **Existence rules** (`file_exists`, `file_absent`, `dir_exists`, `dir_absent`) also evaluate whole-tree, but the engine **skips a rule entirely when its `paths:` scope does not intersect the diff**. So a missing `LICENSE` does not fail every PR; it fails only the PRs that touch a `LICENSE`-shaped path. This keeps whole-tree correctness without re-reporting the same unchanged-tree finding on every unrelated PR.
+
+## Edge cases
+
+- **Empty diff** (nothing modified, nothing untracked): the run short-circuits to an empty report in milliseconds, so a no-op pre-commit is nearly free.
+- **Outside a git repo** (or `git` missing from `PATH`): `--changed` hard-errors rather than silently falling back to a full check, because a silent full run would betray the intent the flag expressed.
+- **Deleted files** appear in the diff. A `LICENSE` you deleted is in the changed set, the walker no longer sees it on disk, and an existence rule for `LICENSE` evaluates the whole tree (which now lacks it) and fires.
+
+`--changed` pairs naturally with [`git_tracked_only:`](/docs/concepts/walker-and-gitignore/): the changed set is a working-tree concept and the tracked set is an index concept, so a rule with both fires only on tracked entries that are part of this diff.
+
+## In practice
+
+A PR check that lints only the files the branch touched, against the merge-base:
+
+```bash
+alint check --changed --base=origin/main
+```
+
+If the branch added a trailing-whitespace line to `src/parser.rs` and deleted `api.c` (leaving `api.h` orphaned), one report carries both a per-file finding and a whole-tree one:
+
+```
+warning  no-trailing-whitespace  src/parser.rs:42 trailing whitespace
+error    header-source-pair      api.h has no matching api.c
+```
+
+The `no-trailing-whitespace` finding came through the diff filter; the `pair` finding came from the whole-tree pass, even though `api.h` was never in the diff.
+
+## Going deeper
+
+- [The walker and git](/docs/concepts/walker-and-gitignore/) is the whole-tree index this filter sits on top of.
+- [Scoping](/docs/concepts/scoping/) covers `changed_since:`, the per-rule scope_filter counterpart to the run-wide `--changed`.
+- [Configuration](/docs/configuration/) documents the rule kinds and their cross-file versus per-file classification.

--- a/docs/site/concepts/composition-and-trust.md
+++ b/docs/site/concepts/composition-and-trust.md
@@ -38,7 +38,7 @@ A config rarely stands alone. `extends:` pulls in other configs and merges their
 <text class="tag ac" x="230" y="106" text-anchor="middle">trust boundary</text>
 <rect class="card" x="30" y="122" width="400" height="214" rx="10"/>
 <text class="ui mut" x="44" y="144">extends (fetched or bundled)</text>
-<text class="tag mut" x="44" y="162">alint://bundled/ci@v1, https pinned by #sha256</text>
+<text class="tag mut" x="44" y="162">alint://bundled/oss-baseline@v1, https pinned by #sha256</text>
 <rect class="chip" x="44" y="172" width="210" height="26" rx="6"/><rect x="44" y="172" width="5" height="26" rx="2" fill="#22c55e"/><text class="tag tx" x="62" y="189">readme-exists: error</text><text class="tag" x="272" y="189" fill="#22c55e">merges by id</text>
 <rect class="chip" x="44" y="208" width="210" height="26" rx="6"/><rect x="44" y="208" width="5" height="26" rx="2" fill="#7c3aed"/><text class="tag tx" x="62" y="225">kind: command</text><text class="tag pulse" x="272" y="225" fill="#ef4444">rejected at load</text>
 <rect class="chip" x="44" y="244" width="210" height="26" rx="6"/><rect x="44" y="244" width="5" height="26" rx="2" fill="#7c3aed"/><text class="tag tx" x="62" y="261">allow_out_of_root</text><text class="tag pulse" x="272" y="261" fill="#ef4444">rejected at load</text>
@@ -50,7 +50,7 @@ A config rarely stands alone. `extends:` pulls in other configs and merges their
 
 Each `extends:` entry names another config, and they resolve **left to right**: a later entry overrides an earlier one, and your own file overrides everything it extends. Merging is **by rule `id`, field by field**, so an entry that re-declares `readme-exists` with only `level: error` changes just that field and inherits `kind`, `paths`, and `message` from below. An entry can be a local file, an `https://` URL, or a bundled ruleset resolved offline from the binary (`alint://bundled/...`); `only:` / `except:` filters (mutually exclusive on one entry) narrow which rules an entry contributes.
 
-Fetched and bundled configs are **leaf nodes**: they cannot declare `extends:` of their own, because relative-path resolution inside a fetched body has no principled base. You nest `extends:` locally instead.
+Fetched and bundled configs are **leaf nodes**: they cannot declare `extends:` of their own. A fetched body has no principled base for resolving relative paths, and bundled rulesets are deliberately flat catalogs; you nest `extends:` locally instead.
 
 ## The trust boundary
 
@@ -87,9 +87,10 @@ rules:
 alint refuses to load, naming the rule and the offending config rather than running anything:
 
 ```
-rule "deploy-check": kind: command spawns a process and is only allowed in the
-user's top-level config; declaring one in an extended config (ci-rules.yml)
-is refused because it would let a ruleset run arbitrary code
+rule "deploy-check": `kind: command` spawns a process and is only allowed in
+the user's top-level config; declaring one in an extended config
+(./ci-rules.yml), including inside a `require:` block, is refused because it
+would let a ruleset run arbitrary code
 ```
 
 Move `deploy-check` into your own top-level `.alint.yml` and it runs, because now you are the one declaring it.

--- a/docs/site/concepts/composition-and-trust.md
+++ b/docs/site/concepts/composition-and-trust.md
@@ -1,0 +1,101 @@
+---
+title: Composition and trust
+description: "How extends: merges other configs into yours field-by-field by id, and the trust boundary that lets a fetched or bundled ruleset tighten your checks but never run your machine's code."
+sidebar:
+  order: 8
+---
+
+A config rarely stands alone. `extends:` pulls in other configs and merges their rules into yours, field by field, keyed on rule `id`. But the further a config sits from you, the less it is trusted: your own `.alint.yml` may run commands and reach outside the repo, while anything reached through `extends:` cannot. Adopting someone else's ruleset can only ever tighten your checks; it can never make your machine run their code.
+
+<svg class="alint-trust" viewBox="0 0 460 388" role="img" aria-labelledby="trust-t trust-d" xmlns="http://www.w3.org/2000/svg">
+<title id="trust-t">extends merges rules by id, but the trust boundary blocks spawning rules and other privileged fields</title>
+<desc id="trust-d">Your top-level config is trusted and may spawn commands, add custom facts, read out of root, and set a baseline. An extended ruleset sits below a trust boundary: its ordinary rules merge up by id, but a kind: command rule and an allow_out_of_root field are rejected at load.</desc>
+<style>
+  .alint-trust { --tx:#1e1b4b; --mut:#64748b; --card:#ffffff; --bd:#c7cfe0; --ac:#4f46e5; width:100%; max-width:480px; height:auto; font:600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  :root[data-theme="dark"] .alint-trust { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; }
+  @media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) .alint-trust { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; } }
+  .alint-trust .ui { font:600 12px system-ui, -apple-system, sans-serif; }
+  .alint-trust .tag { font:600 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .alint-trust .tx { fill:var(--tx); } .alint-trust .mut { fill:var(--mut); } .alint-trust .ac { fill:var(--ac); }
+  .alint-trust .card { fill:var(--card); stroke:var(--bd); stroke-width:1.3; }
+  .alint-trust .trusted { fill:var(--card); stroke:var(--ac); stroke-width:1.8; }
+  .alint-trust .shield { fill:var(--card); stroke:var(--ac); stroke-width:1.5; }
+  .alint-trust .chip { fill:var(--card); stroke:var(--bd); stroke-width:1.2; }
+  .alint-trust .flow { fill:none; stroke:var(--ac); stroke-width:2; stroke-dasharray:7 5; opacity:.7; animation:trustflow 1s linear infinite; }
+  .alint-trust .pulse { animation:trustpulse 2.2s ease-in-out infinite; }
+  @keyframes trustflow { to { stroke-dashoffset:-12; } }
+  @keyframes trustpulse { 0%,100%{opacity:1} 50%{opacity:.5} }
+  @media (prefers-reduced-motion:reduce){ .alint-trust .flow{animation:none;stroke-dasharray:none} .alint-trust .pulse{animation:none} }
+</style>
+<text class="ui ac" x="18" y="16">extends merges rules by id</text>
+<text class="ui mut" x="442" y="16" text-anchor="end">code stays out</text>
+<rect class="trusted" x="30" y="26" width="400" height="58" rx="10"/>
+<text class="ui ac" x="44" y="48">your .alint.yml + .alint.d/</text>
+<text class="tag mut" x="416" y="46" text-anchor="end">trusted source</text>
+<text class="tag" x="44" y="70" fill="#22c55e">may: command, custom facts, allow_out_of_root, baseline</text>
+<path class="flow" d="M 20 102 H 440"/>
+<rect class="shield" x="166" y="90" width="128" height="24" rx="12"/>
+<text class="tag ac" x="230" y="106" text-anchor="middle">trust boundary</text>
+<rect class="card" x="30" y="122" width="400" height="214" rx="10"/>
+<text class="ui mut" x="44" y="144">extends (fetched or bundled)</text>
+<text class="tag mut" x="44" y="162">alint://bundled/ci@v1, https pinned by #sha256</text>
+<rect class="chip" x="44" y="172" width="210" height="26" rx="6"/><rect x="44" y="172" width="5" height="26" rx="2" fill="#22c55e"/><text class="tag tx" x="62" y="189">readme-exists: error</text><text class="tag" x="272" y="189" fill="#22c55e">merges by id</text>
+<rect class="chip" x="44" y="208" width="210" height="26" rx="6"/><rect x="44" y="208" width="5" height="26" rx="2" fill="#7c3aed"/><text class="tag tx" x="62" y="225">kind: command</text><text class="tag pulse" x="272" y="225" fill="#ef4444">rejected at load</text>
+<rect class="chip" x="44" y="244" width="210" height="26" rx="6"/><rect x="44" y="244" width="5" height="26" rx="2" fill="#7c3aed"/><text class="tag tx" x="62" y="261">allow_out_of_root</text><text class="tag pulse" x="272" y="261" fill="#ef4444">rejected at load</text>
+<text class="tag mut" x="44" y="302">bundled resolves offline; fetched bodies match their hash</text>
+<text class="tag mut" x="230" y="362" text-anchor="middle">an extended ruleset can tighten your checks, never run your commands</text>
+</svg>
+
+## How extends merges
+
+Each `extends:` entry names another config, and they resolve **left to right**: a later entry overrides an earlier one, and your own file overrides everything it extends. Merging is **by rule `id`, field by field**, so an entry that re-declares `readme-exists` with only `level: error` changes just that field and inherits `kind`, `paths`, and `message` from below. An entry can be a local file, an `https://` URL, or a bundled ruleset resolved offline from the binary (`alint://bundled/...`); `only:` / `except:` filters (mutually exclusive on one entry) narrow which rules an entry contributes.
+
+Fetched and bundled configs are **leaf nodes**: they cannot declare `extends:` of their own, because relative-path resolution inside a fetched body has no principled base. You nest `extends:` locally instead.
+
+## The trust boundary
+
+Sources are not equally trusted, and the boundary is drawn at `extends:`. Your own `.alint.yml` and its `.alint.d/` drop-ins are **trusted source**: they may declare process-spawning rules (`kind: command` and its siblings), `custom:` facts (which also spawn), `allow_out_of_root:`, and `baseline:`. A config reached **through `extends:`** may declare none of these. Each is rejected at load, by name, so adopting a published ruleset can never:
+
+- **run code** on your machine (a spawning rule, including one smuggled through a `require:` block or a `templates:` entry, is refused),
+- **read outside the repo** (`allow_out_of_root:` is a top-level-only grant), or
+- **choose which findings are suppressed** (`baseline:` is a top-level-only input).
+
+For `https://` entries, a **SHA-256 subresource-integrity hash** (`#sha256-...`) pins exactly which bytes are trusted; a body that does not match its hash is refused. Bundled rulesets ship inside the binary and are resolved offline, so there is nothing to fetch or pin. The hash pins *which* bytes load, and the trust boundary governs *what those bytes may do*.
+
+## In practice
+
+You extend a shared CI ruleset that, whether by mistake or by malice, hides a `command` rule:
+
+```yaml
+# .alint.yml
+version: 1
+extends:
+  - ./ci-rules.yml
+```
+
+```yaml
+# ci-rules.yml (reached through extends:)
+version: 1
+rules:
+  - id: deploy-check
+    kind: command
+    command: ["sh", "deploy.sh"]
+    paths: "**/*"
+    level: error
+```
+
+alint refuses to load, naming the rule and the offending config rather than running anything:
+
+```
+rule "deploy-check": kind: command spawns a process and is only allowed in the
+user's top-level config; declaring one in an extended config (ci-rules.yml)
+is refused because it would let a ruleset run arbitrary code
+```
+
+Move `deploy-check` into your own top-level `.alint.yml` and it runs, because now you are the one declaring it.
+
+## Going deeper
+
+- [Configuration](/docs/configuration/#extends) is the field reference for `extends:`, `allow_out_of_root:`, and the rule filters.
+- [Config layering](/docs/concepts/config-layering/) covers drop-ins and nested configs, the other sources that merge into one effective config.
+- [Variable interpolation](/docs/concepts/variable-interpolation/) details the `#sha256-...` pin and how `{{env.X}}` interacts with an `extends:` URL.

--- a/docs/site/concepts/config-layering.md
+++ b/docs/site/concepts/config-layering.md
@@ -1,0 +1,100 @@
+---
+title: Config layering
+description: "How one effective config is assembled from drop-ins and nested configs, and how the three interpolation timings resolve values at load, at template expansion, and per violation."
+sidebar:
+  order: 9
+---
+
+Your root `.alint.yml` is rarely the whole config. Drop-ins layer over it, per-directory nested configs add subtree-scoped rules, and three interpolation timings fill in values at three different moments. Knowing which layer resolves when is the difference between a config that behaves and one that surprises you.
+
+<svg class="alint-layer" viewBox="0 0 460 392" role="img" aria-labelledby="layer-t layer-d" xmlns="http://www.w3.org/2000/svg">
+<title id="layer-t">The three interpolation timings resolve at three different moments</title>
+<desc id="layer-d">A timeline with three stages. At config load, {{env.PKG_ROOT}} resolves to packages. At template expansion, {{vars.dir}} resolves to packages. Per violation, {{ctx.path}} resolves to packages/README.md. Each resolves at its own moment.</desc>
+<style>
+  .alint-layer { --tx:#1e1b4b; --mut:#64748b; --card:#ffffff; --bd:#c7cfe0; --ac:#4f46e5; width:100%; max-width:480px; height:auto; font:600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  :root[data-theme="dark"] .alint-layer { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; }
+  @media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) .alint-layer { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; } }
+  .alint-layer .ui { font:600 12px system-ui, -apple-system, sans-serif; }
+  .alint-layer .tag { font:600 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .alint-layer .tx { fill:var(--tx); } .alint-layer .mut { fill:var(--mut); } .alint-layer .ac { fill:var(--ac); }
+  .alint-layer .card { fill:var(--card); stroke:var(--bd); stroke-width:1.3; }
+  .alint-layer .node { fill:var(--ac); }
+  .alint-layer .spine { fill:none; stroke:var(--ac); stroke-width:2; stroke-dasharray:6 6; opacity:.6; animation:layerflow 1s linear infinite; }
+  .alint-layer .token { fill:var(--ac); animation:layertok 3.6s cubic-bezier(.5,0,.5,1) infinite; }
+  @keyframes layerflow { to { stroke-dashoffset:-12; } }
+  @keyframes layertok { 0%{transform:translateY(0);opacity:0} 8%{opacity:1} 90%{opacity:1} 100%{transform:translateY(200px);opacity:0} }
+  @media (prefers-reduced-motion:reduce){ .alint-layer .spine{animation:none;stroke-dasharray:none} .alint-layer .token{animation:none;opacity:1;transform:translateY(200px)} }
+</style>
+<text class="ui ac" x="18" y="16">three interpolation timings</text>
+<text class="ui mut" x="442" y="16" text-anchor="end">three moments</text>
+<path class="spine" d="M 54 60 V 322"/>
+<circle class="node" cx="54" cy="74" r="6"/>
+<circle class="node" cx="54" cy="174" r="6"/>
+<circle class="node" cx="54" cy="274" r="6"/>
+<circle class="token" cx="54" cy="74" r="4.5"/>
+<rect class="card" x="82" y="52" width="338" height="76" rx="10"/>
+<text class="ui ac" x="98" y="74">config load</text>
+<text class="tag tx" x="98" y="98">{{env.PKG_ROOT}} -&gt; packages</text>
+<text class="tag mut" x="98" y="118">from the process environment; local configs only</text>
+<rect class="card" x="82" y="152" width="338" height="76" rx="10"/>
+<text class="ui ac" x="98" y="174">template expansion</text>
+<text class="tag tx" x="98" y="198">{{vars.dir}} -&gt; packages</text>
+<text class="tag mut" x="98" y="218">only inside a templates: body</text>
+<rect class="card" x="82" y="252" width="338" height="76" rx="10"/>
+<text class="ui ac" x="98" y="274">per violation</text>
+<text class="tag tx" x="98" y="298">{{ctx.path}} -&gt; packages/README.md</text>
+<text class="tag mut" x="98" y="318">in a rule's message, once per finding</text>
+<text class="tag mut" x="230" y="362" text-anchor="middle">each resolves at its own moment; no layer sees another's values</text>
+</svg>
+
+## Drop-ins: `.alint.d/`
+
+When a `.alint.d/` directory sits next to your root `.alint.yml`, alint discovers every `*.yml` (or `*.yaml`) inside it and merges them in **alphabetical order, last wins** on a field-level conflict. It is the `/etc/*.d/` pattern applied to config: ops layer `50-policy.yml` through provisioning, a developer gitignores `99-local.yml`. Each drop-in is a complete config (its own `version: 1`) and can add rules, override existing ones by id, add `extends:`, or layer more `facts:` and `vars:`.
+
+Drop-ins are **trust-equivalent to your root config**: they live in the same workspace under your control, so they may declare spawning rules and `custom:` facts, unlike anything reached through `extends:`. Only the root config gets `.alint.d/` discovery; a config reached via `extends:` does not carry its own drop-ins.
+
+## Nested configs
+
+Opt in with `nested_configs: true` in the root config, and alint walks the tree (respecting `.gitignore` and `ignore:`) and picks up a `.alint.yml` in any subdirectory. A nested config's rules are **added, not overridden**, and each rule's path-like scope is **auto-prefixed with that subtree**, so a rule in `packages/web/.alint.yml` only ever looks at `packages/web/`.
+
+The guardrails keep nesting predictable: a nested config may declare only `version:` and `rules:`; every nested rule needs at least one scope field; absolute and `..`-escaping paths are rejected; and a duplicate rule `id` anywhere is a load error, never a silent override. Nesting is untrusted in the same way an `extends:`'d ruleset is (no spawning rules), and only the top-level config may turn it on, one level deep.
+
+## Three interpolation timings
+
+The same `{{...}}` syntax resolves at three distinct times, and each layer only ever sees its own inputs:
+
+- **`{{env.X}}`** resolves at **config load**, from the process environment, in local config files only. A `{{env.X | default('...')}}` filter supplies a fallback.
+- **`{{vars.X}}`** resolves when a **`templates:` body expands** into its instances. A plain, non-template rule does not expand `{{vars.X}}` in its fields; a bare `when: vars.X` reads a top-level var directly.
+- **`{{ctx.X}}`** resolves **per violation**, inside a rule's `message`, so each finding can name its own file or match.
+
+Because they resolve at different moments, they never cross: `{{ctx.path}}` is meaningless at load, and `{{env.X}}` is long since resolved by the time a violation is formatted.
+
+## In practice
+
+One config threads all three timings in order, an env value feeding a template var, the var scoping a path, and the violation naming it:
+
+```yaml
+version: 1
+templates:
+  - id: dir-readme
+    kind: file_exists
+    paths: ["{{vars.dir}}/README.md"]        # {{vars}} fills at template expansion
+    level: error
+    message: "{{ctx.path}} is required"        # {{ctx}} fills per violation
+rules:
+  - extends_template: dir-readme
+    id: pkg-readme
+    vars: { dir: "{{env.PKG_ROOT | default('packages')}}" }   # {{env}} fills at load
+```
+
+With `PKG_ROOT` unset and no `packages/README.md`, the default resolves at load, the template expands to `packages/README.md`, and the violation fills the message:
+
+```
+error  pkg-readme  packages/README.md is required
+```
+
+## Going deeper
+
+- [The config model](/docs/concepts/the-config-model/) is the whole assembly picture these layers feed into.
+- [Composition and trust](/docs/concepts/composition-and-trust/) covers `extends:`, the other way configs combine.
+- [Variable interpolation](/docs/concepts/variable-interpolation/) and [Rule templates](/docs/concepts/templates/) are the field-level references for the timings above.

--- a/docs/site/concepts/config-layering.md
+++ b/docs/site/concepts/config-layering.md
@@ -9,7 +9,7 @@ Your root `.alint.yml` is rarely the whole config. Drop-ins layer over it, per-d
 
 <svg class="alint-layer" viewBox="0 0 460 392" role="img" aria-labelledby="layer-t layer-d" xmlns="http://www.w3.org/2000/svg">
 <title id="layer-t">The three interpolation timings resolve at three different moments</title>
-<desc id="layer-d">A timeline with three stages. At config load, {{env.PKG_ROOT}} resolves to packages. At template expansion, {{vars.dir}} resolves to packages. Per violation, {{ctx.path}} resolves to packages/README.md. Each resolves at its own moment.</desc>
+<desc id="layer-d">A timeline with three stages. At config load, {{env.SRC_ROOT | default('src')}} resolves to src. At template expansion, {{vars.dir}} resolves to src. Per violation, {{ctx.primary}} resolves to src/app.c. Each resolves at its own moment.</desc>
 <style>
   .alint-layer { --tx:#1e1b4b; --mut:#64748b; --card:#ffffff; --bd:#c7cfe0; --ac:#4f46e5; width:100%; max-width:480px; height:auto; font:600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
   :root[data-theme="dark"] .alint-layer { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; }
@@ -34,15 +34,15 @@ Your root `.alint.yml` is rarely the whole config. Drop-ins layer over it, per-d
 <circle class="token" cx="54" cy="74" r="4.5"/>
 <rect class="card" x="82" y="52" width="338" height="76" rx="10"/>
 <text class="ui ac" x="98" y="74">config load</text>
-<text class="tag tx" x="98" y="98">{{env.PKG_ROOT}} -&gt; packages</text>
+<text class="tag tx" x="98" y="98">{{env.SRC_ROOT|default('src')}} -&gt; src</text>
 <text class="tag mut" x="98" y="118">from the process environment; local configs only</text>
 <rect class="card" x="82" y="152" width="338" height="76" rx="10"/>
 <text class="ui ac" x="98" y="174">template expansion</text>
-<text class="tag tx" x="98" y="198">{{vars.dir}} -&gt; packages</text>
+<text class="tag tx" x="98" y="198">{{vars.dir}} -&gt; src</text>
 <text class="tag mut" x="98" y="218">only inside a templates: body</text>
 <rect class="card" x="82" y="252" width="338" height="76" rx="10"/>
 <text class="ui ac" x="98" y="274">per violation</text>
-<text class="tag tx" x="98" y="298">{{ctx.path}} -&gt; packages/README.md</text>
+<text class="tag tx" x="98" y="298">{{ctx.primary}} -&gt; src/app.c</text>
 <text class="tag mut" x="98" y="318">in a rule's message, once per finding</text>
 <text class="tag mut" x="230" y="362" text-anchor="middle">each resolves at its own moment; no layer sees another's values</text>
 </svg>
@@ -57,7 +57,7 @@ Drop-ins are **trust-equivalent to your root config**: they live in the same wor
 
 Opt in with `nested_configs: true` in the root config, and alint walks the tree (respecting `.gitignore` and `ignore:`) and picks up a `.alint.yml` in any subdirectory. A nested config's rules are **added, not overridden**, and each rule's path-like scope is **auto-prefixed with that subtree**, so a rule in `packages/web/.alint.yml` only ever looks at `packages/web/`.
 
-The guardrails keep nesting predictable: a nested config may declare only `version:` and `rules:`; every nested rule needs at least one scope field; absolute and `..`-escaping paths are rejected; and a duplicate rule `id` anywhere is a load error, never a silent override. Nesting is untrusted in the same way an `extends:`'d ruleset is (no spawning rules), and only the top-level config may turn it on, one level deep.
+The guardrails keep nesting predictable: a nested config may declare only `version:` and `rules:`; every nested rule needs at least one scope field; absolute and `..`-escaping paths are rejected; and a duplicate rule `id` anywhere is a load error, never a silent override. Nesting is untrusted in the same way an `extends:`'d ruleset is (no spawning rules), and only the top-level config may turn it on; a nested config cannot enable its own nested discovery.
 
 ## Three interpolation timings
 
@@ -65,32 +65,33 @@ The same `{{...}}` syntax resolves at three distinct times, and each layer only 
 
 - **`{{env.X}}`** resolves at **config load**, from the process environment, in local config files only. A `{{env.X | default('...')}}` filter supplies a fallback.
 - **`{{vars.X}}`** resolves when a **`templates:` body expands** into its instances. A plain, non-template rule does not expand `{{vars.X}}` in its fields; a bare `when: vars.X` reads a top-level var directly.
-- **`{{ctx.X}}`** resolves **per violation**, inside a rule's `message`, so each finding can name its own file or match.
+- **`{{ctx.X}}`** resolves **per violation**, inside the `message` of a rule that populates it. A `pair` rule fills `{{ctx.primary}}` and `{{ctx.partner}}`, for example; not every rule interpolates its message, and one like `file_exists` emits its `message` verbatim.
 
-Because they resolve at different moments, they never cross: `{{ctx.path}}` is meaningless at load, and `{{env.X}}` is long since resolved by the time a violation is formatted.
+Because they resolve at different moments, they never cross: `{{ctx.primary}}` is meaningless at load, and `{{env.X}}` is long since resolved by the time a violation is formatted.
 
 ## In practice
 
-One config threads all three timings in order, an env value feeding a template var, the var scoping a path, and the violation naming it:
+One config threads all three timings in order: an env value feeds a template var, the var scopes which files the rule pairs, and each violation names the file and its missing partner:
 
 ```yaml
 version: 1
 templates:
-  - id: dir-readme
-    kind: file_exists
-    paths: ["{{vars.dir}}/README.md"]        # {{vars}} fills at template expansion
+  - id: sources-need-headers
+    kind: pair
+    primary: "{{vars.dir}}/**/*.c"                     # {{vars}} fills at template expansion
+    partner: "{dir}/{stem}.h"
+    message: "{{ctx.primary}} has no header at {{ctx.partner}}"   # {{ctx}} fills per violation
     level: error
-    message: "{{ctx.path}} is required"        # {{ctx}} fills per violation
 rules:
-  - extends_template: dir-readme
-    id: pkg-readme
-    vars: { dir: "{{env.PKG_ROOT | default('packages')}}" }   # {{env}} fills at load
+  - extends_template: sources-need-headers
+    id: lib-headers
+    vars: { dir: "{{env.SRC_ROOT | default('src')}}" }     # {{env}} fills at load
 ```
 
-With `PKG_ROOT` unset and no `packages/README.md`, the default resolves at load, the template expands to `packages/README.md`, and the violation fills the message:
+With `SRC_ROOT` unset and `src/app.c` missing its header, the default resolves at load, the template expands to pair `src/**/*.c` files, and the `pair` rule fills the message per violation:
 
 ```
-error  pkg-readme  packages/README.md is required
+error  lib-headers  src/app.c has no header at src/app.h
 ```
 
 ## Going deeper

--- a/docs/site/concepts/scoping.md
+++ b/docs/site/concepts/scoping.md
@@ -5,11 +5,11 @@ sidebar:
   order: 6
 ---
 
-A rule never judges the whole repository. It narrows from the walked index to a specific set of files through three gates applied in a fixed order: `when:` decides whether the rule runs at all, `paths:` selects files by glob, and `scope_filter:` refines that selection per file. Only what survives all three (and the optional `git_tracked_only:` narrowing) is evaluated.
+A rule never judges the whole repository. It narrows from the walked index to a specific set of files through three gates applied in a fixed order: `when:` decides whether the rule runs at all, `paths:` selects files by glob, and `scope_filter:` refines that selection per file. Only what survives all three is evaluated.
 
-<svg class="alint-scope" viewBox="0 0 460 340" role="img" aria-labelledby="scope-t scope-d" xmlns="http://www.w3.org/2000/svg">
+<svg class="alint-scope" viewBox="0 0 460 296" role="img" aria-labelledby="scope-t scope-d" xmlns="http://www.w3.org/2000/svg">
 <title id="scope-t">A rule narrows the file index through gates in a fixed order</title>
-<desc id="scope-d">A when: gate decides whether the rule runs. Then the walked index of 40 files narrows through the paths: glob to 12, through scope_filter: to 8, and through git_tracked_only to 8, leaving 8 files evaluated. Each gate is a narrower bar than the one above it.</desc>
+<desc id="scope-d">A when: gate decides whether the rule runs. Then the walked index of 40 files narrows through the paths: glob to 12 and through scope_filter: to 8, leaving 8 files evaluated. Each gate is a narrower bar than the one above it.</desc>
 <style>
   .alint-scope { --tx:#1e1b4b; --mut:#64748b; --card:#ffffff; --bd:#c7cfe0; --ac:#4f46e5; width:100%; max-width:480px; height:auto; font:600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
   :root[data-theme="dark"] .alint-scope { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; }
@@ -23,20 +23,19 @@ A rule never judges the whole repository. It narrows from the walked index to a 
   .alint-scope .flow { fill:none; stroke:var(--ac); stroke-width:2; stroke-dasharray:6 6; opacity:.6; animation:scopeflow 1s linear infinite; }
   .alint-scope .token { fill:var(--ac); animation:scopetok 3.4s cubic-bezier(.5,0,.5,1) infinite; }
   @keyframes scopeflow { to { stroke-dashoffset:-12; } }
-  @keyframes scopetok { 0%{transform:translateY(0);opacity:0} 8%{opacity:1} 90%{opacity:1} 100%{transform:translateY(190px);opacity:0} }
-  @media (prefers-reduced-motion:reduce){ .alint-scope .flow{animation:none;stroke-dasharray:none} .alint-scope .token{animation:none;opacity:1;transform:translateY(190px)} }
+  @keyframes scopetok { 0%{transform:translateY(0);opacity:0} 8%{opacity:1} 90%{opacity:1} 100%{transform:translateY(146px);opacity:0} }
+  @media (prefers-reduced-motion:reduce){ .alint-scope .flow{animation:none;stroke-dasharray:none} .alint-scope .token{animation:none;opacity:1;transform:translateY(146px)} }
 </style>
 <rect class="gate" x="126" y="22" width="208" height="28" rx="14"/>
 <text class="tag ac" x="230" y="40" text-anchor="middle">when: facts.has_rust</text>
 <text class="tag mut" x="230" y="66" text-anchor="middle">true: the rule runs. false: dropped before any file is read.</text>
-<path class="flow" d="M 230 74 V 286"/>
+<path class="flow" d="M 230 74 V 242"/>
 <rect class="bar" x="30" y="80" width="400" height="30" rx="6"/><text class="tag mut" x="42" y="99">walked index</text><text class="tag tx" x="418" y="99" text-anchor="end">40 files</text>
 <rect class="bar" x="64" y="124" width="332" height="30" rx="6"/><text class="tag tx" x="76" y="143">paths: src/**/*.rs</text><text class="tag mut" x="384" y="143" text-anchor="end">12</text>
 <rect class="bar" x="98" y="168" width="264" height="30" rx="6"/><text class="tag tx" x="110" y="187">scope_filter: has_ancestor</text><text class="tag mut" x="350" y="187" text-anchor="end">8</text>
-<rect class="bar" x="132" y="212" width="196" height="30" rx="6"/><text class="tag tx" x="144" y="231">git_tracked_only</text><text class="tag mut" x="316" y="231" text-anchor="end">8</text>
-<rect class="final" x="160" y="256" width="140" height="30" rx="6"/><text class="tag ac" x="172" y="275">evaluate</text><text class="tag ac" x="288" y="275" text-anchor="end">8</text>
+<rect class="final" x="130" y="212" width="200" height="30" rx="6"/><text class="tag ac" x="142" y="231">evaluate</text><text class="tag ac" x="318" y="231" text-anchor="end">8</text>
 <circle class="token" cx="230" cy="86" r="5"/>
-<text class="tag mut" x="230" y="316" text-anchor="middle">each gate ANDs onto the last; the set only ever shrinks</text>
+<text class="tag mut" x="230" y="272" text-anchor="middle">each gate ANDs onto the last; the set only ever shrinks</text>
 </svg>
 
 ## The three gates
@@ -45,12 +44,12 @@ A rule never judges the whole repository. It narrows from the walked index to a 
 
 `paths:` is the primary selector: a glob, a list of globs, or an `{include, exclude}` pair matched against the walked index. It answers "which files is this rule about."
 
-`scope_filter:` refines that per file, for the cases a glob cannot express. Its predicates **AND-compose**: when more than one is set, a file must satisfy all of them. At least one predicate must be present. Cross-file rules (`pair`, `for_each_dir`, `file_exists`, and their siblings) reject `scope_filter:` at build time, with a pointer to the `for_each_dir` + `when_iter:` pattern instead; the rule-major per-file kinds (`filename_case`, `file_max_size`, and their siblings) honor it as of v0.15.
+`scope_filter:` refines that per file, for the cases a glob cannot express. Its predicates **AND-compose**: when more than one is set, a file must satisfy all of them. At least one predicate must be present. Cross-file rules (`pair`, `for_each_dir`, and their siblings) reject `scope_filter:` at build time, with a pointer to the `for_each_dir` + `when_iter:` pattern instead; the rule-major per-file kinds (`filename_case`, `file_max_size`, and their siblings) honor it as of v0.15.
 
 ## scope_filter predicates
 
 - **`has_ancestor:`** keeps a file only when a named manifest sits somewhere in its ancestor directory chain. The engine walks `Path::parent()` upward (the file's own directory counts) and stops at the first match, so a content rule scopes to just its ecosystem's subtree in a polyglot monorepo. The bundled ecosystem rulesets use it to confine per-file rules to their package subtrees.
-- **`changed_since: <git-ref>`** keeps only files in the `<ref>...HEAD` diff, the same merge-base diff as [`--changed`](/docs/concepts/changed-mode/). It accepts `{{env.X}}` interpolation and resolves the diff once per run.
+- **`changed_since: <git-ref>`** keeps only files in the `<ref>...HEAD` merge-base diff, the form [`--changed --base=<ref>`](/docs/concepts/changed-mode/) uses (bare `--changed` uses a working-tree diff instead). It accepts `{{env.X}}` interpolation and resolves the diff once per run.
 - **`include_manifest_paths:` / `exclude_manifest_paths:`** scope by membership in a path set a manifest declares (a `Cargo.toml` `workspace.members`, a `package.json` `bin`), so the manifest that owns the truth and the rule that depends on it stay in one place. An optional **`derive_target: { from, to }`** regex maps a declared build output back to its source (`dist/cli.js` back to `src/cli.ts`); `expect_nonempty:` (default `true`) warns when an include set resolves to nothing rather than silently matching no files.
 
 A manifest **value** only gates which files a rule sees, never what it decides about them: extraction is pure parsing (no spawn, so it is safe inside an `extends:`'d ruleset), and `alint explain <rule>` prints the resolved set.
@@ -80,7 +79,7 @@ rules:
 On a PR that adds one unheadered `crates/core/src/new.rs`:
 
 ```
-error  spdx-on-changed-rust  crates/core/src/new.rs: add an SPDX-License-Identifier header
+error  spdx-on-changed-rust  add an SPDX-License-Identifier header
 ```
 
 Unchanged Rust files, and every file outside a `Cargo.toml` subtree, are never considered.

--- a/docs/site/concepts/scoping.md
+++ b/docs/site/concepts/scoping.md
@@ -1,0 +1,92 @@
+---
+title: Scoping
+description: "How a rule narrows from the whole index to the files it judges: the when: fact gate, the paths: glob, and scope_filter: predicates, applied in a fixed order."
+sidebar:
+  order: 6
+---
+
+A rule never judges the whole repository. It narrows from the walked index to a specific set of files through three gates applied in a fixed order: `when:` decides whether the rule runs at all, `paths:` selects files by glob, and `scope_filter:` refines that selection per file. Only what survives all three (and the optional `git_tracked_only:` narrowing) is evaluated.
+
+<svg class="alint-scope" viewBox="0 0 460 340" role="img" aria-labelledby="scope-t scope-d" xmlns="http://www.w3.org/2000/svg">
+<title id="scope-t">A rule narrows the file index through gates in a fixed order</title>
+<desc id="scope-d">A when: gate decides whether the rule runs. Then the walked index of 40 files narrows through the paths: glob to 12, through scope_filter: to 8, and through git_tracked_only to 8, leaving 8 files evaluated. Each gate is a narrower bar than the one above it.</desc>
+<style>
+  .alint-scope { --tx:#1e1b4b; --mut:#64748b; --card:#ffffff; --bd:#c7cfe0; --ac:#4f46e5; width:100%; max-width:480px; height:auto; font:600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  :root[data-theme="dark"] .alint-scope { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; }
+  @media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) .alint-scope { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; } }
+  .alint-scope .ui { font:600 12px system-ui, -apple-system, sans-serif; }
+  .alint-scope .tag { font:600 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .alint-scope .tx { fill:var(--tx); } .alint-scope .mut { fill:var(--mut); } .alint-scope .ac { fill:var(--ac); }
+  .alint-scope .bar { fill:var(--card); stroke:var(--bd); stroke-width:1.3; }
+  .alint-scope .gate { fill:var(--card); stroke:var(--ac); stroke-width:1.6; }
+  .alint-scope .final { fill:var(--card); stroke:var(--ac); stroke-width:1.8; }
+  .alint-scope .flow { fill:none; stroke:var(--ac); stroke-width:2; stroke-dasharray:6 6; opacity:.6; animation:scopeflow 1s linear infinite; }
+  .alint-scope .token { fill:var(--ac); animation:scopetok 3.4s cubic-bezier(.5,0,.5,1) infinite; }
+  @keyframes scopeflow { to { stroke-dashoffset:-12; } }
+  @keyframes scopetok { 0%{transform:translateY(0);opacity:0} 8%{opacity:1} 90%{opacity:1} 100%{transform:translateY(190px);opacity:0} }
+  @media (prefers-reduced-motion:reduce){ .alint-scope .flow{animation:none;stroke-dasharray:none} .alint-scope .token{animation:none;opacity:1;transform:translateY(190px)} }
+</style>
+<rect class="gate" x="126" y="22" width="208" height="28" rx="14"/>
+<text class="tag ac" x="230" y="40" text-anchor="middle">when: facts.has_rust</text>
+<text class="tag mut" x="230" y="66" text-anchor="middle">true: the rule runs. false: dropped before any file is read.</text>
+<path class="flow" d="M 230 74 V 286"/>
+<rect class="bar" x="30" y="80" width="400" height="30" rx="6"/><text class="tag mut" x="42" y="99">walked index</text><text class="tag tx" x="418" y="99" text-anchor="end">40 files</text>
+<rect class="bar" x="64" y="124" width="332" height="30" rx="6"/><text class="tag tx" x="76" y="143">paths: src/**/*.rs</text><text class="tag mut" x="384" y="143" text-anchor="end">12</text>
+<rect class="bar" x="98" y="168" width="264" height="30" rx="6"/><text class="tag tx" x="110" y="187">scope_filter: has_ancestor</text><text class="tag mut" x="350" y="187" text-anchor="end">8</text>
+<rect class="bar" x="132" y="212" width="196" height="30" rx="6"/><text class="tag tx" x="144" y="231">git_tracked_only</text><text class="tag mut" x="316" y="231" text-anchor="end">8</text>
+<rect class="final" x="160" y="256" width="140" height="30" rx="6"/><text class="tag ac" x="172" y="275">evaluate</text><text class="tag ac" x="288" y="275" text-anchor="end">8</text>
+<circle class="token" cx="230" cy="86" r="5"/>
+<text class="tag mut" x="230" y="316" text-anchor="middle">each gate ANDs onto the last; the set only ever shrinks</text>
+</svg>
+
+## The three gates
+
+`when:` is a run-wide switch, not a per-file filter. It is a bounded boolean expression over four namespaces (`facts.`, `vars.`, `env.`, and `iter.` inside iteration contexts), evaluated once per run against facts computed once. If it is false, the whole rule is dropped before a single file is read, so a rule gated on an absent ecosystem costs nothing. A missing fact reads as `null` (falsy).
+
+`paths:` is the primary selector: a glob, a list of globs, or an `{include, exclude}` pair matched against the walked index. It answers "which files is this rule about."
+
+`scope_filter:` refines that per file, for the cases a glob cannot express. Its predicates **AND-compose**: when more than one is set, a file must satisfy all of them. At least one predicate must be present. Cross-file rules (`pair`, `for_each_dir`, `file_exists`, and their siblings) reject `scope_filter:` at build time, with a pointer to the `for_each_dir` + `when_iter:` pattern instead; the rule-major per-file kinds (`filename_case`, `file_max_size`, and their siblings) honor it as of v0.15.
+
+## scope_filter predicates
+
+- **`has_ancestor:`** keeps a file only when a named manifest sits somewhere in its ancestor directory chain. The engine walks `Path::parent()` upward (the file's own directory counts) and stops at the first match, so a content rule scopes to just its ecosystem's subtree in a polyglot monorepo. The bundled ecosystem rulesets use it to confine per-file rules to their package subtrees.
+- **`changed_since: <git-ref>`** keeps only files in the `<ref>...HEAD` diff, the same merge-base diff as [`--changed`](/docs/concepts/changed-mode/). It accepts `{{env.X}}` interpolation and resolves the diff once per run.
+- **`include_manifest_paths:` / `exclude_manifest_paths:`** scope by membership in a path set a manifest declares (a `Cargo.toml` `workspace.members`, a `package.json` `bin`), so the manifest that owns the truth and the rule that depends on it stay in one place. An optional **`derive_target: { from, to }`** regex maps a declared build output back to its source (`dist/cli.js` back to `src/cli.ts`); `expect_nonempty:` (default `true`) warns when an include set resolves to nothing rather than silently matching no files.
+
+A manifest **value** only gates which files a rule sees, never what it decides about them: extraction is pure parsing (no spawn, so it is safe inside an `extends:`'d ruleset), and `alint explain <rule>` prints the resolved set.
+
+## In practice
+
+Require an SPDX header, but only on the Rust files a PR actually touched, and only in a repo that has Rust at all:
+
+```yaml
+version: 1
+facts:
+  - id: has_rust
+    any_file_exists: [Cargo.toml]
+rules:
+  - id: spdx-on-changed-rust
+    kind: file_header
+    when: facts.has_rust
+    paths: "**/*.rs"
+    pattern: "^// SPDX-License-Identifier:"
+    scope_filter:
+      has_ancestor: Cargo.toml
+      changed_since: "{{env.ALINT_BASE_SHA | default('origin/main')}}"
+    level: error
+    message: "add an SPDX-License-Identifier header"
+```
+
+On a PR that adds one unheadered `crates/core/src/new.rs`:
+
+```
+error  spdx-on-changed-rust  crates/core/src/new.rs: add an SPDX-License-Identifier header
+```
+
+Unchanged Rust files, and every file outside a `Cargo.toml` subtree, are never considered.
+
+## Going deeper
+
+- [Configuration](/docs/configuration/#scope_filter-per-file-rules-v096) is the field reference for every `scope_filter:` predicate and its options.
+- [The walker and git](/docs/concepts/walker-and-gitignore/) is the index these gates narrow, and where `git_tracked_only:` is defined.
+- [Changed mode](/docs/concepts/changed-mode/) is the run-wide `--changed` counterpart to the per-rule `changed_since:` predicate.

--- a/docs/site/concepts/walker-and-gitignore.md
+++ b/docs/site/concepts/walker-and-gitignore.md
@@ -60,7 +60,7 @@ Every run begins by walking your repository once into a sorted in-memory index, 
 
 Starting at the path you pass to `alint check` (or the current directory), the walker yields every regular file under that root, **except** paths matched by any of: the repo's `.gitignore` files (root and per-directory), `.git/info/exclude`, your global gitignore (`core.excludesFile`), `.ignore` files (the same syntax, honored by the [`ignore`](https://docs.rs/ignore/) crate that powers `ripgrep` and the walker), the `.git/` directory itself, and anything in the config's `ignore:` list.
 
-Hidden files **are** included: alint walks `.github/`, `.editorconfig`, and `.cargo/` by default. Symlinks are followed. No git repo is required; on a plain directory the walk just has nothing to filter, so every file is visible.
+Hidden files **are** included: alint walks `.github/`, `.editorconfig`, and `.cargo/` by default. In-tree symlinks are followed, but a symlink whose target escapes the repo root, or that dangles, is pruned from the walk. No git repo is required; on a plain directory the walk just has nothing to filter, so every file is visible.
 
 Two config fields shape the filtering. `respect_gitignore` (default `true`) toggles every gitignore source at once; the CLI's `--no-gitignore` forces it off for one run. `ignore:` adds gitignore-style patterns on top, and applies regardless of `respect_gitignore`, for exclusions that are an alint concern rather than a git one:
 
@@ -95,10 +95,11 @@ In a healthy repo neither case is common, and `git ls-files <path>` is the autho
 | Gitignored, never built | silent | silent |
 | Gitignored, built locally | silent | silent |
 | Not gitignored, on disk | **fires** | silent (not in index) |
-| Tracked in git's index | **fires** | **fires** |
+| Committed (not gitignored) | **fires** | **fires** |
+| Gitignored but force-added | silent (walker prunes it) | **fires** |
 | Not a git repo | **fires** | silent (no index) |
 
-`git_tracked_only` applies to the existence kinds `file_exists`, `file_absent`, `dir_exists`, and `dir_absent`; other kinds ignore it. Outside a git repo (or with `git` off `PATH`) the tracked set is empty, so absence rules with the flag become silent no-ops (there is nothing to commit) and existence rules with it fail conservatively (no file qualifies). The git-hygiene family also ships `git_commit_message`, `git_no_denied_paths`, and other git-aware kinds; see the [rule reference](/docs/rules/) for the full set.
+`git_tracked_only` applies to the existence kinds `file_exists`, `file_absent`, `dir_exists`, and `dir_absent`; any other kind rejects it at load rather than ignoring it. Outside a git repo (or with `git` off `PATH`) the tracked set is empty, so absence rules with the flag become silent no-ops (there is nothing to commit) and existence rules with it fail conservatively (no file qualifies). The git-hygiene family also ships `git_commit_message`, `git_no_denied_paths`, and other git-aware kinds; see the [rule reference](/docs/rules/) for the full set.
 
 ## In practice
 

--- a/docs/site/concepts/walker-and-gitignore.md
+++ b/docs/site/concepts/walker-and-gitignore.md
@@ -1,97 +1,86 @@
 ---
-title: The walker and .gitignore
-description: How alint discovers files, what `.gitignore` filters out by default, and how rules like `file_absent` / `dir_absent` interpret git state.
+title: The walker and git
+description: "How alint discovers files by walking the tree through git's own ignore rules, why the walked tree can diverge from git's index, and how git_tracked_only switches a rule to the index."
 sidebar:
   order: 5
 ---
 
-Every alint run starts the same way: walk the repo, build an in-memory index of files, then evaluate rules against that index. The walker is a thin wrapper around the [`ignore`](https://docs.rs/ignore/) crate (the same crate that powers `ripgrep`), and its filtering behaviour is the most common source of confusion when a rule "doesn't fire when I expected it to."
+Every run begins by walking your repository once into a sorted in-memory index, and every rule reads that index, never the raw filesystem and never `git` directly. What lands in the index is the working tree minus everything `.gitignore` excludes, so a rule's idea of "what is here" is the un-ignored working tree. That is almost always what you want; the two places it diverges from git's own index are the source of nearly every "why didn't my rule fire" question.
 
-<likec4-view view-id="walkerFlow"></likec4-view>
+<svg class="alint-walk" viewBox="0 0 460 424" role="img" aria-labelledby="walk-t walk-d" xmlns="http://www.w3.org/2000/svg">
+<title id="walk-t">The walker builds an index from the un-ignored tree; git_tracked_only reads git's index instead</title>
+<desc id="walk-d">Files on disk split two ways. The default walked tree includes README.md and an un-ignored untracked file but drops a gitignored-but-committed file. The git index, which git_tracked_only consults, includes README.md and the committed file but not the untracked one. The two divergent files are the ones a mis-set gitignore hides.</desc>
+<style>
+  .alint-walk { --tx:#1e1b4b; --mut:#64748b; --card:#ffffff; --bd:#c7cfe0; --ac:#4f46e5; width:100%; max-width:480px; height:auto; font:600 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  :root[data-theme="dark"] .alint-walk { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; }
+  @media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) .alint-walk { --tx:#e6e8ef; --mut:#93a0b8; --card:#2a2f3e; --bd:#3b4254; --ac:#8b93f8; } }
+  .alint-walk .ui { font:600 12px system-ui, -apple-system, sans-serif; }
+  .alint-walk .tag { font:600 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .alint-walk .tx { fill:var(--tx); } .alint-walk .mut { fill:var(--mut); } .alint-walk .ac { fill:var(--ac); }
+  .alint-walk .card { fill:var(--card); stroke:var(--bd); stroke-width:1.3; }
+  .alint-walk .chip { fill:var(--card); stroke:var(--bd); stroke-width:1.2; }
+  .alint-walk .off  { opacity:.42; }
+  .alint-walk .flow { fill:none; stroke:var(--ac); stroke-width:2; stroke-dasharray:6 6; opacity:.7; animation:walkflow 1s linear infinite; }
+  .alint-walk .pulse { animation:walkpulse 2.4s ease-in-out infinite; }
+  @keyframes walkflow { to { stroke-dashoffset:-12; } }
+  @keyframes walkpulse { 0%,100% { opacity:1; } 50% { opacity:.55; } }
+  @media (prefers-reduced-motion:reduce){ .alint-walk .flow{animation:none;stroke-dasharray:none} .alint-walk .pulse{animation:none} }
+</style>
+<text class="ui ac" x="18" y="16">one walk, one index</text>
+<text class="ui mut" x="442" y="16" text-anchor="end">git_tracked_only reads git instead</text>
+<rect class="card" x="20" y="28" width="420" height="118" rx="10"/>
+<text class="ui mut" x="34" y="46">on disk</text>
+<rect class="chip" x="34" y="54" width="400" height="24" rx="6"/><rect x="34" y="54" width="5" height="24" rx="2" fill="#22c55e"/><text class="tag tx" x="48" y="70">README.md</text><text class="tag mut" x="428" y="70" text-anchor="end">committed</text>
+<rect class="chip" x="34" y="82" width="400" height="24" rx="6"/><rect x="34" y="82" width="5" height="24" rx="2" fill="#7c3aed"/><text class="tag tx" x="48" y="98">config.local.yml</text><text class="tag mut" x="428" y="98" text-anchor="end">gitignored, committed</text>
+<rect class="chip" x="34" y="110" width="400" height="24" rx="6"/><rect x="34" y="110" width="5" height="24" rx="2" fill="#f59e0b"/><text class="tag tx" x="48" y="126">scratch.tmp</text><text class="tag mut" x="428" y="126" text-anchor="end">untracked</text>
+<path class="flow" d="M 180 146 C 180 176, 120 176, 120 200"/>
+<path class="flow" d="M 280 146 C 280 176, 340 176, 340 200"/>
+<text class="tag mut" x="34" y="166">walk + .gitignore</text>
+<text class="tag mut" x="426" y="166" text-anchor="end">git ls-files</text>
+<rect class="card" x="20" y="204" width="200" height="182" rx="10"/>
+<text class="ui ac" x="34" y="226">walked tree</text>
+<text class="tag mut" x="34" y="242">default rule view</text>
+<rect class="chip" x="34" y="252" width="172" height="24" rx="6"/><rect x="34" y="252" width="5" height="24" rx="2" fill="#22c55e"/><text class="tag tx" x="48" y="268">README.md</text>
+<rect class="chip pulse" x="34" y="282" width="172" height="24" rx="6"/><rect x="34" y="282" width="5" height="24" rx="2" fill="#f59e0b"/><text class="tag tx" x="48" y="298">scratch.tmp</text>
+<rect class="chip off" x="34" y="312" width="172" height="24" rx="6" stroke-dasharray="4 3"/><text class="tag mut" x="48" y="328">config.local.yml</text>
+<text class="tag mut" x="34" y="356">the un-ignored tree,</text>
+<text class="tag mut" x="34" y="372">committed file filtered out</text>
+<rect class="card" x="240" y="204" width="200" height="182" rx="10"/>
+<text class="ui ac" x="254" y="226">git index</text>
+<text class="tag mut" x="254" y="242">git_tracked_only: true</text>
+<rect class="chip" x="254" y="252" width="172" height="24" rx="6"/><rect x="254" y="252" width="5" height="24" rx="2" fill="#22c55e"/><text class="tag tx" x="268" y="268">README.md</text>
+<rect class="chip pulse" x="254" y="282" width="172" height="24" rx="6"/><rect x="254" y="282" width="5" height="24" rx="2" fill="#7c3aed"/><text class="tag tx" x="268" y="298">config.local.yml</text>
+<rect class="chip off" x="254" y="312" width="172" height="24" rx="6" stroke-dasharray="4 3"/><text class="tag mut" x="268" y="328">scratch.tmp</text>
+<text class="tag mut" x="254" y="356">what git tracks,</text>
+<text class="tag mut" x="254" y="372">catches the drift</text>
+<text class="tag mut" x="230" y="410" text-anchor="middle">the two files that differ are the ones a mis-set .gitignore hides</text>
+</svg>
 
-## What the walker sees by default
+## What the walker sees
 
-Starting at the path you pass to `alint check` (or the current directory), the walker yields every regular file under that root, **except** for paths matched by any of the following:
+Starting at the path you pass to `alint check` (or the current directory), the walker yields every regular file under that root, **except** paths matched by any of: the repo's `.gitignore` files (root and per-directory), `.git/info/exclude`, your global gitignore (`core.excludesFile`), `.ignore` files (the same syntax, honored by the [`ignore`](https://docs.rs/ignore/) crate that powers `ripgrep` and the walker), the `.git/` directory itself, and anything in the config's `ignore:` list.
 
-- The repo's `.gitignore` files (root and per-directory)
-- `.git/info/exclude`
-- Your global gitignore (`~/.config/git/ignore`, or whatever `core.excludesFile` points at)
-- `.ignore` files (the `ignore` crate's own convention; same syntax as `.gitignore`)
-- The `.git/` directory itself
-- Anything added under the config's `ignore:` field (see below)
+Hidden files **are** included: alint walks `.github/`, `.editorconfig`, and `.cargo/` by default. Symlinks are followed. No git repo is required; on a plain directory the walk just has nothing to filter, so every file is visible.
 
-Hidden files (those starting with `.`) **are** included; alint walks `.github/`, `.editorconfig`, `.cargo/`, etc. by default. Symlinks are followed.
-
-The walker does *not* require a git repo to function. Rules run identically on a plain directory, a tarball extraction, or a fresh git clone. The only difference is that without `.gitignore` files, no paths get filtered out.
-
-## The `respect_gitignore` config field
-
-The default is the equivalent of:
-
-```yaml
-version: 1
-respect_gitignore: true   # the default
-```
-
-Set it to `false` to disable every gitignore source above (per-directory, root, info/exclude, global, `.ignore`):
-
-```yaml
-version: 1
-respect_gitignore: false
-```
-
-The CLI's `--no-gitignore` flag overrides whatever's in config to `false` for one invocation. Useful when you want to lint files that *would* be committed if `.gitignore` weren't there, e.g. for a one-off audit of a build directory.
-
-## The `ignore:` config field
-
-`ignore:` adds patterns *on top of* whatever `.gitignore` already excludes. Same gitignore-style syntax. Use it for repo-specific exclusions you don't want to put in `.gitignore` itself (because they're an alint thing, not a git thing):
+Two config fields shape the filtering. `respect_gitignore` (default `true`) toggles every gitignore source at once; the CLI's `--no-gitignore` forces it off for one run. `ignore:` adds gitignore-style patterns on top, and applies regardless of `respect_gitignore`, for exclusions that are an alint concern rather than a git one:
 
 ```yaml
 version: 1
 ignore:
   - "vendor/**"
   - "**/*.snapshot.json"
-  - "fixtures/golden/**"
 ```
 
-These patterns are excluded *regardless* of `respect_gitignore`. Setting `respect_gitignore: false` disables `.gitignore`-sourced filters but leaves `ignore:` filters in place.
+Setting `respect_gitignore: false` is rarely useful during development: absence-style rules (`dir_absent`, `file_absent`) begin firing on every locally-built `target/`, `node_modules/`, and `__pycache__/`. It fits one-off audits of a build tree, or linting a directory that is not a git repo.
 
-## How this affects rules
+## Walked tree versus git's index
 
-Every rule sees a **pre-filtered file index**. If a path was excluded by the walker, no rule can act on it; they don't get a chance.
+Because the walker filters by `.gitignore`, "the walked tree" is a close but imperfect stand-in for "what git would commit." alint never reads `.git/index` or shells out to `git ls-files` for the walk, so the approximation drifts in two directions:
 
-For most rules (`file_exists`, `file_content_matches`, `filename_case`, `for_each_dir`) this is exactly what you want. You don't care about gitignored caches, you care about the files git would actually track.
+- **A gitignored-but-tracked file** (added to git first and gitignored later, or forced in with `git add -f`) stays in git's index on every commit, yet the walker filters it out. Absence rules never see it and content rules never inspect it.
+- **An un-ignored untracked file** (a scratch file no `.gitignore` pattern covers) is in the walked tree but not git's index, so a rule fires on a file git is not tracking.
 
-For **absence-style rules** (`file_absent`, `dir_absent`, `no_*` rules), the implication is sharper:
-
-> A `dir_absent` rule with `paths: "**/target"` fires whenever `target/` exists in the walked tree. If `target/` is in `.gitignore`, the walker filters it out, and the rule never sees it. No violation, even if `target/` is sitting on disk full of build artefacts.
-
-That's the intent. When your `.gitignore` is correct, build artefacts are invisible to alint, and the rule effectively means "this directory wouldn't be committed." When `.gitignore` is missing or wrong, the directory becomes visible, the rule fires, and you've caught a hygiene gap.
-
-The rule's name often reads as "no committed `target/`". That's a useful mental model, but the actual implementation is **"no un-ignored `target/`"**. The two coincide in well-configured repos. They diverge in the edge cases below.
-
-## What this is *not*: a check against git's index
-
-alint doesn't read `.git/index` and doesn't shell out to `git ls-files`. The walker observes the filesystem; `.gitignore` is a coarse approximation of "what would be committed." Two cases where this approximation drifts:
-
-- **Tracked-then-gitignored files.** `.gitignore` only affects *untracked* files. If a file was added to git first and then later listed in `.gitignore`, git still tracks it on every commit, but alint's walker filters it out, so absence-style rules don't fire and content rules don't inspect it. `git ls-files <path>` would still report the file.
-- **`git add -f`'d files.** Adding a file with `--force` overrides `.gitignore`. The file is in git's index, but alint's walker still filters it out by the matching gitignore entry.
-
-In a healthy repo neither case is common. If you suspect either, `git ls-files <path>` is the authoritative answer.
-
-## When to use `respect_gitignore: false`
-
-Rare, but legitimate cases:
-
-- **Auditing a CI runner's working tree** where build outputs accumulated and you want to enforce content rules on everything, including gitignored caches.
-- **Linting a directory that isn't a git repo** but happens to contain a stray `.gitignore` you don't want to honour.
-- **Running absence-style rules deliberately on the full disk state**, e.g. as a pre-package check that "no `.env` is sitting in this directory regardless of `.gitignore`."
-
-Don't reach for `--no-gitignore` casually. With it on, every `dir_absent` / `file_absent` rule fires on any developer who has built locally: `target/`, `node_modules/`, `__pycache__/`, `.next/` all become violations. That's almost never what you want during normal development.
-
-## Tightening the rule with `git_tracked_only`
-
-The walker's gitignore-based approximation works for most repos, but if you want a rule that fires *only* when a path is actually in git's index (independent of `.gitignore` state) set `git_tracked_only: true` on the rule:
+In a healthy repo neither case is common, and `git ls-files <path>` is the authoritative answer when you suspect one. When a rule must key off git's index rather than the walked tree, set `git_tracked_only: true` on it. The rule then fires only for paths git actually tracks, independent of `.gitignore` state:
 
 ```yaml
 - id: target-not-tracked
@@ -101,46 +90,42 @@ The walker's gitignore-based approximation works for most repos, but if you want
   level: error
 ```
 
-This is the canonical "don't let `target/` be committed" rule. With the flag set, the rule only fires when `target/` contains at least one file in `git ls-files`. A locally-built `target/` that's properly gitignored stays silent (no tracked content). A `target/` whose contents have been added with `git add -f` or before `.gitignore` was set up (the cases the [walker approximation misses](#what-this-is-not-a-check-against-gits-index)) does fire, because `git ls-files` reports them.
-
-Behaviour summary:
-
-| `target/` state | Without `git_tracked_only` | With `git_tracked_only` |
+| `target/` state | default | `git_tracked_only` |
 |---|---|---|
 | Gitignored, never built | silent | silent |
 | Gitignored, built locally | silent | silent |
-| Not gitignored, exists on disk | **fires** | silent (not in index) |
+| Not gitignored, on disk | **fires** | silent (not in index) |
 | Tracked in git's index | **fires** | **fires** |
-| Repo isn't a git repo | **fires** | silent (no index) |
+| Not a git repo | **fires** | silent (no index) |
 
-`git_tracked_only` currently applies to four rule kinds: `file_exists`, `file_absent`, `dir_exists`, `dir_absent`. The other rule kinds ignore the field; we'll extend coverage as use cases come up.
+`git_tracked_only` applies to the existence kinds `file_exists`, `file_absent`, `dir_exists`, and `dir_absent`; other kinds ignore it. Outside a git repo (or with `git` off `PATH`) the tracked set is empty, so absence rules with the flag become silent no-ops (there is nothing to commit) and existence rules with it fail conservatively (no file qualifies). The git-hygiene family also ships `git_commit_message`, `git_no_denied_paths`, and other git-aware kinds; see the [rule reference](/docs/rules/) for the full set.
 
-When `alint` runs outside a git repo (no `.git/`), or when `git` isn't on `PATH`, the tracked-set is empty and absence-style rules with `git_tracked_only: true` become silent no-ops. That's the right default for "don't let X be committed": if there's no repo, there's nothing to commit. Existence rules with the flag set fail in that case (no file qualifies), which is also the correct conservative behaviour.
+## In practice
 
-The git-hygiene family also ships `git_commit_message`, `git_no_denied_paths`, and other git-aware kinds; see the rule reference for the full set.
+The canonical "do not let `target/` be committed" rule keys off the index, not the walked tree, so a locally-built `target/` stays quiet while a force-added one is caught:
 
-## Restricting the walk: `--changed`
+```yaml
+version: 1
+rules:
+  - id: target-not-tracked
+    kind: dir_absent
+    paths: "**/target"
+    git_tracked_only: true
+    level: error
+    message: "target/ must not be committed"
+```
 
-The walker is the engine's source of truth about what's on disk. `alint check --changed` adds a second filter layer on top: only files that appear in the *diff* are visible to per-file rules. The walked index still spans the whole tree (so cross-file rules and existence rules can answer their full-tree questions), but per-file rules see a filtered view.
+On a repo where someone ran `git add -f target/debug/build.log`:
 
-Two diff modes:
+```
+error  target-not-tracked  target/ must not be committed
+```
 
-| Invocation | Diff source | Right shape for |
-|---|---|---|
-| `alint check --changed` | `git ls-files --modified --others --exclude-standard` | Pre-commit / local dev |
-| `alint check --changed --base=main` | `git diff --name-only --relative main...HEAD` | PR checks (three-dot, merge-base) |
+The same rule is silent for every developer who merely built locally, because that `target/` is gitignored and untracked.
 
-The `<base>...HEAD` form (three-dot) diffs against the merge-base of `<base>` and `HEAD`, which is what GitHub PR checks consider "your changes." The two-dot form `<base>..HEAD` is rarely what you want here, because it includes commits in `HEAD` since you branched, plus any commits *removed* from `<base>` since the branch point.
+## Going deeper
 
-**Which rules opt out of the changed-set filter:**
-
-- **Cross-file rules** (`pair`, `for_each_dir`, `every_matching_has`, `unique_by`, `dir_contains`, `dir_only_contains`) always evaluate against the full tree. A `pair` rule still fires when a `.h` partner is missing, even if the matching `.c` wasn't in your diff.
-- **Existence rules** (`file_exists`, `file_absent`, `dir_exists`, `dir_absent`) evaluate against the full tree, but the engine *skips them entirely* when their `paths:` scope doesn't intersect the diff. So an unchanged-but-missing `LICENSE` doesn't fire on every PR; it only fires on PRs that touched a `LICENSE*` path.
-
-**Edge cases:**
-
-- **Empty diff** (no working-tree changes, no untracked files): the engine short-circuits to an empty report. The "ran on a no-op commit" pre-commit case completes in milliseconds.
-- **Outside a git repo** (or `git` missing from `PATH`): `--changed` exits non-zero with an explicit error rather than silently fall back to a full check. Falling back would violate the intent the user expressed by passing the flag.
-- **Deleted files** are reported by both diff modes. A `LICENSE` deleted in your branch shows up in the diff; the walker doesn't see it on disk (it's gone), so an existence rule for `LICENSE*` evaluates against the full tree (which lacks it) and fires.
-
-`--changed` pairs naturally with `git_tracked_only: true`: the changed-set is a working-tree concept, the tracked-set is an index concept, and an absence-style rule with both is "fire only on tracked entries that are part of this diff." The same flags work for `alint fix --changed`.
+- [Configuration](/docs/configuration/) is the field reference for `ignore:`, `respect_gitignore`, and every rule field.
+- [Scoping](/docs/concepts/scoping/) is how a rule narrows within the index, with `paths:`, `when:`, and `scope_filter:`.
+- [Changed mode](/docs/concepts/changed-mode/) restricts a run to the files in a diff, layered on top of the walk.
+- The interactive <a href="/docs/about/architecture-diagrams/">architecture diagrams</a> include the walker view (`walkerFlow`) as an explorable model.

--- a/docs/site/configuration/index.md
+++ b/docs/site/configuration/index.md
@@ -160,7 +160,7 @@ Common per-rule fields:
 - **`kind`** *(required)*: which built-in implementation to invoke. Required somewhere in the `extends:` chain.
 - **`level`** *(required)*: `error`, `warning`, `info`, or `off`. `off` disables the rule entirely.
 - **`paths`**: glob, list of globs, or `{include, exclude}` pair. Required for most kinds.
-- **`when`**: bounded expression gating the rule on facts / vars.
+- **`when`**: bounded expression gating the rule on facts / vars. See [Scoping](/docs/concepts/scoping/) for the gate order.
 - **`scope_filter`**: extra per-file scoping by ancestor manifest presence, git diff, or membership in a manifest-declared path set (see below). Cross-file rules reject this field at build time.
 - **`fix`**: fix-op declaration (e.g. `file_trim_trailing_whitespace: {}`).
 - **`message`**: override the rule's display message.
@@ -314,3 +314,4 @@ A `--baseline <path>` flag overrides this key. There is **no silent auto-detect*
 - [JSON Schema](https://alint.org/_alint/configuration/schema.json): authoritative source for option types.
 - [Rules](/docs/rules/): every rule kind, organised by family, with per-rule options.
 - [Concepts](/docs/concepts/): the rule model, the walker, and how alint runs, explained.
+- [Scoping](/docs/concepts/scoping/): the `when:`, `paths:`, and `scope_filter:` gates a rule narrows its files through.


### PR DESCRIPTION
Phase 4 of the concepts-section redesign (`docs/design/concepts-section-redesign.md`), the "targeting and composition" group.

## Pages

- **The walker and git** (rewrite): reshaped to the concept template with an animated walker-vs-index diagram (the two files a mis-set `.gitignore` hides), the `git_tracked_only` behaviour table, and a worked example. The `--changed` material moved to its own page.
- **Scoping** (new): the `when:` / `paths:` / `scope_filter:` gates and their fixed order, every `scope_filter` predicate (`has_ancestor`, `changed_since`, `include`/`exclude_manifest_paths` with `derive_target` and `expect_nonempty`), AND-composition, and the cross-file rejection. Delivers the `when:` mental model the configuration reference used to only gesture at.
- **Changed mode** (new): the `--changed` / `--base` fast path, which rules stay whole-tree (cross-file always; existence whole-tree but skipped when paths miss the diff) and why, and the edge cases.
- **Composition and trust** (new): `extends:` field-merge and the trust boundary (spawning rules, custom facts, `allow_out_of_root`, and `baseline` rejected from an extended config; SRI; path confinement), with the real spawn-gate load error.
- **Config layering** (new): drop-ins, nested configs, and the three interpolation timings (`{{env}}` at load, `{{vars}}` at expansion, `{{ctx}}` per violation).

Each page carries one animated inline-SVG diagram in the v3 visual language (narrow, mobile-first, theme-aware, reduced-motion-guarded), screenshot-QA'd in light and dark.

## Verification

- All five diagrams render and animate in both themes, no overflow at 320 to 414px.
- Signal-free prose (no em-dashes or other AI tells), consistent with the Phase 3 purge.
- alint.org builds (213 pages, +4 new); the doc-link gate passes.

## Deferred to Phase 6 (as designed)

The walker page keeps its `walker-and-gitignore.md` filename for now; the rename to `the-walker-and-git.md`, the per-group subdir move, the grouped sidebar (`astro.config.mjs`), and the redirects all land together in Phase 6 so the URL changes are handled atomically.

https://claude.ai/code/session_01DY5e8zTE8XDCDsaPkJT8Ai
