### PR TITLE
fix: de-duplicate fix-report path and drop em-dashes from fix/agent output

### DIFF
--- a/crates/alint-output/src/agent.rs
+++ b/crates/alint-output/src/agent.rs
@@ -303,6 +303,14 @@ mod tests {
             "got: {inst}"
         );
         assert!(
+            inst.contains("(or run `alint fix --only readme-exists` to apply the auto-fix)"),
+            "fixable instruction should carry the parenthetical fix hint: {inst}"
+        );
+        assert!(
+            !inst.contains('\u{2014}'),
+            "agent_instruction must not contain an em-dash: {inst}"
+        );
+        assert!(
             inst.contains("https://example.com/policy"),
             "policy URL should be cited: {inst}"
         );

--- a/crates/alint-output/src/agent.rs
+++ b/crates/alint-output/src/agent.rs
@@ -167,8 +167,8 @@ fn severity_str(level: Level) -> &'static str {
 /// Concrete shapes:
 ///
 /// - Path-bound, fixable: `"warning: README is missing. To
-///   resolve: edit README — or run `alint fix --only
-///   readme-exists` to apply the auto-fix."`
+///   resolve: edit README (or run `alint fix --only
+///   readme-exists` to apply the auto-fix)."`
 /// - Path-bound, non-fixable: `"warning: console.log left in
 ///   non-test source. To resolve: edit src/api.ts:2:1."`
 /// - Cross-file (no path): `"error: Multiple lockfiles present.
@@ -208,9 +208,9 @@ fn build_agent_instruction(rule: &RuleResult, violation: &Violation) -> String {
     }
 
     if rule.is_fixable {
-        out.push_str(" — or run `alint fix --only ");
+        out.push_str(" (or run `alint fix --only ");
         out.push_str(&rule.rule_id);
-        out.push_str("` to apply the auto-fix");
+        out.push_str("` to apply the auto-fix)");
     }
 
     if let Some(url) = rule.policy_url.as_deref() {

--- a/crates/alint-output/src/human.rs
+++ b/crates/alint-output/src/human.rs
@@ -470,11 +470,14 @@ pub fn write_fix_human(
             "{level_style}{level_name}{level_style:#} {rule_style}[{safe_rule_id}]{rule_style:#}:",
         )?;
         for item in &rule.items {
+            // The applied summary already names the file it touched, so the
+            // path prefix is added only to the message-based skipped / no-fixer
+            // lines below, where the file would otherwise go unnamed.
             let path_prefix = item
                 .violation
                 .path
                 .as_ref()
-                .map(|p| format!("{} — ", p.display()))
+                .map(|p| format!("{} - ", p.display()))
                 .unwrap_or_default();
             let (glyph, line_style_open, line_style_close, content) = match &item.status {
                 FixStatus::Applied(summary) => {
@@ -483,7 +486,7 @@ pub fn write_fix_human(
                         opts.glyphs.success,
                         format!("{s}"),
                         format!("{s:#}"),
-                        format!("{path_prefix}{summary}"),
+                        summary.clone(),
                     )
                 }
                 FixStatus::Skipped(reason) => (

--- a/crates/alint-output/src/markdown.rs
+++ b/crates/alint-output/src/markdown.rs
@@ -89,17 +89,22 @@ pub fn write_fix_markdown(report: &FixReport, w: &mut dyn Write) -> std::io::Res
         writeln!(w, "## `{}` ({})", md_inline_code(&r.rule_id), r.items.len())?;
         writeln!(w)?;
         for item in &r.items {
-            let status_label = match &item.status {
-                FixStatus::Applied(msg) => format!("**applied** — {}", md_escape(msg)),
-                FixStatus::Skipped(msg) => format!("**skipped** — {}", md_escape(msg)),
-                FixStatus::Unfixable => "**unfixable**".to_string(),
+            // The applied summary already names its file, so show the path
+            // prefix only on the message-based skipped / unfixable lines.
+            let (status_label, show_path) = match &item.status {
+                FixStatus::Applied(msg) => (format!("**applied** - {}", md_escape(msg)), false),
+                FixStatus::Skipped(msg) => (format!("**skipped** - {}", md_escape(msg)), true),
+                FixStatus::Unfixable => ("**unfixable**".to_string(), true),
             };
-            let path_part = item
-                .violation
-                .path
-                .as_ref()
-                .map(|p| format!("`{}` — ", md_inline_code(&p.display().to_string())))
-                .unwrap_or_default();
+            let path_part = if show_path {
+                item.violation
+                    .path
+                    .as_ref()
+                    .map(|p| format!("`{}` - ", md_inline_code(&p.display().to_string())))
+                    .unwrap_or_default()
+            } else {
+                String::new()
+            };
             writeln!(
                 w,
                 "- {path_part}{status_label}: {}",

--- a/crates/alint-output/src/markdown.rs
+++ b/crates/alint-output/src/markdown.rs
@@ -635,7 +635,7 @@ mod tests {
                             is_note: false,
                             baseline_key: None,
                         },
-                        status: FixStatus::Applied("removed 3 trailing spaces".into()),
+                        status: FixStatus::Applied("trimmed trailing whitespace in a.rs".into()),
                     },
                     FixItem {
                         violation: Violation {
@@ -656,5 +656,23 @@ mod tests {
         assert!(out.contains("**applied**"));
         assert!(out.contains("**unfixable**"));
         assert!(out.contains("**1 applied**, **0 skipped**, **1 unfixable**."));
+        // Applied: the summary already carries the path, so it is not re-prefixed.
+        assert!(
+            out.contains("**applied** - trimmed trailing whitespace in a"),
+            "applied line should carry the summary verbatim: {out}"
+        );
+        assert!(
+            !out.contains("`a.rs` - **applied**"),
+            "applied line must not duplicate the path as a prefix: {out}"
+        );
+        // Unfixable is message-based, so it keeps the path prefix.
+        assert!(
+            out.contains("`b.rs` - **unfixable**"),
+            "unfixable line should keep the path prefix: {out}"
+        );
+        assert!(
+            !out.contains('\u{2014}'),
+            "markdown fix report must not contain an em-dash: {out}"
+        );
     }
 }

--- a/crates/alint-rules/src/fixers/creators.rs
+++ b/crates/alint-rules/src/fixers/creators.rs
@@ -494,7 +494,10 @@ mod tests {
             .apply(&Violation::new("x"), &make_ctx(&tmp, true))
             .unwrap();
         match outcome {
-            FixOutcome::Applied(s) => assert!(s.starts_with("would create")),
+            FixOutcome::Applied(s) => {
+                assert!(s.starts_with("would create"));
+                assert!(s.contains("x.txt"), "summary must name the file: {s}");
+            }
             FixOutcome::Skipped(_) => panic!("expected Applied"),
         }
         assert!(!tmp.path().join("x.txt").exists());

--- a/crates/alint-rules/src/fixers/file_ops.rs
+++ b/crates/alint-rules/src/fixers/file_ops.rs
@@ -117,7 +117,7 @@ impl Fixer for FileRenameFixer {
         }
         if ctx.dry_run {
             return Ok(FixOutcome::Applied(format!(
-                "would rename {} → {}",
+                "would rename {} -> {}",
                 path.display(),
                 new_path.display()
             )));
@@ -127,7 +127,7 @@ impl Fixer for FileRenameFixer {
             source,
         })?;
         Ok(FixOutcome::Applied(format!(
-            "renamed {} → {}",
+            "renamed {} -> {}",
             path.display(),
             new_path.display()
         )))
@@ -213,7 +213,10 @@ mod tests {
             )
             .unwrap();
         match outcome {
-            FixOutcome::Applied(s) => assert!(s.starts_with("would remove")),
+            FixOutcome::Applied(s) => {
+                assert!(s.starts_with("would remove"));
+                assert!(s.contains("victim.bak"), "summary must name the file: {s}");
+            }
             FixOutcome::Skipped(_) => panic!("expected Applied"),
         }
         assert!(target.exists());

--- a/crates/alint/tests/cli/fix-file-append.stdout
+++ b/crates/alint/tests/cli/fix-file-append.stdout
@@ -1,4 +1,4 @@
 warning [spdx-in-readme]:
-  ✓ README.md — appended to README.md
+  ✓ appended to README.md
 
 1 applied, 0 skipped, 0 unfixable.

--- a/crates/alint/tests/cli/fix-file-prepend.stdout
+++ b/crates/alint/tests/cli/fix-file-prepend.stdout
@@ -1,4 +1,4 @@
 error [has-header]:
-  ✓ src/module.rs — prepended src/module.rs
+  ✓ prepended src/module.rs
 
 1 applied, 0 skipped, 0 unfixable.

--- a/crates/alint/tests/cli/fix-file-remove.stdout
+++ b/crates/alint/tests/cli/fix-file-remove.stdout
@@ -1,4 +1,4 @@
 error [no-bak]:
-  ✓ sneaky.bak — removed sneaky.bak
+  ✓ removed sneaky.bak
 
 1 applied, 0 skipped, 0 unfixable.

--- a/crates/alint/tests/cli/fix-file-rename.stdout
+++ b/crates/alint/tests/cli/fix-file-rename.stdout
@@ -1,4 +1,4 @@
 error [rust-snake]:
-  ✓ renamed src/FooBar.rs → src/foo_bar.rs
+  ✓ renamed src/FooBar.rs -> src/foo_bar.rs
 
 1 applied, 0 skipped, 0 unfixable.

--- a/crates/alint/tests/cli/fix-file-rename.stdout
+++ b/crates/alint/tests/cli/fix-file-rename.stdout
@@ -1,4 +1,4 @@
 error [rust-snake]:
-  ✓ src/FooBar.rs — renamed src/FooBar.rs → src/foo_bar.rs
+  ✓ renamed src/FooBar.rs → src/foo_bar.rs
 
 1 applied, 0 skipped, 0 unfixable.

--- a/crates/alint/tests/cli/fix-trim.in/.alint.yml
+++ b/crates/alint/tests/cli/fix-trim.in/.alint.yml
@@ -1,0 +1,8 @@
+version: 1
+rules:
+  - id: trim
+    kind: no_trailing_whitespace
+    paths: "**/*.md"
+    level: warning
+    fix:
+      file_trim_trailing_whitespace: {}

--- a/crates/alint/tests/cli/fix-trim.in/doc.md
+++ b/crates/alint/tests/cli/fix-trim.in/doc.md
@@ -1,0 +1,2 @@
+hello   
+world

--- a/crates/alint/tests/cli/fix-trim.stdout
+++ b/crates/alint/tests/cli/fix-trim.stdout
@@ -1,0 +1,4 @@
+warning [trim]:
+  ✓ trimmed trailing whitespace in doc.md
+
+1 applied, 0 skipped, 0 unfixable.

--- a/crates/alint/tests/cli/fix-trim.toml
+++ b/crates/alint/tests/cli/fix-trim.toml
@@ -1,0 +1,3 @@
+bin.name = "alint"
+args = ["fix", "."]
+fs.sandbox = true

--- a/docs/site/concepts/fixing.md
+++ b/docs/site/concepts/fixing.md
@@ -97,12 +97,12 @@ rules:
 error [license-present]:
   ✓ created LICENSE
 info [md-trim]:
-  ✓ docs/guide.md — trimmed trailing whitespace in docs/guide.md
+  ✓ trimmed trailing whitespace in docs/guide.md
 
 2 applied, 0 skipped, 0 unfixable.
 ```
 
-Each applied line is prefixed with the file it touched. A file over `fix_size_limit`, or a `content_from:` source that is missing, shows on its rule as `(skipped: <reason>)` and lands in the `skipped` count instead.
+Each applied line names the file in its summary; skipped and unfixable lines carry it as a prefix. A file over `fix_size_limit`, or a `content_from:` source that is missing, shows on its rule as `(skipped: <reason>)` and lands in the `skipped` count instead.
 
 ## Going deeper
 

--- a/docs/site/concepts/the-agent-surface.md
+++ b/docs/site/concepts/the-agent-surface.md
@@ -97,7 +97,7 @@ One fixable finding comes back as a flat object with a ready-to-run `fix_command
       "line": 12,
       "column": 80,
       "human_message": "trailing whitespace",
-      "agent_instruction": "warning: trailing whitespace. To resolve: edit src/app.rs:12:80 — or run `alint fix --only no-trailing-whitespace` to apply the auto-fix.",
+      "agent_instruction": "warning: trailing whitespace. To resolve: edit src/app.rs:12:80 (or run `alint fix --only no-trailing-whitespace` to apply the auto-fix).",
       "fix_available": true,
       "fix_command": ["fix", "--only", "no-trailing-whitespace"]
     }


### PR DESCRIPTION
Two output-hygiene follow-ups from the Phase 5 docs audit (#233).

## 1. Fix report no longer prints the path twice

For content-edit fixers the human/markdown fix report showed the file twice: the formatter prepends `` `<path>` - `` while the fixer's own summary already names it (`trimmed trailing whitespace in <path>`). The summary is authoritative for the path, so the prefix is dropped on **applied** lines and kept on the message-based **skipped** / **unfixable** lines (which would otherwise be unnamed). `file_create` is unchanged — its violation is path-less, so `created <path>` already carries the file.

Before / after (human):
```
- ✓ README.md — appended to README.md
+ ✓ appended to README.md
```

## 2. No em-dashes in the agent + fix output

- `agent_instruction` fixable suffix: `… — or run \`alint fix --only <id>\` …` → `… (or run \`alint fix --only <id>\` to apply the auto-fix).`
- fix-report path separator: em-dash → ASCII hyphen.

(Rule messages and the violation renderer still use em-dashes — out of scope for this change.)

## Docs

Updated the two Phase 5 concept examples (`fixing`, `the-agent-surface`) to the new output, which also makes the concept docs **fully em-dash-free** in prose and code blocks.

## Verification

fmt · clippy `-D warnings` · `cargo test --workspace` (2267 pass, 0 fail) · `cargo doc -D warnings` · 4 regenerated snapshots · doc-example + doc-link gates · alint.org build + overflow detector — all green.

https://claude.ai/code/session_01DY5e8zTE8XDCDsaPkJT8Ai