### PR TITLE
docs: auto-fix framework + rule-coverage-gap analysis (ADR-0017)

### DIFF
--- a/crates/alint-e2e/tests/coverage_audit_doc_links.rs
+++ b/crates/alint-e2e/tests/coverage_audit_doc_links.rs
@@ -117,6 +117,50 @@ fn links(text: &str) -> Vec<String> {
     urls
 }
 
+/// Remove fenced code blocks and inline code spans before link
+/// extraction. A `[text](./path)` shown as an EXAMPLE inside backticks
+/// renders as literal text on GitHub, not a live link, so the gate must
+/// not treat it as one (rule-coverage-gaps.md documents markdown-link
+/// syntax this way). Only the bytes *between* backticks are dropped, so
+/// a real link whose visible text is code-formatted keeps its
+/// `](target)` and is still checked.
+fn strip_code(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut in_fence = false;
+    for line in text.lines() {
+        let t = line.trim_start();
+        if t.starts_with("```") || t.starts_with("~~~") {
+            in_fence = !in_fence;
+            out.push('\n');
+            continue;
+        }
+        if in_fence {
+            out.push('\n');
+            continue;
+        }
+        let mut in_code = false;
+        for ch in line.chars() {
+            if ch == '`' {
+                in_code = !in_code;
+            } else if !in_code {
+                out.push(ch);
+            }
+        }
+        out.push('\n');
+    }
+    out
+}
+
+#[test]
+fn strip_code_drops_example_links_but_keeps_real_ones() {
+    // A whole link inside one code span is an example -> dropped.
+    assert!(!strip_code("see `[text](./path)` here").contains("]("));
+    // A real link whose visible text is code-formatted -> kept + checked.
+    assert!(strip_code("see [`auto-fix.md`](auto-fix.md)").contains("](auto-fix.md)"));
+    // Fenced code blocks are dropped wholesale.
+    assert!(!strip_code("```\n[x](./nope)\n```").contains("]("));
+}
+
 #[test]
 fn repo_doc_links_are_not_dead_on_github() {
     let root = repo_root();
@@ -143,7 +187,7 @@ fn repo_doc_links_are_not_dead_on_github() {
             }
         }
 
-        for url in links(&text) {
+        for url in links(&strip_code(&text)) {
             // Anchors, externals, mail/other schemes: not our concern.
             if url.starts_with('#') || url.starts_with("mailto:") {
                 continue;

--- a/docs/adr/0017-auto-fix-edit-model-and-applicability.md
+++ b/docs/adr/0017-auto-fix-edit-model-and-applicability.md
@@ -87,22 +87,27 @@ contract that makes a Safe-only fixpoint terminate without the cap); a Safe **st
 a **well-behaved lens** (the GetPut and PutGet laws hold at apply time). Safe `set_value` is
 restricted to a scalar replacing an existing scalar; object/array values, key insertion, and
 nested creation are Suggestions. `alint fix` applies only Safe fixes by default. The report gains
-a `Suggested(edit)` outcome and the agent format gains an `applicability` field and a
-`proposed_edit` payload; a Suggestion is never applied, so an error-level violation whose only fix
-is a Suggestion **still stands and still drives a nonzero `fix` exit** (the reframing is confined
-to the agent output, not the exit-code predicate). The 12 existing ops are classified Safe on
-introduction so current behavior is unchanged.
+a `FixStatus::Suggested(edit)` variant and the agent format gains an `applicability` field and a
+`proposed_edit` payload; because a Suggestion is never applied, `has_unresolved` is **extended to
+count `Suggested` as unresolved**, so an error-level Suggestion still stands and still drives a
+nonzero `fix` exit. Existing ops are classified Safe on introduction, **except `file_remove`,
+reclassified Unsafe by default** (deleting a whole file irreversibly is a poor default), with a
+one-release migration and a per-rule Safe override from top-level config.
 
 **3. A fixer trust boundary distinct from the kind-level spawn gate.** A fixer is a new trust
 surface, and the existing `SPAWNING_RULE_KINDS` allowlist gates the rule **kind**, not a
-**fixer** attached to a non-spawning kind. We will add a fix-level gate. **Spawning** fix ops
-(`git_untrack`, a `command`-backed fix, regenerate-from-command) are **refused at load** from an
-`extends:`-ed ruleset, mirroring the kind-level `SPAWNING_RULE_KINDS` hard-reject.
-**Content-mutating** fix ops (`replace`, `set_value`, `remove_value`, `sync_from`,
-`insert_header`) are, when inherited, **demoted to Suggestion** rather than refused. Applicability
-promotion is top-level-only (an inherited fixer may be demoted but never promoted). The gate
-reuses the loader's existing top-level-versus-`extends:` provenance plumbing (the same mechanism
-that forces `allow_out_of_root` off for inherited rules).
+**fixer** attached to a non-spawning kind. We will add a fix-level gate keyed on
+capability and provenance. **Fixed-behavior fixers** (the seven normalizers, rename-to-case,
+`file_remove`, `chmod`, `dir_create`) inject no bytes and do not spawn, so they are honored at
+their tier from any source (this keeps bundled rulesets' trailing-whitespace / final-newline fixes
+auto-applying). **Content-injecting fixers** (`replace`, `set_value`, `sync_from`, `insert_header`,
+create/prepend/append-with-content) are honored from top-level config, local-path `extends:`, and
+first-party bundled rulesets, but **demoted to Suggestion** from a remote-URL `extends:`, with a
+top-level `trusted_extends:` allowlist to opt specific remote sources back in. **Spawning fixers**
+(`git_untrack`, a `command`-backed fix, regenerate-from-command) are **refused at load** from any
+non-top-level source. Applicability promotion is top-level-only (an inherited fixer may be demoted
+but never promoted). The gate reuses the loader's existing top-level-versus-`extends:` provenance
+plumbing (the same mechanism that forces `allow_out_of_root` off for inherited rules).
 
 ## Consequences
 

--- a/docs/adr/0017-auto-fix-edit-model-and-applicability.md
+++ b/docs/adr/0017-auto-fix-edit-model-and-applicability.md
@@ -64,34 +64,45 @@ this step), filter by applicability threshold, group per file, sort by a total o
 `(start, end, rule_index, violation_index)` and apply non-overlapping edits while skipping
 conflicts (with Ruff-style isolation groups), verify a re-parse postcondition (reject and
 demote to Suggestion, memoized per edit, any edit that would produce an unparseable file), and
-write atomically. The **fixpoint loop lands in Phase 1**, not Phase 0, so the Phase 0 engine is
-a single behavior-preserving pass; the fixpoint carries an index-invalidation rule (a
+write atomically. Whole-file transforms (the existing ops) are **not** modeled as `0..len`
+ranges; they compose functionally in config order, so **Phase 0, which ships only whole-file
+ops, reproduces today's behavior exactly**, and the located-edit batch, overlap-skip, and
+fixpoint arrive in Phase 1. The engine is a **non-confluent rewriting system** driven by a
+total-order strategy, which buys reproducibility, not canonicity, and whose soundness rests on
+the fact that disjoint edits commute. The fixpoint carries an index-invalidation rule (a
 path-mutating edit forces a deterministic re-walk) and a loud non-convergence cap. A fix that
-spans files is applied as an all-or-nothing multi-file transaction. Idempotence is a tested
-contract per fixer. Format-preserving structured edits are span-splices against a per-format
-CST or spanned parser, never a parse-then-dump, with a per-format value serializer for quoting,
-type fidelity, and separator surgery.
+spans files is an all-or-nothing multi-file transaction whose postconditions are checked over
+the staged set. Format-preserving structured edits are span-splices against a per-format CST or
+spanned parser, never a parse-then-dump, with a per-format value serializer for quoting, type
+fidelity, and separator surgery.
 
 **2. A four-state applicability model, defined by application policy.** Every fixer declares
 one of: **Safe** (applied by default), **Unsafe** (applied only with `--unsafe-fixes`),
 **Suggestion** (never written; surfaced as a concrete `proposed_edit` payload in the
 `agent` / `json` / LSP output), and **Never** (no fix proposed). The tier is the policy; the
-properties (idempotent, output re-parses, discards no human content, target unambiguous) are
-the inputs an author uses to pick it. Safe `set_value` is restricted to a scalar replacing an
-existing scalar; object/array values, key insertion, and nested creation are Suggestions.
-`alint fix` applies only Safe fixes by default. The report gains a `Suggested(edit)` outcome and
-the agent format gains an `applicability` field, reconciling `has_unfixable_errors` so a
-Suggested outcome is not an unresolved error. The 12 existing ops are classified Safe on
+properties are the inputs an author uses to pick it. A **Safe** fixer must be idempotent, pass a
+localized-equivalence acceptance test where it edits content, and **strictly decrease the
+outstanding-violation multiset** without introducing others (a Dershowitz-Manna termination
+contract that makes a Safe-only fixpoint terminate without the cap); a Safe **structured** fix is
+a **well-behaved lens** (the GetPut and PutGet laws hold at apply time). Safe `set_value` is
+restricted to a scalar replacing an existing scalar; object/array values, key insertion, and
+nested creation are Suggestions. `alint fix` applies only Safe fixes by default. The report gains
+a `Suggested(edit)` outcome and the agent format gains an `applicability` field and a
+`proposed_edit` payload; a Suggestion is never applied, so an error-level violation whose only fix
+is a Suggestion **still stands and still drives a nonzero `fix` exit** (the reframing is confined
+to the agent output, not the exit-code predicate). The 12 existing ops are classified Safe on
 introduction so current behavior is unchanged.
 
 **3. A fixer trust boundary distinct from the kind-level spawn gate.** A fixer is a new trust
 surface, and the existing `SPAWNING_RULE_KINDS` allowlist gates the rule **kind**, not a
-**fixer** attached to a non-spawning kind. We will add a fix-level gate: content-mutating fix
-ops (`replace`, `set_value`, `remove_value`, `insert_header`, `sync_from`) and spawning fix ops
-(`git_untrack`, a `command`-backed fix, regenerate-from-command) are honored only from the
-user's own top-level config, never from an `extends:`-ed ruleset; applicability promotion is
-top-level-only (an inherited fixer may be demoted but never promoted), and an inherited
-content-mutating fixer defaults to Suggestion.
+**fixer** attached to a non-spawning kind. We will add a fix-level gate. **Spawning** fix ops
+(`git_untrack`, a `command`-backed fix, regenerate-from-command) are **refused at load** from an
+`extends:`-ed ruleset, mirroring the kind-level `SPAWNING_RULE_KINDS` hard-reject.
+**Content-mutating** fix ops (`replace`, `set_value`, `remove_value`, `sync_from`,
+`insert_header`) are, when inherited, **demoted to Suggestion** rather than refused. Applicability
+promotion is top-level-only (an inherited fixer may be demoted but never promoted). The gate
+reuses the loader's existing top-level-versus-`extends:` provenance plumbing (the same mechanism
+that forces `allow_out_of_root` off for inherited rules).
 
 ## Consequences
 
@@ -111,6 +122,13 @@ pipeline cannot be reused for write-back; multi-file fixes need all-or-nothing t
 fix-level trust gate must be built and maintained because reusing the kind-level spawn gate
 would leave a fixer-on-a-non-spawning-kind hole. Reclassifying an existing op (treating
 `file_remove` as Unsafe) is a safety-default and semver decision rather than a free change.
+
+The engine's guarantees are bounded and stated as such: reproducibility, not order-independence;
+a Safe-tier fixpoint that terminates by the multiset contract (the cap only guards Unsafe and
+promoted fixers); lens-law correctness for structured write-back; and per-run translation
+validation rather than a CompCert-grade proof. These map onto the repo's existing verification
+tiers (`formal-methods.md`): proptest for the algebraic laws, one bounded Kani proof for the
+splice or overlap invariant, and debug_assert runtime contracts.
 
 ## Considered Options
 
@@ -136,6 +154,10 @@ would leave a fixer-on-a-non-spawning-kind hole. Reclassifying an existing op (t
 
 Design doc: [`docs/design/auto-fix.md`](../design/auto-fix.md). Trust boundary:
 [ADR-0004](0004-extends-trust-boundary-and-path-confinement.md). Dispatch and determinism:
-[ADR-0003](0003-rule-engine-dispatch-and-determinism.md). Prior art with primary sources is
+[ADR-0003](0003-rule-engine-dispatch-and-determinism.md). The formal model (rewriting-system
+determinism, the Safe-tier termination contract, the lens laws, and the verification plan) is
+section 5.8 of the design doc; the completeness-theory framing for the detection surface is the
+companion [`rule-coverage-gaps.md`](../design/rule-coverage-gaps.md). Prior art with primary
+sources is
 collected in the design doc's references section (ESLint, Ruff, `toml_edit`,
 `node-jsonc-parser`, and the archived Repolinter).

--- a/docs/adr/0017-auto-fix-edit-model-and-applicability.md
+++ b/docs/adr/0017-auto-fix-edit-model-and-applicability.md
@@ -1,0 +1,141 @@
+---
+status: proposed
+date: 2026-09-08
+decision-makers: asamarts
+---
+
+# 0017. Auto-fix edit model and applicability tiers
+
+## Status
+
+Proposed. Companion design doc:
+[`docs/design/auto-fix.md`](../design/auto-fix.md), which carries the research survey (the
+seven-class fix taxonomy), the per-format structured-write feasibility verdicts, the
+architecture, and the phased build plan. This ADR records the two load-bearing decisions
+that everything in that plan depends on.
+
+## Context
+
+alint's auto-fix surface is narrow and structurally capped. Only 16 of 94 distinct rule
+kinds (about 17%) attach a fixer, and the single largest family, structured query (25 kinds
+across JSON / YAML / TOML / XML / dotenv / properties / INI / HCL), is entirely unfixable.
+Two properties of the current implementation are the cause, not the symptom:
+
+- **The edit model is whole-file only.** `FixEdit` has four variants (`SetContent`,
+  `CreateFile`, `DeleteFile`, `RenameFile`), none of which expresses a located edit at a
+  computed byte range or a permission-bit change. Every existing fixer either writes a whole
+  file from a template, deletes/renames a whole file, or runs a pure byte-to-byte transform
+  over the whole file. A "set the value at this path" or "remove this matched token" fix
+  cannot be expressed.
+- **The apply loop is single-pass and unaware of fix safety.** `Engine::fix` evaluates each
+  rule once and applies its fixer, with no fixpoint, no re-check, no conflict detection
+  between edits, and no way to say a fix exists but is not safe to apply unattended.
+  Convergence rests entirely on each fixer's own idempotency guard.
+
+The state of the art (ESLint, Ruff) converges on a different substrate: a fix is a
+`{range, text}` edit; the engine collects candidates, sorts them, applies the non-overlapping
+ones in one pass while skipping conflicts, and re-lints to a fixpoint. Ruff adds a three-tier
+`Applicability` (Safe / Unsafe / DisplayOnly), safe-by-default, `--unsafe-fixes` opt-in.
+Format-preserving config editing (`toml_edit`, `node-jsonc-parser`) is a span-splice against
+a CST or spanned parser, never a parse-then-dump. alint's own unfixed-rule notes already sort
+into buckets that map cleanly onto a Safe / Unsafe / Suggestion / Never model, so the model
+fits the existing reasoning rather than imposing a new one.
+
+Constraints: determinism of fixes (constitution invariant 1); bounded fixes
+(`fix_size_limit`, invariant 4); the spawn/network trust boundary and path confinement
+(ADR-0004, invariants 5 and 6); telemetry-free at runtime; backward compatibility for the 12
+existing ops.
+
+## Decision
+
+We will make three changes, together, as the foundation of the auto-fix expansion.
+
+**1. A ranged edit primitive and a batched, verifying apply engine.** We will add
+`FixEdit::ReplaceRange { path, range, content }` (a byte-span splice; insert is a zero-width
+range, delete is empty content) and `FixEdit::SetMode { path, mode }` (chmod, unix-gated),
+keeping the existing four variants (`RenameFile` already covers cross-directory moves, so no
+`MoveFile` is added). The edit-producing path is generalized to **rule level** via
+`collect_edits(&[Violation], file, bytes, root) -> Vec<(FixEdit, Applicability)>`, so a rule
+that fans out over N matches (structured-query violations carry no span, and `*_path_absent`
+is one file-level violation over N nodes) can re-query with a located API and emit exactly
+one edit per node; simple fixers keep the per-violation `apply` / `fix_edit` path.
+`Engine::fix` changes from evaluate-then-write to: collect edits (read-only, size-guarded at
+this step), filter by applicability threshold, group per file, sort by a total order
+`(start, end, rule_index, violation_index)` and apply non-overlapping edits while skipping
+conflicts (with Ruff-style isolation groups), verify a re-parse postcondition (reject and
+demote to Suggestion, memoized per edit, any edit that would produce an unparseable file), and
+write atomically. The **fixpoint loop lands in Phase 1**, not Phase 0, so the Phase 0 engine is
+a single behavior-preserving pass; the fixpoint carries an index-invalidation rule (a
+path-mutating edit forces a deterministic re-walk) and a loud non-convergence cap. A fix that
+spans files is applied as an all-or-nothing multi-file transaction. Idempotence is a tested
+contract per fixer. Format-preserving structured edits are span-splices against a per-format
+CST or spanned parser, never a parse-then-dump, with a per-format value serializer for quoting,
+type fidelity, and separator surgery.
+
+**2. A four-state applicability model, defined by application policy.** Every fixer declares
+one of: **Safe** (applied by default), **Unsafe** (applied only with `--unsafe-fixes`),
+**Suggestion** (never written; surfaced as a concrete `proposed_edit` payload in the
+`agent` / `json` / LSP output), and **Never** (no fix proposed). The tier is the policy; the
+properties (idempotent, output re-parses, discards no human content, target unambiguous) are
+the inputs an author uses to pick it. Safe `set_value` is restricted to a scalar replacing an
+existing scalar; object/array values, key insertion, and nested creation are Suggestions.
+`alint fix` applies only Safe fixes by default. The report gains a `Suggested(edit)` outcome and
+the agent format gains an `applicability` field, reconciling `has_unfixable_errors` so a
+Suggested outcome is not an unresolved error. The 12 existing ops are classified Safe on
+introduction so current behavior is unchanged.
+
+**3. A fixer trust boundary distinct from the kind-level spawn gate.** A fixer is a new trust
+surface, and the existing `SPAWNING_RULE_KINDS` allowlist gates the rule **kind**, not a
+**fixer** attached to a non-spawning kind. We will add a fix-level gate: content-mutating fix
+ops (`replace`, `set_value`, `remove_value`, `insert_header`, `sync_from`) and spawning fix ops
+(`git_untrack`, a `command`-backed fix, regenerate-from-command) are honored only from the
+user's own top-level config, never from an `extends:`-ed ruleset; applicability promotion is
+top-level-only (an inherited fixer may be demoted but never promoted), and an inherited
+content-mutating fixer defaults to Suggestion.
+
+## Consequences
+
+Easier: the structured-query family and located content replacement become fixable through a
+shared substrate rather than per-rule special cases; the LSP gets minimal-diff `TextEdit`s
+instead of whole-document replacements; conflicting fixers compose safely; agents get
+first-class "proposed but not auto-applied" edits via a new `Suggested` outcome and a
+`proposed_edit` payload alongside the existing `fix_command`; every fixer carries a
+machine-readable safety declaration.
+
+Harder: `Engine::fix` grows a real scheduler (rule-level collect, total-order sort,
+overlap-skip, isolation, postcondition, and from Phase 1 a fixpoint with index invalidation)
+instead of a loop, which is more code to keep deterministic and more to test; each structured
+format needs its own span resolver and value serializer because the lossy `serde_json::Value`
+pipeline cannot be reused for write-back; multi-file fixes need all-or-nothing transactions;
+`fix` must become baseline-aware so it does not rewrite grandfathered findings; and a new
+fix-level trust gate must be built and maintained because reusing the kind-level spawn gate
+would leave a fixer-on-a-non-spawning-kind hole. Reclassifying an existing op (treating
+`file_remove` as Unsafe) is a safety-default and semver decision rather than a free change.
+
+## Considered Options
+
+- **Keep whole-file `SetContent` only, compute spliced bytes inside each fixer.** Rejected as
+  the primary model: it hides the edit range from the engine, so conflict detection and
+  minimal LSP diffs are impossible, though a phase may still emit `SetContent` where a ranged
+  edit adds no value.
+- **Two-tier autofix/suggestion (ESLint style) instead of four states.** Rejected: it cannot
+  distinguish "apply with opt-in" from "never apply", which is exactly the Unsafe vs
+  Suggestion line alint's own rule notes already draw.
+- **Parse-then-reserialize for structured fixes.** Rejected: it destroys comments, key order,
+  and whitespace on every edited config, which is the precise failure that made Repolinter's
+  remediation unusable.
+- **Keep the per-violation fixer shape for structured edits.** Rejected: a structured-query
+  violation carries no span and `*_path_absent` is one file-level violation over N nodes, so a
+  per-violation call cannot tell which node it fixes; the rule-level `collect_edits` binding is
+  required.
+- **Reuse the kind-level `SPAWNING_RULE_KINDS` gate for spawning fixers.** Rejected: it gates
+  the rule kind, so a spawning fixer attached to a non-spawning kind (a `git_untrack` fix on
+  `file_absent`) would pass untouched; a distinct fix-level gate is required.
+
+## More Information
+
+Design doc: [`docs/design/auto-fix.md`](../design/auto-fix.md). Trust boundary:
+[ADR-0004](0004-extends-trust-boundary-and-path-confinement.md). Dispatch and determinism:
+[ADR-0003](0003-rule-engine-dispatch-and-determinism.md). Prior art with primary sources is
+collected in the design doc's references section (ESLint, Ruff, `toml_edit`,
+`node-jsonc-parser`, and the archived Repolinter).

--- a/docs/adr/0017-auto-fix-edit-model-and-applicability.md
+++ b/docs/adr/0017-auto-fix-edit-model-and-applicability.md
@@ -11,7 +11,7 @@ decision-makers: asamarts
 Proposed. Companion design doc:
 [`docs/design/auto-fix.md`](../design/auto-fix.md), which carries the research survey (the
 seven-class fix taxonomy), the per-format structured-write feasibility verdicts, the
-architecture, and the phased build plan. This ADR records the two load-bearing decisions
+architecture, and the phased build plan. This ADR records the three load-bearing decisions
 that everything in that plan depends on.
 
 ## Context
@@ -67,12 +67,12 @@ demote to Suggestion, memoized per edit, any edit that would produce an unparsea
 write atomically. Whole-file transforms (the existing ops) are **not** modeled as `0..len`
 ranges; they compose functionally in config order, so **Phase 0, which ships only whole-file
 ops, reproduces today's behavior exactly**, and the located-edit batch, overlap-skip, and
-fixpoint arrive in Phase 1. The engine is a **non-confluent rewriting system** driven by a
+fixpoint are built in Phase 0 but first exercised in Phase 1. The engine is a **non-confluent rewriting system** driven by a
 total-order strategy, which buys reproducibility, not canonicity, and whose soundness rests on
 the fact that disjoint edits commute. The fixpoint carries an index-invalidation rule (a
 path-mutating edit forces a deterministic re-walk) and a loud non-convergence cap. A fix that
-spans files is an all-or-nothing multi-file transaction whose postconditions are checked over
-the staged set. Format-preserving structured edits are span-splices against a per-format CST or
+spans files is a multi-file transaction, all-or-nothing through the verify phase (postconditions
+checked over the staged set) but best-effort through the per-file writes (no cross-file journal). Format-preserving structured edits are span-splices against a per-format CST or
 spanned parser, never a parse-then-dump, with a per-format value serializer for quoting, type
 fidelity, and separator surgery.
 
@@ -162,6 +162,19 @@ splice or overlap invariant, and debug_assert runtime contracts.
 - **Reuse the kind-level `SPAWNING_RULE_KINDS` gate for spawning fixers.** Rejected: it gates
   the rule kind, so a spawning fixer attached to a non-spawning kind (a `git_untrack` fix on
   `file_absent`) would pass untouched; a distinct fix-level gate is required.
+- **A leaner v1 that defers the located-edit engine (the `ReplaceRange` primitive, the batch,
+  overlap-skip, and the fixpoint) until the regex `replace` family needs cross-rule same-file
+  conflict resolution, shipping the structured-value flagship as one whole-file `SetContent` per
+  file from a rule-level `collect_edits` plus the span bridge.** The technical premise is sound: a
+  single `collect_edits` can splice all N nodes internally and emit one `SetContent`, which the
+  current engine applies with nothing to conflict against, so the flagship does not strictly require
+  the ranged primitive. Rejected as the plan of record anyway, because it trades one fix-path
+  migration for two (a `SetContent`-only bridge now, then the located-edit engine later when
+  `replace` lands, which is already on the roadmap) and leaves the re-parse postcondition, the tier
+  filter, and the determinism / total-order contract without a single engine-level home in the
+  interim. The located-edit machinery is dormant in Phase 0 (whole-file ops reproduce today exactly,
+  Decision 1), so building it up front is implementation cost but no behavior risk. Design doc
+  section 5.1 records the same trade-off at the primitive level.
 
 ## More Information
 

--- a/docs/adr/0017-auto-fix-edit-model-and-applicability.md
+++ b/docs/adr/0017-auto-fix-edit-model-and-applicability.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-09-08
 decision-makers: asamarts
 ---
@@ -8,7 +8,7 @@ decision-makers: asamarts
 
 ## Status
 
-Proposed. Companion design doc:
+Accepted (ratified 2026-09-09). Companion design doc:
 [`docs/design/auto-fix.md`](../design/auto-fix.md), which carries the research survey (the
 seven-class fix taxonomy), the per-format structured-write feasibility verdicts, the
 architecture, and the phased build plan. This ADR records the three load-bearing decisions

--- a/docs/adr/0017-auto-fix-edit-model-and-applicability.md
+++ b/docs/adr/0017-auto-fix-edit-model-and-applicability.md
@@ -106,8 +106,12 @@ first-party bundled rulesets, but **demoted to Suggestion** from a remote-URL `e
 top-level `trusted_extends:` allowlist to opt specific remote sources back in. **Spawning fixers**
 (`git_untrack`, a `command`-backed fix, regenerate-from-command) are **refused at load** from any
 non-top-level source. Applicability promotion is top-level-only (an inherited fixer may be demoted
-but never promoted). The gate reuses the loader's existing top-level-versus-`extends:` provenance
-plumbing (the same mechanism that forces `allow_out_of_root` off for inherited rules).
+but never promoted). This provenance does **not** exist in the loader today (rules are merged into
+one id-keyed list with no source tag; `allow_out_of_root` is a top-level policy matched by
+id/kind, and inherited-rule safety is done by rejecting-and-dropping at load, not by tagging
+origin): the spawning-fixer *refusal* fits that existing reject-at-load pattern, but the
+content-fixer *demotion* and `trusted_extends:` require new per-source provenance threaded through
+`merge()` onto `RuleSpec` / `RuleEntry` to fix time. It is new, security-load-bearing plumbing.
 
 ## Consequences
 
@@ -118,15 +122,19 @@ first-class "proposed but not auto-applied" edits via a new `Suggested` outcome 
 `proposed_edit` payload alongside the existing `fix_command`; every fixer carries a
 machine-readable safety declaration.
 
-Harder: `Engine::fix` grows a real scheduler (rule-level collect, total-order sort,
-overlap-skip, isolation, postcondition, and from Phase 1 a fixpoint with index invalidation)
-instead of a loop, which is more code to keep deterministic and more to test; each structured
+Harder: `Engine::fix` grows a real scheduler (rule-level collect, total-order sort, overlap-skip,
+isolation, postcondition, and from Phase 1 a fixpoint whose path-mutating passes re-walk, amending
+ARCHITECTURE's "walk once per invocation" invariant for `fix`) instead of a loop; each structured
 format needs its own span resolver and value serializer because the lossy `serde_json::Value`
-pipeline cannot be reused for write-back; multi-file fixes need all-or-nothing transactions;
-`fix` must become baseline-aware so it does not rewrite grandfathered findings; and a new
-fix-level trust gate must be built and maintained because reusing the kind-level spawn gate
-would leave a fixer-on-a-non-spawning-kind hole. Reclassifying an existing op (treating
-`file_remove` as Unsafe) is a safety-default and semver decision rather than a free change.
+pipeline cannot be reused for write-back; multi-file fixes are all-or-nothing through the verify
+phase but only best-effort through the per-file write phase (no cross-file journal); `fix` becomes
+baseline-aware; new per-source provenance plumbing must be threaded through the loader for the
+content-fixer trust gate (it does not exist today); carrying fixes in `check --format sarif` /
+`agent` adds edit computation to `check` when those formats are selected; and each new op or status
+must update the gated downstream artifacts (`schemas/*.json`, `facts.json auto_fix_ops`, README
+counts, `docs/rules.md`, ARCHITECTURE.md) plus land a gated `fix` perf-bench. Reclassifying
+`file_remove` as Unsafe is a safety-default and (pre-1.0) versioning decision, sequenced as a
+warned v0.17 change that flips about two minors later, not a free change.
 
 The engine's guarantees are bounded and stated as such: reproducibility, not order-independence;
 a Safe-tier fixpoint that terminates by the multiset contract (the cap only guards Unsafe and
@@ -159,7 +167,9 @@ splice or overlap invariant, and debug_assert runtime contracts.
 
 Design doc: [`docs/design/auto-fix.md`](../design/auto-fix.md). Trust boundary:
 [ADR-0004](0004-extends-trust-boundary-and-path-confinement.md). Dispatch and determinism:
-[ADR-0003](0003-rule-engine-dispatch-and-determinism.md). The formal model (rewriting-system
+[ADR-0003](0003-rule-engine-dispatch-and-determinism.md). Baseline suppression, which
+[ADR-0006](0006-baseline-suppression.md) scopes to `check`, is extended to `fix` by this proposal
+(5.7). The formal model (rewriting-system
 determinism, the Safe-tier termination contract, the lens laws, and the verification plan) is
 section 5.8 of the design doc; the completeness-theory framing for the detection surface is the
 companion [`rule-coverage-gaps.md`](../design/rule-coverage-gaps.md). Prior art with primary

--- a/docs/design/auto-fix.md
+++ b/docs/design/auto-fix.md
@@ -1,7 +1,7 @@
 # Auto-fix: a systematic framework for mechanical remediation
 
-Status: Draft (revised five times after independent adversarial audits; see the changelog note at the end).
-Decisions: [ADR-0017](../adr/0017-auto-fix-edit-model-and-applicability.md) (proposed) records the load-bearing decisions (the batched range-edit apply engine, the applicability model, and the fixer trust boundary).
+Status: Accepted (ratified 2026-09-09; revised five times after independent adversarial audits, see the changelog note at the end). Execution plan to follow as a companion design doc.
+Decisions: [ADR-0017](../adr/0017-auto-fix-edit-model-and-applicability.md) (accepted) records the load-bearing decisions (the batched range-edit apply engine, the applicability model, and the fixer trust boundary).
 Demand evidence: the structured-query family (25 kinds, the largest family) is 100% unfixable today; see the `format-coverage.md` arc and the 30-repo `examples/` corpus.
 
 > This is an arc document (the scale of `distribution.md` / `format-coverage.md`, not a
@@ -630,8 +630,9 @@ could ship a fix that silently injects bytes into the user's files or shells out
 **This gate is new plumbing, not a reuse of an existing mechanism (correcting an earlier draft).**
 Today the loader `merge()`s every source's rules into one id-keyed list with **no source tag**,
 and `RuleSpec` / `RuleEntry` carry no origin field; `allow_out_of_root` is a top-level policy
-matched by id/kind, and inherited-rule safety is enforced by **rejecting dangerous keys at load
-and dropping the rule** (`reject_command_rules_in`, `reject_custom_facts_in` in `loader.rs`), so no
+matched by id/kind, and inherited-rule safety is enforced by **rejecting dangerous keys at load**
+(`reject_command_rules_in`, `reject_custom_facts_in` in `loader.rs` abort the whole load with an
+error that names the offending source, rather than dropping one rule and continuing), so no
 provenance needs to survive the merge. Two consequences: (1) the spawning-fixer **refusal** fits
 that existing reject-at-load pattern directly, scanning each `extends:`-ed rule's `fix:` block; but
 (2) the content-fixer **demotion** *keeps* the rule, so its four-way source (top-level /
@@ -704,10 +705,13 @@ security-load-bearing work to build, not a mechanism to inherit.
   `fix --dry-run` doubles as the CI gate (write nothing, fail if fixes are pending), so no
   separate `fix --check` is added.
 - **Downstream artifacts (per phase).** alint gates its own generated/derived surfaces, so each
-  phase that adds an op or a status also updates, in the same PR: `schemas/v1/config.json` (the
-  `FixSpec` op enum) and `schemas/v1/fix-report.json` (the new `suggested` status) via
-  `gen-schema` (constitution invariants 7 and 11); the `facts.json` `auto_fix_ops` count, which is
-  code-derived and gated by `readme_auto_fix_ops_count_matches_fixers` (invariants 9 and 11);
+  phase that adds an op or a status also updates, in the same PR: the hand-written `$defs/fix`
+  branch in `schemas/v1/config.json` (`FixSpec` has no schemars derive, so `gen-schema` only
+  re-syncs the byte-identical in-crate copy `crates/alint-dsl/schemas/v1/config.json`); the
+  hand-written `schemas/v1/fix-report.json` for the new `suggested` status, guarded by the
+  `crates/alint-output` round-trip test rather than `gen-schema` (constitution invariants 7 and 11);
+  the `facts.json` `auto_fix_ops` count, which is code-derived (it counts `*Fixer` structs) and gated
+  by `readme_auto_fix_ops_count_matches_fixers` (invariants 9 and 11);
   `README.md`'s headline counts; the per-op reference in `docs/rules.md`; and `ARCHITECTURE.md`'s
   fix-operations table and execution step 9 (which the batched engine supersedes, and which is
   already stale: it omits `file_footer`). `ROADMAP.md` / `roadmap.json` are wired when the arc is
@@ -993,7 +997,7 @@ non-spawning kind); the coverage audits (invariants 7 and 8; every newly-fixable
 schema entry and gains firing + silent scenarios, plus an idempotence test); and design-doc-first
 plus ADR (invariants 12 and 13).
 
-**ADR-0017** (proposed) records: (1) the ranged edit primitive plus the batched,
+**ADR-0017** (accepted) records: (1) the ranged edit primitive plus the batched,
 conflict-resolving, postcondition-verifying apply engine (whole-file ops composed in config
 order in Phase 0; the located-edit batch and the fixpoint built in Phase 0 but first exercised in
 Phase 1); (2) the four-state

--- a/docs/design/auto-fix.md
+++ b/docs/design/auto-fix.md
@@ -1,0 +1,753 @@
+# Auto-fix: a systematic framework for mechanical remediation
+
+Status: Draft (revised after an adversarial audit; see the changelog note at the end).
+Decisions: [ADR-0017](../adr/0017-auto-fix-edit-model-and-applicability.md) (proposed) records the load-bearing decisions (the batched range-edit apply engine, the applicability model, and the fixer trust boundary).
+Demand evidence: the structured-query family (25 kinds, the largest family) is 100% unfixable today; see the `format-coverage.md` arc and the 30-repo `examples/` corpus.
+
+> This is an arc document (the scale of `distribution.md` / `format-coverage.md`, not a
+> single rule-kind design). It is deliberately split into **Part I: research and analysis**
+> (the universe of auto-fixable classes, the state of the art, and where alint sits) and
+> **Part II: proposal and plan** (the architecture and a phased build). Each numbered phase
+> in Part II carries its own surface, semantics, false-positive analysis, and test plan in
+> the spirit of `TEMPLATE.md`; a phase graduates to its own `docs/design/vX.Y/` doc when it
+> is scheduled. Companion detection-gap analysis: [`rule-coverage-gaps.md`](rule-coverage-gaps.md).
+
+## Contents
+
+- [Thesis](#thesis)
+- [Part I: research and analysis](#part-i-research-and-analysis)
+  - [1. Where alint is today](#1-where-alint-is-today)
+  - [2. The universe of auto-fixable classes](#2-the-universe-of-auto-fixable-classes)
+  - [3. The applicability model](#3-the-applicability-model)
+  - [4. Prevalence and usefulness](#4-prevalence-and-usefulness)
+- [Part II: proposal and plan](#part-ii-proposal-and-plan)
+  - [5. Architecture](#5-architecture)
+  - [6. The phased plan](#6-the-phased-plan)
+  - [7. False-positive and safety surface](#7-false-positive-and-safety-surface)
+  - [8. Invariants and the decision record](#8-invariants-and-the-decision-record)
+  - [9. Open questions](#9-open-questions)
+- [References and prior art](#references-and-prior-art)
+
+## Thesis
+
+Auto-fix should not be a grab-bag of per-rule special cases. Every mechanical fix is one
+instance of a small, closed set of **edit primitives**, chosen by a **fix class** that maps
+a violation shape to a known methodology, and gated by an **applicability tier** that says
+whether it is safe to apply without a human. Get the primitives, the apply engine, and the
+tiers right once, and each new fixer becomes a thin, provably-safe adapter rather than a
+bespoke read-modify-write.
+
+alint has the opposite today. It has four whole-file primitives, a single-pass sequential
+apply loop with no conflict handling and no re-check, and no notion of fix safety. The
+result: **16 of 94 distinct rule kinds are fixable (about 17%)**, the single largest rule
+family (structured query, 25 kinds) is entirely unfixable, and the fixers that do exist
+cannot express a located edit. This document defines the whole universe, shows that the
+gap is structural rather than incidental, and proposes an engine plus a phased build that
+closes it.
+
+The framing is three orthogonal axes. They do not line up row-by-row; any primitive can
+serve several classes, and any class can land in several tiers. They are listed separately
+on purpose:
+
+- **Edit primitives (how bytes change).** Today: `CreateFile`, `DeleteFile`, `RenameFile`
+  (which already covers cross-directory moves), `SetContent` (whole-file). Proposed
+  additions: `ReplaceRange` (a surgical byte-span splice) and `SetMode` (chmod).
+- **Fix classes (violation shape to methodology).** Existence and presence-normalize;
+  whole-file byte-normalize; located replace; format-preserving structured edit; ordering
+  and canonicalization; metadata and permission; cross-file consistency and propagation.
+- **Applicability tiers (is it safe to apply unattended).** Safe (applied by default),
+  Unsafe (opt-in via `--unsafe-fixes`), Suggestion (surfaced, never auto-applied), Never
+  (advisory or a tripwire; no fix proposed).
+
+One batched apply engine runs over the primitives; every class is an adapter that emits
+primitives with a declared tier. The engine, not the individual fixer, owns conflict
+resolution, determinism, postcondition verification, and (from Phase 1) fixpoint iteration.
+
+---
+
+# Part I: research and analysis
+
+## 1. Where alint is today
+
+### 1.1 The numbers
+
+As of v0.16.1 (`facts.json`): 105 rule kinds (94 distinct + 11 aliases), 13 families,
+22 bundled rulesets, **12 fix ops**, 8 output formats. Only **16 distinct kinds (19 counting
+aliases) attach a fixer**. Each fixable builder accepts exactly one op and rejects any other
+at load (`fix.<op> is not compatible with <kind>`).
+
+The 16 fixable kinds: `file_exists`, `file_absent`, `file_content_matches`, `file_header`,
+`file_footer`, `filename_case`, `no_trailing_whitespace`, `final_newline`, `line_endings`,
+`max_consecutive_blank_lines`, `no_bidi_controls`, `no_zero_width_chars`, `no_bom`,
+`no_empty_files`, `no_submodules`, `no_symlinks`.
+
+### 1.2 The current fix model (code map)
+
+Fixes are **rule-attached, not violation-attached**. `Rule::fixer()`
+(`crates/alint-core/src/rule.rs:390`); one `Fixer` per rule, applied to each violation the
+rule emits. The `Fixer` trait (`rule.rs:553-579`) has three methods: `describe`; `apply`
+(mutates the filesystem via `write_atomic`, `crates/alint-rules/src/io.rs:104`); and
+`fix_edit` (the non-writing sibling, currently returning `Option<FixEdit>` per violation,
+that the LSP turns into a `WorkspaceEdit`).
+
+`FixEdit` (`rule.rs:541-550`) is the entire data model of an edit, and it is **whole-file
+only**:
+
+```rust
+pub enum FixEdit {
+    SetContent { path: PathBuf, content: Vec<u8> },  // replace full contents
+    CreateFile { path: PathBuf, content: Vec<u8> },
+    DeleteFile { path: PathBuf },
+    RenameFile { from: PathBuf, to: PathBuf },        // same directory or not
+}
+```
+
+There is no ranged/span variant, no permission-bit variant, and no structured-document
+variant. `FixOutcome` is `Applied | Skipped`; the report tier adds `FixStatus::Unfixable`.
+There is **no field anywhere that expresses fix safety.** The 12 ops split into path-only
+(`file_create`, `file_remove`, `file_rename`) and content-editing (9 ops: `file_prepend`,
+`file_append`, plus the 7 pure normalizers `file_trim_trailing_whitespace`,
+`file_append_final_newline`, `file_normalize_line_endings`, `file_collapse_blank_lines`,
+`file_strip_bidi`, `file_strip_zero_width`, `file_strip_bom`). Every one either creates a
+whole file from a template, deletes/renames a whole file, or runs a **pure byte-to-byte
+transform over the whole file**. None performs a located edit at a computed position.
+
+### 1.3 The apply engine
+
+`Engine::fix` (`crates/alint-core/src/engine.rs:909-1067`) is a **single pass**: iterate the
+rule entries in config order, freshly evaluate each rule, and for every violation call
+`fixer.apply`. It is sequential, not batched (each `apply` re-reads the file from disk via
+`read_for_fix`, so two fixers on one file compose through disk round-trips); there is **no
+fixpoint and no re-check** (convergence rests only on each fixer's own idempotency guard);
+and there is **no conflict detection** (the whole-file model sidesteps it by never producing
+two edits to one region). `alint fix` also **rejects `--baseline`** (`main.rs:179-186`), so
+it acts on the unsuppressed violation set. The safety guards that already exist: `dry_run`,
+`fix_size_limit` (enforced inside the writing `apply` path via `read_for_fix`, not the
+non-writing `fix_edit` path, which is deliberately un-guarded), out-of-root path
+confinement, a binary-content guard, atomic temp-then-rename writes, and skip-on-collision
+for rename.
+
+### 1.4 The gap is structural, and the maintainer already reasons about it
+
+The catalog of unfixed kinds is not random. Reading the "why no fixer" notes across
+`docs/rules.md`, the unfixed kinds already sort into five buckets that map one-to-one onto
+the applicability model formalized later:
+
+1. **Deferred / not-yet-built, low ambiguity:** `executable_bit`,
+   `shebang_has_executable`, `executable_has_shebang` ("chmod auto-apply is deferred"),
+   `ordered_block` (sort the marked lines), `indent_style` ("tab-width-aware reindentation
+   is deferred"), `dir_exists` / `dir_absent` (no directory-level op exists).
+2. **Deliberately check-only because a fix is destructive:** `file_content_forbidden`,
+   `commented_out_code`, `git_no_denied_paths` ("git rm --cached is too destructive to
+   automate"), `git_blame_age`, `no_merge_conflict_markers` (a fix cannot know which side to
+   keep).
+3. **Blocked by target ambiguity:** `file_starts_with` / `file_ends_with`,
+   `markdown_paths_resolve`, `filename_regex` (a regex has no invertible canonical name),
+   `no_illegal_windows_names` / `no_case_conflicts`.
+4. **Integrity tripwires by design:** `file_hash`, `pair_hash`, `generated_file_fresh`
+   (auto-updating the pin would defeat the check).
+5. **Not mechanically fixable:** `json_schema_passes`, size / line caps, the git-commit
+   history family, the cross-file relational family.
+
+That is, in miniature, exactly the applicability taxonomy this document formalizes (bucket 1
+becomes Safe/Unsafe once built; bucket 2 becomes Unsafe; bucket 3 becomes Suggestion;
+buckets 4 and 5 stay Never). The framework is a natural fit, not an imposition. What is
+missing is (a) the edit primitive to express located and structured changes, (b) an engine
+that can batch and verify them safely, and (c) a first-class way to say "this fix exists but
+is not safe to apply unattended."
+
+## 2. The universe of auto-fixable classes
+
+Surveying ESLint, Ruff, the formatter family (Prettier / gofmt / rustfmt / Black / dprint),
+the format-preserving structured editors (`toml_edit`, `tomlkit`, `ruamel.yaml`,
+`node-jsonc-parser`), the codemod family (comby, ast-grep, jscodeshift/recast, Semgrep,
+OpenRewrite), the repo/config/dependency fixers closest to alint, and the archived
+Repolinter, **seven mechanism classes** recur. Each is defined by its canonical algorithm,
+its key safety concern, and its exemplars.
+
+| # | Class | Canonical algorithm | Key safety concern | alint status | Where it lands |
+|---|---|---|---|---|---|
+| 1 | Whole-file canonical reprint | parse -> tree -> pretty-print through a Wadler-style layout algebra, discarding original layout | a parser/printer bug silently changes meaning (Black re-parses and diffs the AST to guard) | out of scope for the core (alint is not a formatter); reachable only via `command` | not proposed |
+| 2 | Surgical span replacement | rule yields `{range, text}`; collect, sort by position, apply non-overlapping in one pass, skip conflicts, re-lint to a fixpoint | overlap resolution; minimal ranges; per-edit safe/unsafe tier | **absent** (no ranged primitive) | Phase 0 (engine) + Phase 1 |
+| 3 | Format-preserving structured-data edit | parse into a lossless CST that keeps trivia and mutate one node; OR splice a minimal `{offset,length,content}` into the original bytes | naive parse->dump destroys comments/order; value serialization (quoting, type, entity-encoding) | **absent** (all 8 formats parse to a lossy detached tree) | Phase 2 (flagship) |
+| 4 | Structural match-and-rewrite (codemod) | match a pattern with metavariable holes -> bind -> substitute into a rewrite template -> replace the matched span | over-matching; formatting survival | partial: `file_content_matches` can only append | Phase 1 (regex capture form) |
+| 5 | Whitespace / trivia normalizers | per-line or per-file byte transform, idempotent by construction | mostly safe; EOL/BOM significant for some files; needs exclusions | **strong**: 7 of the 12 ops are pure normalizers | shipped; retrofit onto the new engine in Phase 0 |
+| 6 | Content insertion / templating | presence-guard, then render from a template and insert at the correct anchor, in the file's comment syntax | never double-insert; correct comment style and placement | partial: `file_prepend` / `file_append` (fixed content, no anchor logic) | Phase 4 (license/SPDX headers) |
+| 7 | Reference / version resolution and pinning | resolve a ref against an external source of truth (registry, git ref -> commit SHA), rewrite via a format-preserving edit | needs network + trust; semver/supply-chain correctness; human-gated | **absent**; tension with the telemetry-free-at-runtime invariant | deferred / special |
+
+Two structural findings dominate the rest of the document.
+
+**Finding A (class 2 is the missing substrate).** ESLint and Ruff converge on the same
+engine: a fix is a `{range, text}` edit; collect every candidate, sort by position, apply
+the non-overlapping ones in a single left-to-right pass while skipping any edit that overlaps
+one already applied, then re-lint and repeat to a fixpoint (ESLint caps at 10 passes, Ruff
+at 100 and bails loudly on non-convergence). alint has none of this because its whole-file
+model never needs it. Adding a ranged primitive plus this engine is the enabler for classes
+2, 3, and 4 at once.
+
+**Finding B (class 3 is the flagship, and it is a span-splice problem).** Every alint
+structured-query rule parses its file (JSON, YAML, TOML, XML, dotenv, properties, INI, HCL)
+into one detached, lossy `serde_json::Value` (`crates/alint-core/src/structured_format.rs`).
+Comments, whitespace, and even key order are discarded before a rule runs (`preserve_order`
+is not enabled; the backing map is a `BTreeMap` and keys are alphabetized). Re-serializing
+from that tree can never preserve formatting. The only viable technique is a **byte-span
+surgical splice** against a span-capable or CST parser, and the JSONPath engine
+(`serde_json_path`, whose `query()` runs over the detached value) can never itself yield a
+span. So a write-back must **bridge** two representations: JSONPath selects the logical node,
+a CST/spanned parser re-locates that node's byte range, and the fixer splices. This is a
+two-part problem (locate the span, then serialize the replacement value), addressed in 5.3
+and 5.4.
+
+### 2.1 The intent view (violation shape to class)
+
+The mechanism table is how bytes change. Authors think in violation shapes, so the same
+universe indexed by intent (which is how the DSL will expose it):
+
+- **Presence** (a file/dir must exist, must not exist, or is misnamed/mislocated): create /
+  delete / rename / relocate (all via the existing `RenameFile`, which spans directories).
+  alint covers create, delete, case-rename; gaps are arbitrary-target rename, relocate,
+  directory create/remove, and cross-file partner creation.
+- **Byte hygiene** (whitespace, newlines, EOL, BOM, Trojan-Source characters, blank-line
+  runs): class 5. Strong; gaps are `indent_style` and `line_max_width` (reflow, genuinely
+  unsafe).
+- **Located content** (a forbidden token must go; a required token inserted or rewritten):
+  classes 2 and 4. alint can only append; it cannot remove a match or rewrite a captured
+  span. The general-purpose gap.
+- **Structured value** (a value at a path must equal / be absent): class 3. Entirely
+  unfixable today; the largest opportunity.
+- **Ordering / canonicalization** (a marked block must stay sorted; entries deduplicated):
+  `ordered_block` sort is the clean win; `unique_by` dedup and `.gitattributes` /
+  `.gitignore` line insertion are adjacent, currently unbuilt.
+- **Metadata / permission** (exec bit, symlink, submodule, portable name): `SetMode` plus
+  delete/rename. alint deletes symlinks and submodules; chmod and portable-name repair are
+  gaps.
+- **Cross-file consistency** (a value or a whole file must match a canonical source across
+  the tree): see 2.2. Unbuilt, and the highest-value repo-scale class.
+- **VCS tree** (a committed artifact should be untracked; a path gitignored): untrack +
+  gitignore insertion. High value; unbuilt; a spawning fixer (see 5.5).
+- **Reference / version** (an Action tag should be a pinned SHA): class 7. Network-gated,
+  special-cased.
+
+Note that `*_path_matches` is listed as Never in 5.3, but the Phase 1 regex `replace` op
+supplies a replacement template, so a user who provides one could make a `*_path_matches`
+violation fixable; this is a deliberate deferral, not an impossibility.
+
+### 2.2 Repo-scale fix classes the single-file view misses
+
+The seven mechanism classes above are single-file-centric because that is where the
+literature lives (code linters and formatters). A repository linter has four fix classes
+that only exist because the unit is a tree, not a file. They compose the primitives above
+but need engine support the single-file model does not (cross-file atomicity, a canonical
+source, index invalidation):
+
+- **Whole-file sync-from-canonical-source.** "Every crate's `LICENSE` must byte-equal the
+  root `LICENSE`"; "every package's `.editorconfig` must match the canonical one." A byte
+  copy from a reference file, distinct from class 1 (reprint) and class 6 (literal
+  template). This is arguably the single most common mechanical repo fix, and it maps
+  directly onto the existing `cross_file` / `cross_file_value_equals` "equals" relation.
+- **Cross-file value propagation.** A version string that must agree across `package.json`,
+  `Cargo.toml`, a `__version__`, a badge, and a tag: pick the source of truth, propagate to
+  the N others via structured edits. Maps onto `unique_by` / the cross-file family, but the
+  structured-value class (5.3, 5.4) is defined per-file, so propagation is an orchestration
+  on top.
+- **Regenerate-from-command.** `generated_file_fresh` is a Never tripwire when the fix would
+  silence it by editing the pin, but "re-run the declared generator and commit its output"
+  is a legitimate (spawn-gated) fix. Distinct because the corrected bytes come from running
+  a command, not from a transform of the existing bytes.
+- **Cross-file atomic create-and-register.** Create a new crate directory and add it to
+  `workspace.members`; create a package and add it to a `CODEOWNERS` block. The fix is two
+  edits to two files with an inter-edit dependency, and a half-applied create-without-
+  register leaves the tree inconsistent, so it needs the multi-file transaction of 5.2.4.
+
+## 3. The applicability model
+
+The most refined safety model in the ecosystem is Ruff's three-tier `Applicability` (Safe /
+Unsafe / DisplayOnly), safe-by-default, `--unsafe-fixes` opt-in, with per-rule
+promote/demote. ESLint expresses the same split more coarsely as autofix versus suggestion.
+alint should adopt a **four-state model**, and the tiers are defined strictly by
+**application policy** (what the engine does with the fix), not by a bag of properties. The
+properties (preserves the file's meaning, discards no human content, idempotent, output
+re-parses) are the **inputs** a fixer author uses to pick the tier, not the definitions:
+
+- **Safe.** Applied by `alint fix` with no flag. A fixer may declare Safe only when it sets
+  exactly the declared or derived target, discards no human-authored content (comments,
+  code), is idempotent, and (for content/structured edits) its output re-parses. Example:
+  the seven hygiene normalizers; setting a structured value to an exact declared **scalar**
+  via a format-preserving edit that re-parses.
+- **Unsafe.** Applied only with `--unsafe-fixes`. Example: regex search-and-replace,
+  structured key removal, chmod, git untrack, tab/space conversion, deleting a whole file.
+- **Suggestion.** Never written by `alint fix`. Surfaced as a concrete proposed edit
+  (path + range + content) in the `agent` / `json` / LSP output for a human or agent to
+  apply. Example: line reflow, merge-conflict resolution, illegal-windows-name rename,
+  structural (non-scalar, key-insertion, nested-creation) structured edits.
+- **Never.** No fix proposed at all. Advisory or a tripwire. Example: `file_hash`,
+  `generated_file_fresh` (unless the regenerate-from-command fix of 2.2 is explicitly
+  configured), size/line caps, git history, most cross-file relations, `json_schema_passes`,
+  duplicate-code.
+
+Because the tiers are a policy, a fix can be property-safe (idempotent, re-parses) yet still
+be a Suggestion because its **target** is ambiguous (which of two files to rename). "Preserves
+meaning," borrowed from Ruff, is a code-behavior notion that does not translate to a value
+edit, where changing the value is the entire point; for alint, the Safe test for a value
+edit is "sets exactly the declared value, output re-parses, recoverable via VCS," not
+"preserves meaning."
+
+This maps one-to-one onto the maintainer's existing five buckets and gives alint three
+properties it lacks: a machine-readable safety declaration on every fixer, a default that
+only applies fixes that cannot surprise, and a first-class home for "proposed but not
+automatic." The data model for Suggestions and their interaction with the existing agent
+output is specified in 5.7.
+
+**Trust:** the applicability tier a fixer runs at is not purely the author's to choose when
+the rule arrives through `extends:`. Promotion toward Safe/Unsafe, and every content-mutating
+or spawning op, is confined to the user's own top-level config (5.5). An inherited fixer may
+be demoted but never promoted.
+
+**Back-compatibility:** the 12 existing ops keep their current behavior and are classified
+Safe on introduction, so `alint fix` is unchanged for existing configs. Whether `file_remove`
+(deleting a whole file by default, with no `--unsafe-fixes`) should be reclassified Unsafe is
+a safety-default question, not merely a semver one; see the open questions.
+
+## 4. Prevalence and usefulness
+
+Ranking the classes by expected value combines three signals: how much of the rule surface
+the class unlocks, how often the underlying violation occurs in real repos (the 30-repo
+`examples/` corpus and the README "where alint shines" evidence), and how much the ecosystem
+invests in that class.
+
+1. **Structured value edit (class 3): highest.** Unlocks the largest family (25 kinds across
+   8 formats) and targets the exact pain the README leads with: manifests and workflows whose
+   structural invariants no per-language tool checks (dotnet's ~2,300 XML manifests, uv's
+   67-crate workspace conventions, GitHub Actions permissions). No mainstream repo linter
+   does format-preserving config repair well; the biggest differentiator available.
+2. **Located content replace (class 2/4): high and general.** One primitive makes
+   `file_content_forbidden` fixable (remove a banned token: `console.log`, a debug pragma,
+   an AI-affirmation phrase) and adds a general regex-capture rewrite. It is also the
+   substrate the whole engine is built on.
+3. **Cross-file consistency (2.2): high for monorepos.** Sync-from-canonical and version
+   propagation are headline monorepo use cases and are what the `examples/` corpus repeatedly
+   wants (uv, pnpm, tokio conventions enforced nowhere).
+4. **Byte hygiene (class 5): the workhorse, keep it.** The fixes people run daily. The work
+   is retrofitting onto the new engine with zero behavior change and closing `indent_style`.
+5. **Content insertion / license headers (class 6): high for compliance repos.** The
+   `compliance/reuse` and `compliance/apache-2` rulesets demand a per-file SPDX or license
+   header; a comment-style-aware inserter turns a wall of violations into one `alint fix`.
+6. **VCS untrack + gitignore: high for the hygiene story.** A tracked `target/`,
+   `node_modules/`, or `.DS_Store` is one of the most common real findings (it is literally
+   the README demo). Spawn-gated (5.5).
+7. **Ordering / canonicalization: medium.** `ordered_block` sort and `unique_by` dedup are
+   clean, deterministic wins.
+8. **Metadata permission (chmod): medium.** `shebang_has_executable` (add +x) is unambiguous
+   and Safe; the others are narrower.
+9. **Reference/version pinning (class 7): high visibility, special-cased.** SHA-pinning a
+   GitHub Action is a marquee security fix, but it requires resolving a tag over the network,
+   colliding with alint's telemetry-free-at-runtime guarantee. Routed to an explicit opt-in
+   or a future WASM plugin.
+
+---
+
+# Part II: proposal and plan
+
+## 5. Architecture
+
+The engine changes below underpin every new fixer. They are the content of ADR-0017.
+
+### 5.1 Edit primitives
+
+Extend `FixEdit` with the two primitives the current model cannot express, keeping the
+existing four (`RenameFile` already covers cross-directory relocation, so no `MoveFile`
+variant is added):
+
+```rust
+pub enum FixEdit {
+    // existing, unchanged
+    SetContent { path, content },
+    CreateFile { path, content },
+    DeleteFile { path },
+    RenameFile { from, to },                                        // same directory or not
+    // new
+    ReplaceRange { path, range: Range<usize>, content: Vec<u8> },   // splice; insert = empty range, delete = empty content
+    SetMode { path, mode: u32 },                                    // chmod (unix-gated)
+}
+```
+
+`ReplaceRange` is the ESLint `{range, text}` primitive. Three payoffs: minimal diffs (the LSP
+maps it straight to a `TextEdit` instead of replacing the whole document, which the current
+`SetContent` path does with a full-document range at `crates/alint-lsp/src/lib.rs:779-782`);
+mechanical overlap detection (two edits conflict iff their ranges intersect); and composition
+(many edits to one file merge into one write). A structured splice can also be delivered as a
+`SetContent` whose bytes differ only in the target span, so `ReplaceRange` is a
+correctness-and-diff-quality optimization, not a hard prerequisite for shipping class 3; for
+overlap and determinism purposes a whole-file `SetContent` is treated as a `ReplaceRange`
+over `0..len`.
+
+### 5.2 The batched apply engine
+
+Replace the single-pass loop with a batched model, keeping the "serial filesystem mutation"
+guarantee. In **Phase 0 the engine runs exactly one pass** (behavior-preserving); the
+**fixpoint loop is introduced in Phase 1**, where the first fixers that can unblock one
+another appear. One pass:
+
+1. **Collect (read-only, not pure).** Each rule's fixer yields its edits as data, tagged with
+   an `Applicability`. This reads and parses files, so it is read-only I/O, not pure; the
+   engine reads each file once and shares the bytes across every fixer targeting that file
+   (the analogue of the file-major `PerFileRule` coalescing, which `alint fix` does not use
+   today). The `fix_size_limit` guard is **re-applied at this collect/read step**, because the
+   `fix_edit` data path it generalizes is currently un-guarded by design (`rule.rs:571-574`);
+   it does not "carry over" for free.
+2. **Tier filter.** Drop edits below the run threshold (Safe by default; Safe+Unsafe with
+   `--unsafe-fixes`; Suggestions never enter the apply set, only the report set of 5.7).
+3. **Group by file, sort, skip overlaps.** Per file, sort by the total order of 5.2.2, walk
+   left-to-right tracking the last applied end, skip any edit overlapping one already taken
+   (deferred to the next fixpoint pass, once Phase 1 adds it). Adopt Ruff's isolation-group
+   idea for edits that must not co-apply even when disjoint.
+4. **Apply in memory and verify the postcondition.** For structured and regex edits, re-parse
+   the buffer and confirm it still parses and the target now satisfies the rule. This is the
+   Black-style equivalence check adapted to structured data: an edit that would produce an
+   unparseable file is rejected and **demoted to Suggestion, memoized per (file, edit) for the
+   run** so a stateless rule does not re-derive and re-demote it every pass.
+5. **Write atomically**, once per file, via the existing `write_atomic`.
+6. **Idempotence as a tested contract.** Every fixer gets a property test: apply twice, the
+   second run is a no-op.
+
+The `allow_out_of_root` confinement, binary guard, and dry-run guards carry over.
+
+#### 5.2.1 Binding violations to edits
+
+The current fixer is invoked once per `Violation` and receives only `&Violation` (path,
+message, `baseline_key`). Structured-query violations carry **no byte span** (they never call
+`with_location`), the rule emits **one violation per matched node** for `*_path_equals` but a
+**single file-level violation for N matched nodes** for `*_path_absent`, and `Op::Equals`
+holds an **arbitrary `serde_json::Value`**, not a scalar. A per-violation `fix_edit` therefore
+cannot tell which of N nodes it is fixing. The fix is to generalize the edit-producing path to
+**rule level**: a fixer exposes
+
+```rust
+fn collect_edits(&self, violations: &[Violation], file: &Path, bytes: &[u8], root: &Path)
+    -> Vec<(FixEdit, Applicability)>;
+```
+
+so a fan-out rule computes the full match set once, re-runs its own query with a **located**
+API (RFC 9535 normalized paths via `serde_json_path`'s `query_located`, which yields a
+per-node location) and emits exactly one edit per node: N deletions for one `*_path_absent`
+violation, one edit per failing node for `*_path_equals` (de-duplicated so M violations do not
+produce M identical edit batches). Simple per-file fixers keep the one-liner `apply` /
+`fix_edit` path; only rules that fan out over matches implement `collect_edits`. This is a
+Phase 2 prerequisite, not a Phase 2 detail.
+
+#### 5.2.2 Determinism and total edit order
+
+Constitution invariant 1 requires byte-identical fixes across runs. Sorting "by start then
+end" is not a total order when two edits share both offsets (two rules rewriting one span; two
+whole-file retrofits both spanning `0..len`). The engine sorts by the total key
+`(start, end, rule_index, violation_index)` with a stable sort, where `rule_index` is config
+order and `violation_index` is the rule's deterministic emission order (JSONPath match order).
+Ties therefore resolve by config order, which is already the determinism anchor elsewhere in
+the engine.
+
+#### 5.2.3 The fixpoint and index invalidation (Phase 1)
+
+Applying one fix can unblock a previously-skipped conflicting fix or expose a new violation,
+so from Phase 1 the engine loops collect -> apply -> re-check until a pass produces no edits or
+a cap is hit (match Ruff; bail loudly on non-convergence). Two subtleties the single-pass Phase
+0 avoids:
+
+- **Index invalidation.** `CreateFile` / `DeleteFile` / `RenameFile` change the tree, but the
+  `FileIndex` is built once. A pass that applied a path-mutating edit forces a **full
+  deterministic re-walk** before the next pass (so cross-file and `requires_full_index()` rules
+  see the new tree); a pass with only content edits re-checks just the touched files. A created
+  file is not a "changed file," so path-mutating fixes and `--changed` interact (5.7).
+- **Termination.** The per-fixer idempotence test catches **self**-oscillation only.
+  **Cross-fixer** oscillation (fixer A reintroduces what fixer B removed) is caught solely by
+  the iteration cap, which is why the cap exists and why non-convergence is a loud error, not a
+  silent stop. 5.7 (isolation groups) and careful tier assignment reduce, but cannot eliminate,
+  cross-fixer cycles.
+
+#### 5.2.4 Multi-file transactions
+
+A single logical fix can span files (create-and-register, sync-from-canonical to N targets,
+version propagation). "Write once per file" gives no cross-file atomicity, so a fix that emits
+edits to multiple files is applied **all-or-nothing**: stage every file's new bytes in memory,
+verify every postcondition, and only then write them (each file still atomically). A failure on
+any file aborts the whole group and writes nothing, so a half-applied create-without-register
+cannot occur.
+
+### 5.3 The structured bridge: locating the span
+
+Class 3 needs, per format, a resolver from a JSONPath (or its normalized path) to the target
+value's byte range. There is no shared abstraction to reuse, because the current shared
+abstraction (`Format::parse -> serde_json::Value`) is exactly what throws spans away. The
+feasibility verdicts, in build order by cost:
+
+| Format | Verdict | Technique and dependency |
+|---|---|---|
+| HCL | free | parse with `hcl::edit` (already compiled in via `hcl-rs`, re-exported as `hcl::edit`); mutable CST, preserves layout |
+| XML | free | `roxmltree` (already a dep) exposes `Node::range()` / `Attribute::range_value()` (behind its `positions` feature, on by default and not disabled); find the span, splice |
+| dotenv | free | the parser is alint-owned and line-oriented; add per-value byte-offset tracking, splice |
+| INI | free | same as dotenv (alint owns `ini.rs`) |
+| properties | cheap | `java-properties` gives no spans; hand-roll a line/value-span locator (separators, backslash continuations, `\uXXXX`) |
+| TOML | one dep | `toml_edit::DocumentMut` (present today only as a dev dependency via `trycmd`; promote to a real dep of `alint-rules`) |
+| JSON | new dep | no in-tree JSON parser preserves formatting; add `jsonc-parser` (dprint), which records comment/value ranges, then splice |
+| YAML | hard | no mature Rust library round-trips YAML comments; use a span-capable parser (`saphyr-parser`) to splice a single scalar (Unsafe until the re-parse postcondition passes); structural edits stay Suggestion |
+
+Op-to-fixability, orthogonal to format: `*_path_equals` is fixable (set the node); `*_path_absent`
+is fixable as a removal; `*_path_matches` and `json_schema_passes` are Never by default (no unique
+target), though the Phase 1 `replace` template can make a `*_path_matches` fixable when the user
+supplies one.
+
+### 5.4 The structured bridge: serializing the value
+
+Locating the span is only half the write; the other half is rendering the replacement value as
+format-correct bytes, and it is where the real complexity lives. Each format needs a value
+serializer that handles:
+
+- **Quoting and escaping:** TOML bare vs quoted keys and strings; dotenv values with spaces;
+  properties `\uXXXX` and separator escapes; XML entity-encoding of `& < >` in text vs
+  attributes; JSON string escaping.
+- **Type fidelity:** `equals: "true"` (a string) vs `equals: true` (a bool) must serialize
+  differently; numbers, nulls, and booleans each have a canonical form per format.
+- **`remove_value` surgery:** deleting a node means deleting its separator too (a trailing comma
+  in JSON, the whole `key = value` line in TOML/dotenv/INI, the element in XML), which is
+  format-specific.
+
+Because `Op::Equals` holds an arbitrary `serde_json::Value`, three cases are explicitly **not**
+Safe and route to Suggestion:
+
+- **Object or array expected value** (deep-equal to a structure): the format-preserving
+  synthesis of a multi-line structure at the right indentation is not a simple splice.
+- **Zero-match `*_path_equals`** (the path is absent but should equal): there is nothing to
+  replace; the fixer must synthesize `key: value` in the correct parent container, which for a
+  missing intermediate (`$.a.b.c` where `.b` is absent) means **nested creation**.
+- **Any edit whose re-parse postcondition the fixer cannot verify.**
+
+Safe `set_value` is therefore restricted to a **scalar** expected value replacing an
+**existing** scalar node, verified by re-parse. Everything else is Unsafe (removals) or
+Suggestion (structures, insertion, nested creation).
+
+### 5.5 Trust boundary for fixers
+
+A fixer is a new trust surface, and the existing `SPAWNING_RULE_KINDS` allowlist does not cover
+it: that gate checks the rule **kind** at load (`crates/alint-dsl/src/lib.rs:513`), so a
+spawning or content-writing **fixer** attached to a non-spawning kind (for example a
+`git_untrack` fix on `file_absent`, or a `replace` fix on `file_content_forbidden`) passes it
+untouched. Without a new gate, an `extends:`-ed ruleset could ship a fix that silently rewrites
+the user's files or shells out on a default `alint fix`, which is the file-writing and RCE
+analogue of the spawning-kind hazard the repo already takes seriously. The rules:
+
+- **Content-mutating fix ops** (`replace`, `set_value`, `remove_value`, `insert_header`, and
+  any future op that rewrites existing bytes) and **spawning fix ops** (`git_untrack`, a
+  `command`-backed fix, regenerate-from-command) are honored **only from the user's own
+  top-level config**, never from an `extends:`-ed ruleset. This needs a new fix-level allowlist
+  distinct from the kind-level `SPAWNING_RULE_KINDS`.
+- **Applicability promotion is top-level-only.** An inherited fixer may be **demoted** (toward
+  Suggestion) but never **promoted** (toward Safe/Unsafe). An inherited content-mutating fixer,
+  if honored at all, defaults to Suggestion.
+- `allow_out_of_root` remains top-level-only, unchanged.
+
+### 5.6 DSL and CLI surface
+
+- **New `fix:` ops.** `replace` (class 2/4, capture substitution); `set_value` and
+  `remove_value` (class 3); `sort` and `dedup` (for `ordered_block` / `unique_by`); `chmod`;
+  `git_untrack` (spawning, top-level-only); `sync_from` (whole-file copy from a canonical
+  source, 2.2); `insert_header` (comment-style-aware). Each declares a default applicability.
+- **Per-rule reclassification.** `fix: { op: ..., applicability: safe | unsafe | suggestion }`
+  (Ruff's `extend-safe-fixes` model), subject to the promotion rule of 5.5.
+- **`command` rule fixability.** The `command` plugin rule may carry a user-supplied fix
+  command; it is a spawning fixer, so top-level-only and gated as in 5.5. Its name is distinct
+  from the agent output's existing `fix_command` field (5.7).
+- **CLI.** `alint fix` keeps applying Safe fixes by default; add `--unsafe-fixes`, `--diff`
+  (print the patch without writing), and `--fix-only`. The `agent` and `json` outputs gain a
+  per-fix `applicability` field and a proposed-edit payload for Suggestions (5.7).
+
+### 5.7 Interaction surfaces
+
+- **Baseline.** `alint fix` rejects `--baseline` today, so it acts on the unsuppressed set;
+  after Phase 2 that would auto-rewrite a structured value a team deliberately grandfathered.
+  The proposal makes `fix` **baseline-aware**: with a baseline, suppressed violations are
+  skipped by the apply set and surfaced only as Suggestions. This is a behavior addition, called
+  out as an open question.
+- **`--changed`.** `Engine::fix` already honors `--changed`. The fixpoint can require writes to
+  files outside the changed set (cross-file consistency, or a file a prior pass created); the
+  proposal confines writes to the changed set plus files a fix in scope created, and treats a
+  required out-of-scope write as a Suggestion rather than silently widening the blast radius.
+- **LSP.** The LSP is not merely a Suggestion sink: a code action is fix application initiated
+  by a human, so Suggestions **should** be offered there (with Unsafe/Safe distinguished in the
+  action title). Multi-edit and multi-file fixes become a multi-document `WorkspaceEdit`. The
+  LSP applies the edit and re-lints the buffer; it does not re-run the whole engine per
+  keystroke, so the re-parse postcondition runs against the open buffer.
+- **Agent output and the Suggestion data model.** The report types carry no tier today
+  (`FixStatus` is `Applied | Skipped | Unfixable`) and the agent format emits `fix_available:
+  bool` plus `fix_command: ["fix","--only",<id>]`. The proposal adds a `Suggested(edit)`
+  outcome (or a tier field on `FixItem`), an `applicability` field on the agent violation, a
+  `proposed_edit: {path, range, content}[]` payload for Suggestions, and gates `fix_command` to
+  Safe/Unsafe (appending `--unsafe-fixes` for Unsafe). `has_unfixable_errors` is reconciled so a
+  Suggested outcome is not counted as an unresolved error.
+
+## 6. The phased plan
+
+Each phase is independently shippable and ordered by value multiplied by feasibility. A phase
+graduates into its own `docs/design/vX.Y/<name>.md` with the full seven-section treatment when
+scheduled.
+
+### Phase 0: the fix-engine foundation (no new user-facing fixers)
+
+The substrate. Add `ReplaceRange` and `SetMode` to `FixEdit`; add `Applicability` to the fixer
+contract (default Safe); add the rule-level `collect_edits` path alongside the existing
+`apply` / `fix_edit`; replace the apply loop with **single-pass** collect / tier-filter / sort
+(total order) / skip-overlap / verify / write; add `--unsafe-fixes`, `--diff`, `--fix-only`;
+relocate the `fix_size_limit` guard onto the collect step. The **fixpoint is deliberately not in
+Phase 0**, so the pass is a genuine no-op for existing configs. Retrofit all 12 existing ops onto
+the engine with **zero behavior change for single-pass-convergent configs**, proven by
+byte-identical fix-report snapshots including the adversarial same-file pairs (`file_header`
+prepend plus `no_trailing_whitespace` trim; `final_newline` plus `max_consecutive_blank_lines`,
+both touching EOF). Tier machinery ships but is not exercised end-to-end until Phase 1, so the
+Phase 0 test plan does not over-claim tier coverage. Risk: low.
+
+### Phase 1: located content replacement + the fixpoint (classes 2 and 4)
+
+A `replace` fix op: a Rust regex plus a replacement template with capture substitution, emitting
+`ReplaceRange` per match, wired to `file_content_forbidden` and `file_content_matches`. Unsafe by
+default; Safe only when the replacement is provably a normalization. This phase also introduces
+the **fixpoint loop and index invalidation** (5.2.3), since two `replace` rules can unblock each
+other. Tests: firing, silent, idempotence, overlap between two `replace` rules on one file,
+cross-fixer non-convergence hits the cap, multiline.
+
+### Phase 2: structured value edits (the flagship, class 3)
+
+Format-preserving `set_value` and `remove_value` via the locate bridge (5.3) and the value
+serializer (5.4), driven by the rule-level `collect_edits` binding (5.2.1), wired to
+`*_path_equals` (Safe only for a scalar replacing an existing scalar) and `*_path_absent`
+(Unsafe removal). Non-scalar, zero-match insertion, and nested creation are Suggestions.
+Sub-ordered strictly by dependency cost so value lands early: 2a (free) HCL, XML, dotenv, INI;
+2b (one dep) TOML; 2c (cheap) properties; 2d (new dep) JSON; 2e (hard, scalar-only) YAML. Tests
+per format: firing + silent + idempotence + a comment/order-preservation golden file + a
+"produces invalid document -> demoted to Suggestion" case + a value-serialization matrix
+(quoting, type fidelity, entity-encoding).
+
+### Phase 3: metadata, VCS, and cross-file (classes 2.2 + metadata)
+
+- **chmod (`SetMode`):** `shebang_has_executable` -> add +x (Safe); `executable_bit` -> set/clear
+  (Unsafe); `executable_has_shebang` -> Suggestion.
+- **VCS untrack:** a `git_untrack` fix (spawning, gated per 5.5) running `git rm --cached` plus an
+  optional `.gitignore` line, Unsafe by default.
+- **Sync-from-canonical (`sync_from`)** and cross-file partner creation, using the multi-file
+  transaction of 5.2.4 for atomic create-and-register.
+- **Directory create** (`dir_create`) for `dir_exists`; **relocate** for lockfile-not-at-root
+  where the target is unambiguous (Suggestion where it is not).
+
+### Phase 4: ordering, canonicalization, and the license-header inserter
+
+- **`ordered_block` sort** and **`unique_by` dedup** (Safe, deterministic).
+- **`indent_style`** leading-indent tab/space conversion (Safe for pure leading indentation only;
+  Unsafe otherwise).
+- **`.gitattributes` / `.gitignore` line insertion** (Safe, presence-guarded).
+- **License / SPDX header inserter** (`insert_header`): comment-style-by-extension,
+  shebang-and-xml-decl-aware, `.license` sidecar for uncommentable types. Presence-guarded, Safe.
+
+### Deferred and special (not a numbered phase)
+
+- **Reference/version pinning (class 7)** and **regenerate-from-command (2.2)**: both need to
+  reach outside the tree (network, or a spawned generator), so they are top-level-only,
+  explicitly-opted-in, spawn-gated fixes or future WASM plugins, never the default binary.
+- **Whole-file reprint (class 1):** out of scope; alint is not a formatter.
+- **`line_max_width` reflow; encoding transcode; JSON-Schema-guided fill:** unsafe or ambiguous;
+  Suggestion at most, deferred behind demand.
+
+## 7. False-positive and safety surface
+
+This section is mandatory (TEMPLATE section 4) and applies across the phases.
+
+- **Producing an invalid file.** The dominant risk for classes 2, 3, 4. Mitigation: the re-parse
+  postcondition (5.2 step 4), memoized demotion to Suggestion for any edit that yields an
+  unparseable file.
+- **Discarding human content.** Mitigation: format-preserving splices only (never parse->dump);
+  minimal ranges; the Unsafe tier for anything that removes content; structural/insertion edits
+  kept to Suggestion.
+- **Untrusted fixers from `extends:`.** Mitigation: the fix-level trust gate of 5.5 (content and
+  spawning fix ops top-level-only; promotion top-level-only; inherited content fixers default to
+  Suggestion). This is a new gate, distinct from the kind-level `SPAWNING_RULE_KINDS`.
+- **Fixing a grandfathered violation.** Mitigation: baseline-aware `fix` (5.7) skips suppressed
+  violations from the apply set.
+- **Overlapping edits and non-convergence.** Mitigation: the total-order sort plus skip-overlap
+  and isolation groups; the fixpoint cap with a loud error; the per-fixer idempotence test (which
+  catches self-oscillation only, not cross-fixer cycles, 5.2.3).
+- **Cross-file half-application.** Mitigation: the all-or-nothing multi-file transaction (5.2.4).
+- **Ambiguous targets.** Mitigation: those stay Suggestion; alint proposes, a human or agent
+  disposes.
+- **Destructiveness and recoverability.** The practical undo is VCS. Keep the pre-commit "fix and
+  fail nonzero" and `--diff` preview postures so machine edits are always reviewed.
+
+## 8. Invariants and the decision record
+
+The design upholds the constitution: determinism of fixes (invariant 1; the total edit order of
+5.2.2 and a deterministic re-walk make the fixpoint reproducible); bounded fixes (invariant 4;
+the `fix_size_limit` guard is relocated onto the new collect step); the trust boundary and path
+confinement (invariants 5 and 6; note that a spawning **fixer** needs a **new** fix-level gate,
+because the existing kind-level `SPAWNING_RULE_KINDS` does not cover a fixer attached to a
+non-spawning kind); the coverage audits (invariants 7 and 8; every newly-fixable kind keeps its
+schema entry and gains firing + silent scenarios, plus an idempotence test); and design-doc-first
+plus ADR (invariants 12 and 13).
+
+**ADR-0017** (proposed) records: (1) the ranged edit primitive plus the batched,
+conflict-resolving, postcondition-verifying apply engine (single-pass in Phase 0, fixpoint from
+Phase 1); (2) the four-state applicability model with safe-by-default and `--unsafe-fixes`
+opt-in; and (3) the fixer trust boundary (content and spawning fix ops top-level-only, promotion
+top-level-only).
+
+**Not touched in the companion PR, to keep it green:** `ROADMAP.md` and the generated
+`roadmap.json` (adding a `roadmap-public` marker requires regenerating `roadmap.json` under the
+`gen-roadmap --check` gate). Proposed placement is a dedicated post-v0.16 cut, "Auto-fix
+expansion"; wiring it in is a follow-up.
+
+## 9. Open questions
+
+1. **Reclassifying `file_remove`.** Deleting a whole file by default with no `--unsafe-fixes` is a
+   poor safety default regardless of semver. Lean toward Unsafe with a one-release migration note;
+   confirm before Phase 0 ships the tiers.
+2. **Inherited fixers by default.** Should an `extends:`-ed ruleset's content-mutating fixer apply
+   at all by default (as a Suggestion), or require the user to opt in per rule? 5.5 defaults it to
+   Suggestion; the stricter option is "not honored unless re-declared top-level."
+3. **`ReplaceRange` versus `SetContent` for class 3.** True ranged edits (best LSP diffs, real
+   conflict detection) or `SetContent`-of-spliced-bytes? Leaning ranged, since Phases 1 and 3 need
+   `ReplaceRange` regardless.
+4. **YAML depth.** Is scalar-only YAML write-back (Unsafe, re-parse-guarded) enough for the real
+   configs users care about, or is a heavier round-trip approach warranted later?
+5. **Baseline-and-fix semantics.** Skip suppressed violations from the apply set (the proposal),
+   refuse to run `fix` when a baseline exists, or surface suppressed findings as Suggestions only?
+6. **Network-gated fixes.** Is a top-level-config-only, explicitly-opted-in network fix (SHA
+   pinning) acceptable within the telemetry-free posture, or must it wait for the WASM sandbox?
+
+## References and prior art
+
+The state-of-the-art survey behind Part I, with primary sources.
+
+- **ESLint `--fix`** (the range+text model, `SourceCodeFixer` sort/skip-overlap, the 10-pass
+  fixpoint, `meta.fixable`, autofix vs suggestion).
+- **Ruff `--fix`** (the `Applicability` Safe/Unsafe/DisplayOnly enum, `--unsafe-fixes`, isolation
+  groups, the 100-iteration fixpoint, per-rule reclassification).
+- **Formatters as idempotent reprinters** (Wadler/Oppen layout algebra, Black's AST-equivalence
+  safety check, dprint's Wasm plugin host): Prettier, gofmt, rustfmt, Black, dprint.
+- **Format-preserving structured editing** (CST/round-trip vs minimal `{offset,length,content}`
+  splice): `toml_edit` (backs `cargo add`), `tomlkit` (Poetry), `ruamel.yaml` round-trip,
+  Microsoft `node-jsonc-parser`, dprint `jsonc-parser`; the reserializing tools (`jq`, `yq`,
+  `dasel`) as the anti-pattern.
+- **Codemods** (match -> bind metavariables -> substitute -> replace-span): comby, ast-grep,
+  jscodeshift/recast, Semgrep autofix, OpenRewrite (Lossless Semantic Tree).
+- **Repo/config/dependency fixers** (read -> transform -> rewrite -> nonzero-on-change):
+  pre-commit-hooks, eclint / editorconfig-checker, addlicense / licenseheaders / REUSE, ratchet /
+  pin-github-action, Dependabot / Renovate, `npm audit fix`.
+- **Repolinter** (todogroup/repolinter, archived 2026-02-06): the predecessor whose entire
+  remediation surface was three blunt, auto-write-by-default ops (file-create, file-modify as
+  prepend/append only, file-remove), with no diff preview and most rules unfixable. That is
+  precisely the gap alint fills.
+
+---
+
+*Revision note: this draft was revised after an independent adversarial audit (technical +
+design). Material changes from the first draft: the rule-level `collect_edits` violation-to-edit
+binding (5.2.1); a total edit order (5.2.2); the fixpoint moved out of Phase 0 with an
+index-invalidation story (5.2.3); multi-file transactions (5.2.4); the structured bridge split
+into locate (5.3) and serialize (5.4) with Safe restricted to scalars; a fixer trust boundary
+distinct from the kind-level `SPAWNING_RULE_KINDS` (5.5); baseline / `--changed` / LSP / agent
+interaction surfaces and the Suggestion data model (5.7); the recount of the hygiene normalizers
+to seven; and the removal of the undefined `MoveFile` primitive in favor of `RenameFile`.*

--- a/docs/design/auto-fix.md
+++ b/docs/design/auto-fix.md
@@ -405,8 +405,11 @@ fan-out **requires** true `ReplaceRange`s, since N whole-file `SetContent`s woul
 
 ### 5.2 The batched apply engine
 
-Replace the single-pass loop with a batched model, keeping the "serial filesystem mutation"
-guarantee. The engine has two composition regimes (5.1): **whole-file transforms** compose
+Replace the single-pass loop with a batched model, keeping the serial-mutation guarantee. (Today
+`Engine::fix` is already fully serial, evaluation included: a plain `for entry in &self.entries`
+loop, not the rayon `PerFileRule` path `check` uses; so "parallel eval, serial fix" describes
+`check`, and `fix` gains parallel edit *collection* only if later profiling warrants it.) The
+engine has two composition regimes (5.1): **whole-file transforms** compose
 functionally in config order, and **located edits** go through the collect / sort /
 skip-overlap batch below. **Phase 0 ships only whole-file ops** (the existing 12), so it
 composes them in config order in memory (one write per file), reproducing today's
@@ -478,9 +481,11 @@ on located edits. Sorting "by start then end" is not total when two edits share 
 (two rules rewriting one span), so the engine sorts by the total key
 `(start, end, rule_index, violation_index)` with a stable sort, where `rule_index` is config
 order and `violation_index` is the rule's deterministic emission order (JSONPath match order).
-Ties resolve by config order, the determinism anchor elsewhere in the engine. The applied
-subset is always pairwise byte-disjoint, and disjoint edits commute (5.8), which is what makes
-skip-overlap sound.
+Ties resolve by config order, the determinism anchor elsewhere in the engine. Across
+`nested_configs`, `rule_index` orders the root config's rules first, then each nested `.alint.yml`
+in the engine's deterministic nested-discovery order, so the total order stays well-defined once
+nested rules are lifted into the flat list. The applied subset is always pairwise byte-disjoint,
+and disjoint edits commute (5.8), which is what makes skip-overlap sound.
 
 #### 5.2.3 The fixpoint and index invalidation (Phase 1)
 
@@ -492,8 +497,13 @@ a cap is hit (match Ruff; bail loudly on non-convergence). Two subtleties the si
 - **Index invalidation.** `CreateFile` / `DeleteFile` / `RenameFile` change the tree, but the
   `FileIndex` is built once. A pass that applied a path-mutating edit forces a **full
   deterministic re-walk** before the next pass (so cross-file and `requires_full_index()` rules
-  see the new tree); a pass with only content edits re-checks just the touched files. A created
-  file is not a "changed file," so path-mutating fixes and `--changed` interact (5.7).
+  see the new tree); a pass with only content edits re-checks just the touched files. This
+  **amends ARCHITECTURE's "the walk runs exactly once per invocation" invariant for the `fix`
+  path only** (`check` is unchanged), so ARCHITECTURE.md must be updated when the fixpoint lands
+  (5.6). It also needs the walk configuration the current `Engine::fix` lacks (it takes a
+  pre-built index and stores no `WalkOptions`): either thread `WalkOptions` into the fix engine,
+  or hoist the fixpoint loop up to the `cmd_fix` layer that already holds them. A created file is
+  not a "changed file," so path-mutating fixes and `--changed` interact (5.7).
 - **Termination.** The per-fixer idempotence test catches **self**-oscillation only.
   **Cross-fixer** oscillation (fixer A reintroduces what fixer B removed) is caught solely by
   the iteration cap, which is why the cap exists and why non-convergence is a loud error, not a
@@ -504,13 +514,19 @@ a cap is hit (match Ruff; bail loudly on non-convergence). Two subtleties the si
 #### 5.2.4 Multi-file transactions
 
 A single logical fix can span files (create-and-register, sync-from-canonical to N targets,
-version propagation). "Write once per file" gives no cross-file atomicity, so a fix that emits
-edits to multiple files is applied **all-or-nothing**: stage every file's new bytes in memory,
-verify every postcondition **against the staged set** (a cross-file postcondition, such as "the
-created crate now resolves in `workspace.members`", is checked over the staged buffers, not a
-single file's), and only then write them (each file still atomically). A failure on any file
-aborts the whole group and writes nothing, so a half-applied create-without-register cannot
-occur.
+version propagation). The apply is **staged**: compute every file's new bytes in memory, verify
+every postcondition **against the staged set** (a cross-file postcondition, such as "the created
+crate now resolves in `workspace.members`", is checked over the staged buffers, not a single
+file's), and only then write. This is genuinely all-or-nothing *through the verify phase*: any
+collect or verify failure discards the whole group and writes nothing. The write phase is honest
+about its limit: `write_atomic` is per-file with no cross-file journal, so a failure *during* the
+writes (ENOSPC on file 3 of 5, after files 1-2's atomic renames already committed) leaves a
+partially-applied group. The proposal shrinks that window (write all temp files first, then
+rename them, since a rename failure is far rarer than a write failure) and reports a partial
+apply loudly with the list of files that changed, rather than claiming a transactionality the
+filesystem does not provide. A single fixer that errors during collect or apply skips *that
+edit* and continues, matching today's per-violation `FixStatus::Skipped("fix error: ...")`
+(`engine.rs:1006-1065`); it never aborts the run.
 
 ### 5.3 The structured bridge: locating the span
 
@@ -531,7 +547,7 @@ caution. In build order by cost:
 | dotenv | free | the parser is alint-owned and line-oriented; add per-value byte-offset tracking, splice |
 | INI | free | same as dotenv (alint owns `ini.rs`) |
 | properties | cheap | `java-properties` gives no spans; hand-roll a line/value-span locator (separators, backslash continuations, `\uXXXX`) |
-| TOML | one dep | `toml_edit::DocumentMut` (present today only as a dev dependency via `trycmd`; promote to a real dep of `alint-rules`) |
+| TOML | zero or one dep | the `toml` 1.1 crate alint already depends on ships `serde_spanned` (span-capable), so a spanned splice may need no new dep; or promote `toml_edit` (a full round-trip CST, present today only as a `trycmd` dev-dep) |
 | JSON | new dep | no in-tree JSON parser preserves formatting; add `jsonc-parser` (dprint), which records comment/value ranges, then splice |
 | YAML | hard | no mature Rust library round-trips YAML comments; use a span-capable parser (`saphyr-parser`) to splice a single scalar (Unsafe until the re-parse postcondition passes); structural edits stay Suggestion |
 
@@ -581,9 +597,7 @@ attached to a non-spawning kind (a `git_untrack` fix on `file_absent`, or a `rep
 `file_content_forbidden`) passes it untouched. Without a new gate, a remote `extends:`-ed ruleset
 could ship a fix that silently injects bytes into the user's files or shells out on a default
 `alint fix`, the file-writing and RCE analogue of the spawning-kind hazard. The gate keys on
-**what the fixer can do** and **where it came from** (the loader already tracks
-top-level-versus-`extends:` provenance and threads a per-rule permission to the fixer, the same
-mechanism that forces `allow_out_of_root` off for inherited rules):
+**what the fixer can do** and **where it came from**:
 
 - **Fixed-behavior fixers** (the seven hygiene normalizers, rename-to-case, `file_remove`, `chmod`,
   `dir_create`) carry no ruleset-supplied bytes and do not spawn, so there is no injection surface;
@@ -593,35 +607,70 @@ mechanism that forces `allow_out_of_root` off for inherited rules):
   Unsafe tier, independent of source.
 - **Content-injecting fixers** (`replace`, `set_value`, `sync_from`, `insert_header`, and
   `file_create` / `file_prepend` / `file_append` with inline content) are honored at their tier
-  from the user's own top-level config, local-path `extends:`, and first-party **bundled**
-  rulesets. From a **remote-URL `extends:`** they are **demoted to Suggestion** by default (they
-  can propose an edit, never auto-write), because the content is authored by a third party. A
-  top-level `trusted_extends:` allowlist opts specific remote URLs (a company's internal ruleset
-  host) into honoring their content fixers at tier.
+  from the user's own top-level config, local-path `extends:`, a nested `.alint.yml` (all the
+  user's own tree), and first-party **bundled** rulesets. From a **remote-URL `extends:`** they
+  are **demoted to Suggestion** by default (they can propose an edit, never auto-write), because
+  the content is authored by a third party. A top-level `trusted_extends:` allowlist opts
+  specific remote URLs (a company's internal ruleset host) into honoring their content fixers at
+  tier.
 - **Spawning fixers** (`git_untrack`, a `command`-backed fix, regenerate-from-command) are
   **refused at load** from any non-top-level source (bundled included), matching the
   top-level-only posture of `SPAWNING_RULE_KINDS`.
 - **Applicability promotion** toward Safe/Unsafe is top-level-only: an inherited fixer may be
   demoted but never promoted. `allow_out_of_root` remains top-level-only, unchanged.
 
-### 5.6 DSL and CLI surface
+**This gate is new plumbing, not a reuse of an existing mechanism (correcting an earlier draft).**
+Today the loader `merge()`s every source's rules into one id-keyed list with **no source tag**,
+and `RuleSpec` / `RuleEntry` carry no origin field; `allow_out_of_root` is a top-level policy
+matched by id/kind, and inherited-rule safety is enforced by **rejecting dangerous keys at load
+and dropping the rule** (`reject_command_rules_in`, `reject_custom_facts_in` in `loader.rs`), so no
+provenance needs to survive the merge. Two consequences: (1) the spawning-fixer **refusal** fits
+that existing reject-at-load pattern directly, scanning each `extends:`-ed rule's `fix:` block; but
+(2) the content-fixer **demotion** *keeps* the rule, so its four-way source (top-level /
+local-path / bundled / remote-URL) must be newly threaded through `merge()` onto `RuleSpec` /
+`RuleEntry` and carried to fix time, and `trusted_extends:` is a new top-level config key. This is
+security-load-bearing work to build, not a mechanism to inherit.
+
+### 5.6 DSL, CLI, and downstream surface
 
 - **New `fix:` ops.** `replace` (class 2/4, capture substitution); `set_value` and
   `remove_value` (class 3); `sort` and `dedup` (for `ordered_block` / `unique_by`); `chmod`;
   `git_untrack` (spawning, top-level-only); `sync_from` (whole-file copy from a canonical
   source, 2.2); `insert_header` (comment-style-aware). Each declares a default applicability.
-- **Per-rule reclassification.** `fix: { op: ..., applicability: safe | unsafe | suggestion }`
-  (Ruff's `extend-safe-fixes` model), subject to the promotion rule of 5.5. This is also how a
-  user promotes `file_remove` back to Safe on a chosen rule.
+- **Per-rule reclassification.** The schema encodes exactly one op per `fix:` block (the op is
+  the key; each branch is `additionalProperties: false`), so applicability is a field *of the
+  op's object*, not a sibling key: `fix: { file_remove: { applicability: safe } }`. The
+  (currently empty-marker) op structs gain an optional `applicability: safe | unsafe | suggestion`
+  (Ruff's `extend-safe-fixes` model), subject to the promotion rule of 5.5. This is how a user
+  promotes `file_remove` back to Safe on a chosen rule.
 - **Trust config.** A top-level `trusted_extends:` list (URL prefixes) opts specific remote
   `extends:` sources into having their content-injecting fixers honored at tier rather than
   demoted to Suggestion (5.5), for teams that trust their own internal ruleset host.
 - **`command` rule fixability.** The `command` plugin rule may carry a user-supplied fix
   command; it is a spawning fixer, so top-level-only and gated as in 5.5. Its name is distinct
   from the agent output's existing `fix_command` field (5.7).
-- **CLI.** `alint fix` keeps applying Safe fixes by default; add `--unsafe-fixes`, `--diff`
-  (print the patch without writing), and `--fix-only`. The `agent` and `json` outputs gain a
-  per-fix `applicability` field and a proposed-edit payload for Suggestions (5.7).
+- **CLI and preview modes.** `alint fix` applies Safe fixes by default. `--unsafe-fixes` widens
+  the set to include Unsafe; Suggestions never enter the apply set and render as a separate
+  "proposed, not applied" block in every mode.
+
+  | Mode | Writes? | Prints | Exit code |
+  |---|---|---|---|
+  | `fix` | yes | applied / skipped / suggested summary | nonzero if an error-level violation is unresolved (5.7) |
+  | `fix --dry-run` (existing) | no | the same summary, "would" phrasing | same predicate, on the simulated result |
+  | `fix --diff` (new) | no | a unified diff of the would-apply edits | same predicate |
+  | `fix --fix-only` (new) | yes | applied only; residual-violation report suppressed | zero unless a fix errored |
+
+  `fix --dry-run` doubles as the CI gate (write nothing, fail if fixes are pending), so no
+  separate `fix --check` is added.
+- **Downstream artifacts (per phase).** alint gates its own generated/derived surfaces, so each
+  phase that adds an op or a status also updates, in the same PR: `schemas/v1/config.json` (the
+  `FixSpec` op enum) and `schemas/v1/fix-report.json` (the new `suggested` status) via
+  `gen-schema` (constitution invariants 7 and 11); the `facts.json` `auto_fix_ops` count, which is
+  code-derived and gated by `readme_auto_fix_ops_count_matches_fixers` (invariants 9 and 11);
+  `README.md`'s headline counts; the per-op reference in `docs/rules.md`; and `ARCHITECTURE.md`'s
+  fix-operations table and execution step 9 (which the batched engine supersedes, and which is
+  already stale: it omits `file_footer`). `ROADMAP.md` / `roadmap.json` are wired when the arc is
+  scheduled as v0.17 (section 9).
 
 ### 5.7 Interaction surfaces
 
@@ -642,19 +691,35 @@ mechanism that forces `allow_out_of_root` off for inherited rules):
   is computed against one buffer version and applied against another, edits carry a pinned
   document version (`OptionalVersionedTextDocumentIdentifier`) and are rejected on version
   drift; this is the one place true concurrency appears, and version-pinning, not operational
-  transformation, is the right tool (5.8).
-- **Agent output and the Suggestion data model.** The report types carry no tier today
-  (`FixStatus` is `Applied | Skipped | Unfixable`, and `has_unresolved` at
-  `crates/alint-core/src/report.rs:106-110` counts only `Skipped | Unfixable`, which drives the
-  nonzero `fix` exit). The proposal adds a **`FixStatus::Suggested(edit)`** variant, an
-  `applicability` field on the agent violation, a `proposed_edit: {path, range, content}[]`
-  payload, and gates `fix_command` to Safe/Unsafe (appending `--unsafe-fixes` for Unsafe). Because
-  a Suggestion is **never applied**, an error-level violation whose only fix is a Suggestion still
-  stands after `alint fix`, so **`has_unresolved` is extended to count `Suggested` as unresolved**
-  for exit-code purposes: the report distinguishes a proposed edit from a bare `unfixable`, while
-  the "fix and fail nonzero" posture of section 7 is preserved (an error-level Suggestion still
-  fails the run). This resolves the earlier ambiguity between "a new status variant" and "reframe
-  the serialization": it is a new variant *and* the `has_unresolved` extension, together.
+  transformation, is the right tool (5.8). `SetMode` (chmod) has no `WorkspaceEdit` representation
+  (LSP has no permission-bit op), so it surfaces as a non-LSP Suggestion, not a code action; the
+  new `FixEdit` and `FixStatus` variants also force mechanical match-arm updates across every
+  formatter and the LSP `fix_edit_to_workspace_edit` mapping.
+- **Platform.** `SetMode` (chmod) edits are skipped with a note on non-unix (Windows has no
+  equivalent), consistent with `executable_bit`'s evaluate path already being `#[cfg(unix)]`.
+  Symlink and `file_remove` fixes stay cross-platform, since `no_symlinks` can fire on Windows; a
+  `SetMode` edit simply never enters the apply set there.
+- **Output formats and the Suggestion data model.** Two report types must not be conflated: the
+  check-side `Report` (what `check` emits; today carries only `is_fixable: bool` per violation) and
+  the fix-side `FixReport` (what `alint fix` emits). The **automatic path is fix-side**: the
+  `FixReport` gains a **`FixStatus::Suggested(edit)`** variant, and `has_unresolved`
+  (`crates/alint-core/src/report.rs:106-110`, which today counts only `Skipped | Unfixable` and
+  drives the nonzero `fix` exit) is **extended to count `Suggested` as unresolved**, so an
+  error-level Suggestion still stands after `alint fix` and still drives a nonzero exit (the "fix
+  and fail nonzero" posture of section 7 is preserved). Carrying a fix in a **check-side finding
+  format** is a separate, deliberate feature: `alint check --format sarif` emits SARIF 2.1.0
+  `result.fixes[]` (an `artifactChange` -> `replacement` of a `deletedRegion` + `insertedContent`,
+  which `ReplaceRange { range, content }` maps onto almost 1:1) for **every tier** (Safe, Unsafe,
+  Suggestion), tagging the tier in each fix's `description`. SARIF fixes are advisory (the consumer
+  chooses to apply), so surfacing all tiers is safe and is the point of emitting SARIF at all;
+  `agent` and `json` gain the same `proposed_edit: {path, range, content}[]` + `applicability`.
+  Because computing an edit means running `collect_edits` during `check` (today `check` computes no
+  edit bytes, only `is_fixable`), it runs **only when a fix-carrying format is selected**
+  (`--format sarif` / `agent`, or `--format json --include-fixes`); the default `human` / `github`
+  / `gitlab` / `junit` check path computes nothing and pays nothing, protecting the sub-second
+  floor. `alint fix` still rejects the finding-only formats, so fixes ride the `check` path;
+  `github`-annotations, `gitlab`, `junit`, and `markdown` carry only the fixable flag (no native
+  edit slot).
 
 ### 5.8 Formal model: the guarantees the engine can and cannot make
 
@@ -753,6 +818,27 @@ validated per run, not proven; and no operational transformation or CRDT is need
 single-writer total order is stronger than eventual convergence (OT is a future LSP-only concern,
 5.7).
 
+### 5.9 Performance and the perf-gate
+
+alint's identity is speed (a benchmarked sub-second floor at ~100k files), so the fix engine must
+not erode it, and the proposal commits to keeping it on the gate rather than asserting it.
+
+- **Cost shape.** A located-edit pass is one sort (`O(e log e)` in the edits) plus a linear
+  splice; the fixpoint runs at most `k` passes (the cap). A content-only pass re-checks just the
+  touched files; a pass that applied a path-mutating edit costs a **full re-walk + re-check** (one
+  `check` pass) before the next iteration, which is the dominant term and the reason path-mutating
+  fixers are rare and the cap is small. A Safe-only run converges in at most `|V|` passes (5.8),
+  in practice one or two.
+- **The default paths stay free.** `alint check` without a fix-carrying format computes no edits
+  (5.7); `alint fix` runs serially after a single evaluation and is not on the interactive hot
+  path. Only a fix-carrying `check` (a CI SARIF/agent run) or a multi-pass `fix` pays extra, and
+  only in proportion to the fixable violations present.
+- **Gate it, do not trust it.** `fix` is **not** on the deterministic perf-gate today
+  (`crates/alint-bench/benches/det_check.rs` gates `check` scenarios only; the one `fix` bench is
+  criterion-only, dry-run, and capped at 1k files). Phase 0 adds a gated `fix` scenario and a
+  fixpoint-convergence scenario to the Valgrind/Ir gate, so a fix-path regression trips CI the way
+  a check-path one does.
+
 ## 6. The phased plan
 
 Each phase is independently shippable and ordered by value multiplied by feasibility. A phase
@@ -772,7 +858,10 @@ configs, including the adversarial same-file pairs (`no_trailing_whitespace` tri
 `final_newline`; `file_header` prepend plus `max_consecutive_blank_lines`, both touching EOF)
 that would each get only one fix under a naive `0..len` overlap-skip. The located-edit batch, the
 overlap-skip, and the fixpoint are built here but first *exercised* in Phase 1, so the Phase 0
-test plan is byte-identical snapshots of the whole-file composition, not a claim of tier or
+test plan is byte-identical snapshots of the whole-file composition **plus a per-fixer
+`apply`-vs-`fix_edit` byte-parity property test** (the batched engine composes the `fix_edit` data
+path, while today's `alint fix` uses `apply`, and those paths can drift; the codebase already
+carries such a guard, e.g. `bom_fix_edit_binary_guard_mirrors_apply`) - not a claim of tier or
 located-edit coverage. Risk: low.
 
 ### Phase 1: located content replacement + the fixpoint (classes 2 and 4)
@@ -899,6 +988,12 @@ Resolved after review (folded into the sections above):
   Suggestions, fix only new ones (5.7).
 - **Network-gated fixes:** the core stays network-free; SHA-pinning is a separate, top-level-only,
   explicitly-opted-in fix or a future WASM plugin, never a bare `alint fix` (6, Deferred).
+- **Versioning:** the arc slots as **v0.17**; it introduces the tiers and a deprecation warning,
+  then flips `file_remove` to Unsafe about two minors later (a warned, pre-1.0 MINOR change) (5.6,
+  6).
+- **Fixes in finding output:** `check --format sarif` emits SARIF `fixes[]` for all tiers, and
+  `agent` / `json --include-fixes` carry a `proposed_edit`; the edit is computed during `check`
+  **only** when such a format is selected, so the default check path is unchanged (5.7).
 
 Still open:
 
@@ -953,7 +1048,7 @@ hierarchy, relational dependency theory) lives in the companion
 
 ---
 
-*Revision note: revised three times after independent adversarial audits. Round 1 (technical +
+*Revision note: revised four times after independent adversarial audits. Round 1 (technical +
 design) added the rule-level `collect_edits` binding (5.2.1), a total edit order (5.2.2),
 multi-file transactions (5.2.4), the locate/serialize split (5.3, 5.4), the fixer trust boundary
 (5.5), the interaction surfaces (5.7), the recount to seven normalizers, and dropped the undefined
@@ -967,4 +1062,14 @@ inverse, 5.8), sharpened the fixed-point and counting framings, specified whole-
 sequencing (5.1, 5.2.3) and the `Suggested` exit-code plumbing (5.7), refined the trust boundary to
 gate content-injecting fixers by provenance with a `trusted_extends:` opt-in while leaving
 fixed-behavior fixers untouched (5.5), and recorded the maintainer's decisions: `file_remove`
-Unsafe-by-default with a per-rule override, baseline-aware `fix`, and a network-free core (3, 9).*
+Unsafe-by-default with a per-rule override, baseline-aware `fix`, and a network-free core (3, 9).
+Round 4 (an implementability-plus-cross-repo-consistency audit and a completeness gap-hunt)
+corrected the trust boundary's false claim that per-source provenance already exists in the loader
+(it must be built; 5.5), noted the fixpoint re-walk amends ARCHITECTURE's "walk once" invariant and
+listed ARCHITECTURE / schema / `facts.json` / README / `docs/rules.md` as downstream artifacts each
+phase must update (5.6), fixed the per-rule `applicability` schema shape, made the multi-file
+failure model honest (all-or-nothing through verify, best-effort through the per-file writes,
+5.2.4), and added SARIF `fixes[]` for all tiers on `check --format sarif`, a
+performance-and-perf-gate section (5.9), a preview-mode table, and Windows / `nested_configs`
+handling. The maintainer resolved: the v0.17 warned-migration slot, all-tier SARIF fixes, and
+computing check-side edits only when a fix-carrying format is selected.*

--- a/docs/design/auto-fix.md
+++ b/docs/design/auto-fix.md
@@ -1,6 +1,6 @@
 # Auto-fix: a systematic framework for mechanical remediation
 
-Status: Draft (revised after an adversarial audit; see the changelog note at the end).
+Status: Draft (revised five times after independent adversarial audits; see the changelog note at the end).
 Decisions: [ADR-0017](../adr/0017-auto-fix-edit-model-and-applicability.md) (proposed) records the load-bearing decisions (the batched range-edit apply engine, the applicability model, and the fixer trust boundary).
 Demand evidence: the structured-query family (25 kinds, the largest family) is 100% unfixable today; see the `format-coverage.md` arc and the 30-repo `examples/` corpus.
 
@@ -25,7 +25,7 @@ Demand evidence: the structured-query family (25 kinds, the largest family) is 1
   - [6. The phased plan](#6-the-phased-plan)
   - [7. False-positive and safety surface](#7-false-positive-and-safety-surface)
   - [8. Invariants and the decision record](#8-invariants-and-the-decision-record)
-  - [9. Open questions](#9-open-questions)
+  - [9. Resolved decisions and open questions](#9-resolved-decisions-and-open-questions)
 - [References and prior art](#references-and-prior-art)
 
 ## Thesis
@@ -59,9 +59,11 @@ on purpose:
   Unsafe (opt-in via `--unsafe-fixes`), Suggestion (surfaced, never auto-applied), Never
   (advisory or a tripwire; no fix proposed).
 
-One batched apply engine runs over the primitives; every class is an adapter that emits
-primitives with a declared tier. The engine, not the individual fixer, owns conflict
-resolution, determinism, postcondition verification, and (from Phase 1) fixpoint iteration.
+One apply engine runs over the primitives; every class is an adapter that emits primitives
+with a declared tier. The engine has **two composition regimes** (5.2): whole-file transforms
+compose in config order, and located edits go through a batched, verifying pass. The engine,
+not the individual fixer, owns conflict resolution, determinism, postcondition verification,
+and (from Phase 1) fixpoint iteration.
 
 ---
 
@@ -216,8 +218,9 @@ universe indexed by intent (which is how the DSL will expose it):
 - **Structured value** (a value at a path must equal / be absent): class 3. Entirely
   unfixable today; the largest opportunity.
 - **Ordering / canonicalization** (a marked block must stay sorted; entries deduplicated):
-  `ordered_block` sort is the clean win; `unique_by` dedup and `.gitattributes` /
-  `.gitignore` line insertion are adjacent, currently unbuilt.
+  `ordered_block` sort and line dedup are the clean wins; `.gitattributes` / `.gitignore` line
+  insertion is adjacent, currently unbuilt; a `unique_by` collision has no unique automatic fix
+  (which duplicate survives is ambiguous) and stays a Suggestion.
 - **Metadata / permission** (exec bit, symlink, submodule, portable name): `SetMode` plus
   delete/rename. alint deletes symlinks and submodules; chmod and portable-name repair are
   gaps.
@@ -296,7 +299,7 @@ edit, where changing the value is the entire point; for alint, the Safe test for
 edit is "sets exactly the declared value, output re-parses, recoverable via VCS," not
 "preserves meaning."
 
-This maps one-to-one onto the maintainer's existing five buckets and gives alint three
+This maps cleanly onto the maintainer's existing five buckets (5-to-4, per 1.4) and gives alint three
 properties it lacks: a machine-readable safety declaration on every fixer, a default that
 only applies fixes that cannot surprise, and a first-class home for "proposed but not
 automatic." The data model for Suggestions and their interaction with the existing agent
@@ -313,8 +316,8 @@ behavior and are classified Safe on introduction. The one intentional change is 
 `hygiene/no-tracked-artifacts` ruleset): it is **reclassified Unsafe by default**, because deleting
 a whole file irreversibly is a poor default for a bare `alint fix`. A one-release deprecation
 warning ships first, and a user can **promote it back to Safe on a specific rule** via
-`fix: { applicability: safe }` in their own top-level config (per-rule promotion is
-top-level-only, 5.5).
+`fix: { file_remove: { applicability: safe } }` in their own top-level config (per-rule promotion
+is top-level-only, 5.5).
 
 ## 4. Prevalence and usefulness
 
@@ -343,8 +346,9 @@ invests in that class.
 6. **VCS untrack + gitignore: high for the hygiene story.** A tracked `target/`,
    `node_modules/`, or `.DS_Store` is one of the most common real findings (it is literally
    the README demo). Spawn-gated (5.5).
-7. **Ordering / canonicalization: medium.** `ordered_block` sort and `unique_by` dedup are
-   clean, deterministic wins.
+7. **Ordering / canonicalization: medium.** `ordered_block` sort and line dedup are clean,
+   deterministic wins; a `unique_by` collision has no Safe fix (which duplicate file survives is
+   ambiguous) and stays a Suggestion.
 8. **Metadata permission (chmod): medium.** `shebang_has_executable` (add +x) is unambiguous
    and Safe; the others are narrower.
 9. **Reference/version pinning (class 7): high visibility, special-cased.** SHA-pinning a
@@ -397,11 +401,15 @@ computed span and can genuinely overlap another, so it is the range/overlap mach
 whole-file `SetContent` is therefore **not** modeled as a `0..len` range for overlap purposes.
 The two shapes do not co-apply to one file in a single pass: a file a whole-file transform touches
 in a pass takes no located edits that pass, and located edits re-collect against the new bytes on
-the next fixpoint pass (5.2.3), so every located byte offset stays valid. And because a single
-`*_path_absent` violation expands to N node deletions (5.2.1), the multi-node structured
-fan-out **requires** true `ReplaceRange`s, since N whole-file `SetContent`s would each claim
-`0..len` and mutually conflict; `ReplaceRange` is load-bearing for class 3, not optional
-(open question 3).
+the next fixpoint pass (5.2.3), so every located byte offset stays valid. A single `*_path_absent`
+violation expands to N node deletions (5.2.1). `ReplaceRange` is the **chosen** representation for
+that fan-out rather than a strict necessity: a rule-level `collect_edits` (5.2.1) could instead
+splice all N nodes internally and return one whole-file `SetContent`, which would conflict with
+nothing, so the flagship does not *require* the ranged primitive. The engine adopts `ReplaceRange`
+anyway because it gives the whole located-edit family - including the Phase 1 regex `replace`, where
+two rules genuinely overlap one span - a single substrate with engine-level overlap detection and
+minimal LSP diffs, instead of pushing that bookkeeping into each fixer. The leaner
+single-`SetContent` alternative is recorded and rejected in ADR-0017 (resolved; 5.2.1).
 
 ### 5.2 The batched apply engine
 
@@ -633,10 +641,43 @@ security-load-bearing work to build, not a mechanism to inherit.
 
 ### 5.6 DSL, CLI, and downstream surface
 
-- **New `fix:` ops.** `replace` (class 2/4, capture substitution); `set_value` and
-  `remove_value` (class 3); `sort` and `dedup` (for `ordered_block` / `unique_by`); `chmod`;
-  `git_untrack` (spawning, top-level-only); `sync_from` (whole-file copy from a canonical
-  source, 2.2); `insert_header` (comment-style-aware). Each declares a default applicability.
+- **New `fix:` ops and their config surface.** Each new op declares a default applicability and
+  binds to a specific set of host rule kinds; the existing "`fix.<op> is not compatible with
+  <kind>`" load-time gate (enforced by each fixable builder, e.g. `no_empty_files.rs`,
+  `file_header.rs`) is extended to the new pairings. Most ops read their parameters from the **host
+  rule** so a fix restates no data the rule already carries; the table gives, per op, the host
+  kind(s), what it reads from the rule, and the few genuinely new fields of the op object:
+
+  | Op | Class | Host kind(s) | Reads from the rule | New op field(s) | Default tier |
+  |---|---|---|---|---|---|
+  | `replace` | 2/4 | `file_content_forbidden`, `file_content_matches`, `*_path_matches` | the search regex (`pattern:`; `matches:` on `*_path_matches`) | `replacement` (template, capture substitution) | Unsafe |
+  | `set_value` | 3 | `*_path_equals` only | target `path:` and value (`equals:`) | none | Safe (scalar into an existing scalar), else Suggestion |
+  | `remove_value` | 3 | `*_path_absent` | target `path:` (the node to delete) | none | Unsafe |
+  | `sort` | 6 | `ordered_block` | `comparator` / `start` / `end` / `select` / `unique` | none | Safe |
+  | `dedup` | 6 | `ordered_block` only | the marked-block bounds | none | Safe |
+  | `chmod` | metadata | `executable_bit`, `shebang_has_executable`, `executable_has_shebang` | the desired bit (`require:`) | none (mode derived from `require:`) | Unsafe (Safe for shebang add-+x) |
+  | `git_untrack` | VCS | `file_absent` (and `no_committed_binaries` once built) | the violating path | `gitignore` (also append a `.gitignore` line; default true) | Unsafe, spawning (top-level-only, 5.5) |
+  | `sync_from` | 2.2 | `cross_file` (`identical` / `equals`) | the canonical `source:` file | none | Unsafe |
+  | `insert_header` | 6 | `file_header` | (nothing: `pattern:` is a regex, unusable as literal bytes) | `text` (literal header) + `comment_style` (`line` / `block` / `auto`) | Safe (presence-guarded) |
+  | `dir_create` | presence | `dir_exists` | the missing directory path | none | Safe |
+
+  Three bindings need an explicit design call, because the obvious reading collides with an existing
+  mechanism:
+  - **`dedup` is `ordered_block`-only.** Deduping a marked line-block is a clean Safe transform. The
+    superficially similar `unique_by` violation is cross-*file* (N files share a key), where "dedup"
+    would mean *deleting* all but one source file with no principled rule for which survives; that is
+    a destructive, ambiguous-target fix and routes to **Suggestion** (a human picks the survivor),
+    never a Safe `dedup`. One op name must not span both.
+  - **`insert_header` does not replace the existing `file_header` fix.** `file_header` is already
+    fixable today via `file_prepend` (`file_header.rs:136-149` builds a `FilePrependFixer` from
+    `content` / `content_from`), which inserts verbatim bytes. `insert_header` is a *distinct*,
+    comment-style-aware op that renders the header in the file's comment syntax by extension; a rule
+    carries one or the other (one op per `fix:` block), and plain `file_prepend` stays valid for an
+    already-formatted literal block.
+  - **`sync_from` takes its source from the host rule, not a new field.** It reads the canonical file
+    from `cross_file`'s existing `source:`, so it introduces no `content_from:`-style field (which
+    would duplicate the `file_create` / `file_append` content source). `cross_file` parses no `fix:`
+    block today, so this is new fix-block plumbing on that kind.
 - **Per-rule reclassification.** The schema encodes exactly one op per `fix:` block (the op is
   the key; each branch is `additionalProperties: false`), so applicability is a field *of the
   op's object*, not a sibling key: `fix: { file_remove: { applicability: safe } }`. The
@@ -868,9 +909,9 @@ located-edit coverage. Risk: low.
 
 A `replace` fix op: a Rust regex plus a replacement template with capture substitution, emitting
 `ReplaceRange` per match, wired to `file_content_forbidden` and `file_content_matches`. Unsafe by
-default; Safe only when the replacement is provably a normalization. This phase also introduces
-the **fixpoint loop and index invalidation** (5.2.3), since two `replace` rules can unblock each
-other. Tests: firing, silent, idempotence, overlap between two `replace` rules on one file,
+default; Safe only when the replacement is provably a normalization. This phase also **first
+exercises the fixpoint loop and index invalidation** (5.2.3, both built in Phase 0), since two
+`replace` rules can unblock each other. Tests: firing, silent, idempotence, overlap between two `replace` rules on one file,
 cross-fixer non-convergence hits the cap, multiline.
 
 ### Phase 2: structured value edits (the flagship, class 3)
@@ -898,7 +939,9 @@ per format: firing + silent + idempotence + a comment/order-preservation golden 
 
 ### Phase 4: ordering, canonicalization, and the license-header inserter
 
-- **`ordered_block` sort** and **`unique_by` dedup** (Safe, deterministic).
+- **`ordered_block` sort** and **`ordered_block` dedup** (Safe, deterministic). A `unique_by`
+  collision has no Safe fix - deleting all but one of N files that share a key is destructive and
+  the survivor is ambiguous - so it surfaces as a Suggestion (5.6).
 - **`indent_style`** leading-indent tab/space conversion (Safe for pure leading indentation only;
   Unsafe otherwise).
 - **`.gitattributes` / `.gitignore` line insertion** (Safe, presence-guarded).
@@ -932,7 +975,8 @@ This section is mandatory (TEMPLATE section 4) and applies across the phases.
 - **Overlapping edits and non-convergence.** Mitigation: the total-order sort plus skip-overlap
   and isolation groups; the fixpoint cap with a loud error; the per-fixer idempotence test (which
   catches self-oscillation only, not cross-fixer cycles, 5.2.3).
-- **Cross-file half-application.** Mitigation: the all-or-nothing multi-file transaction (5.2.4).
+- **Cross-file half-application.** Mitigation: the multi-file transaction (5.2.4), all-or-nothing
+  through verify and best-effort (no cross-file journal) through the per-file writes.
 - **Ambiguous targets.** Mitigation: those stay Suggestion; alint proposes, a human or agent
   disposes.
 - **Destructiveness and recoverability.** The practical undo is VCS. Keep the pre-commit "fix and
@@ -951,7 +995,8 @@ plus ADR (invariants 12 and 13).
 
 **ADR-0017** (proposed) records: (1) the ranged edit primitive plus the batched,
 conflict-resolving, postcondition-verifying apply engine (whole-file ops composed in config
-order in Phase 0; the located-edit batch and the fixpoint arrive in Phase 1); (2) the four-state
+order in Phase 0; the located-edit batch and the fixpoint built in Phase 0 but first exercised in
+Phase 1); (2) the four-state
 applicability model with safe-by-default and `--unsafe-fixes` opt-in, including the
 Dershowitz-Manna termination contract for Safe fixers and the well-behaved-lens acceptance test
 for structured fixes (5.8); and (3) the fixer trust boundary (spawning fix ops refused from
@@ -982,8 +1027,11 @@ Resolved after review (folded into the sections above):
   any source (so bundled hygiene keeps auto-applying), remote-URL content-injecting fixers are
   **demoted to Suggestion** with a `trusted_extends:` opt-in, and spawning fixers are refused from
   any non-top-level source (5.5).
-- **`ReplaceRange` vs `SetContent`:** **ranged**, since the multi-node structured fan-out requires
-  it (5.1, 5.2.1).
+- **`ReplaceRange` vs `SetContent`:** **ranged**. The multi-node structured fan-out does not
+  strictly require it (a rule-level `collect_edits` could emit one whole-file `SetContent`), but a
+  ranged primitive gives the whole located-edit family one substrate with engine-level overlap
+  detection and minimal LSP diffs; the leaner single-`SetContent` alternative is recorded and
+  rejected in ADR-0017 (5.1, 5.2.1).
 - **Baseline and `fix`:** **baseline-aware**; skip suppressed violations, surface them as
   Suggestions, fix only new ones (5.7).
 - **Network-gated fixes:** the core stays network-free; SHA-pinning is a separate, top-level-only,
@@ -1048,7 +1096,7 @@ hierarchy, relational dependency theory) lives in the companion
 
 ---
 
-*Revision note: revised four times after independent adversarial audits. Round 1 (technical +
+*Revision note: revised five times after independent adversarial audits. Round 1 (technical +
 design) added the rule-level `collect_edits` binding (5.2.1), a total edit order (5.2.2),
 multi-file transactions (5.2.4), the locate/serialize split (5.3, 5.4), the fixer trust boundary
 (5.5), the interaction surfaces (5.7), the recount to seven normalizers, and dropped the undefined
@@ -1072,4 +1120,17 @@ failure model honest (all-or-nothing through verify, best-effort through the per
 5.2.4), and added SARIF `fixes[]` for all tiers on `check --format sarif`, a
 performance-and-perf-gate section (5.9), a preview-mode table, and Windows / `nested_configs`
 handling. The maintainer resolved: the v0.17 warned-migration slot, all-tier SARIF fixes, and
-computing check-side edits only when a fix-carrying format is selected.*
+computing check-side edits only when a fix-carrying format is selected. Round 5 (a holistic
+coherence and drift audit, a coverage-doc re-audit with DSL worked-examples, and an
+over-engineering critique) specified 5.6's per-op config surface (host kinds, inputs-read-from-rule
+versus new op fields) for every new op and resolved three collisions the worked-examples exposed
+(`dedup` is `ordered_block`-only, since deduping `unique_by` would delete source files;
+`insert_header` is distinct from the existing `file_prepend`-on-`file_header` fix; `sync_from` reads
+`cross_file`'s `source:` rather than a new content field), defined the referenced-but-undefined
+`dir_create` op, fixed a schema-shape contradiction (the section 3 `file_remove` promotion example
+used the invalid sibling-key form) and a run of cross-reference drift (the section 9 TOC anchor, a
+dangling "open question 3", the round count, the Thesis two-regime framing, and the multi-file
+"all-or-nothing" qualifier), and made the `ReplaceRange` justification honest (a chosen substrate,
+not a strict necessity, since a single `collect_edits` could emit one `SetContent`). The maintainer
+resolved to keep the full-engine-first plan of section 6 as written, with the leaner "defer the
+located-edit engine" alternative recorded and rejected in ADR-0017.*

--- a/docs/design/auto-fix.md
+++ b/docs/design/auto-fix.md
@@ -307,10 +307,14 @@ the rule arrives through `extends:`. Promotion toward Safe/Unsafe, and every con
 or spawning op, is confined to the user's own top-level config (5.5). An inherited fixer may
 be demoted but never promoted.
 
-**Back-compatibility:** the 12 existing ops keep their current behavior and are classified
-Safe on introduction, so `alint fix` is unchanged for existing configs. Whether `file_remove`
-(deleting a whole file by default, with no `--unsafe-fixes`) should be reclassified Unsafe is
-a safety-default question, not merely a semver one; see the open questions.
+**Back-compatibility and `file_remove`:** the content and path-normalizing ops keep their current
+behavior and are classified Safe on introduction. The one intentional change is `file_remove`
+(used by `file_absent`, `no_empty_files`, `no_submodules`, `no_symlinks`, and the bundled
+`hygiene/no-tracked-artifacts` ruleset): it is **reclassified Unsafe by default**, because deleting
+a whole file irreversibly is a poor default for a bare `alint fix`. A one-release deprecation
+warning ships first, and a user can **promote it back to Safe on a specific rule** via
+`fix: { applicability: safe }` in their own top-level config (per-rule promotion is
+top-level-only, 5.5).
 
 ## 4. Prevalence and usefulness
 
@@ -384,15 +388,16 @@ from a whole-file `SetContent` to minimal `ReplaceRange`s with an O(ND) Myers di
 1986), which tightens both the LSP diff and the overlap footprint.
 
 Two edit shapes must not be conflated, and conflating them was a round-1 error this revision
-corrects. A **whole-file transform** (the seven normalizers, or a create/remove/rename path
-op) is a function of the file's bytes, not an edit at a span. Whole-file transforms compose by
-**function composition in config order** (exactly today's behavior), and the seven pure
-normalizers additionally form a confluent, terminating sub-system (5.8), so their composite
-normal form is order-independent. A **located edit** (`ReplaceRange` from `replace` /
-`set_value` / `remove_value`) targets a computed span and can genuinely overlap another, so it
-is the range/overlap machinery's job. A whole-file `SetContent` is therefore **not** modeled as
-a `0..len` range for overlap purposes; a file that receives both a whole-file transform and
-located edits has them sequenced across fixpoint passes (5.2.3). And because a single
+corrects. A **whole-file transform** (the seven normalizers, or a create / remove / rename path op) is not
+an edit at a span; the engine applies each in **config order** (exactly today's per-op behavior),
+and Phase 0 replays that same order. It does *not* rely on these transforms commuting (they do
+not: 5.8 gives a counterexample); reproducing today's config order is all the Phase 0 no-op
+needs. A **located edit** (`ReplaceRange` from `replace` / `set_value` / `remove_value`) targets a
+computed span and can genuinely overlap another, so it is the range/overlap machinery's job. A
+whole-file `SetContent` is therefore **not** modeled as a `0..len` range for overlap purposes.
+The two shapes do not co-apply to one file in a single pass: a file a whole-file transform touches
+in a pass takes no located edits that pass, and located edits re-collect against the new bytes on
+the next fixpoint pass (5.2.3), so every located byte offset stays valid. And because a single
 `*_path_absent` violation expands to N node deletions (5.2.1), the multi-node structured
 fan-out **requires** true `ReplaceRange`s, since N whole-file `SetContent`s would each claim
 `0..len` and mutually conflict; `ReplaceRange` is load-bearing for class 3, not optional
@@ -570,28 +575,34 @@ well-behaved fix here" signal that routes creation to Suggestion.
 ### 5.5 Trust boundary for fixers
 
 A fixer is a new trust surface, and the existing `SPAWNING_RULE_KINDS` allowlist does not cover
-it: that gate checks the rule **kind** at load (`crates/alint-dsl/src/lib.rs:513`), so a
-spawning or content-writing **fixer** attached to a non-spawning kind (for example a
-`git_untrack` fix on `file_absent`, or a `replace` fix on `file_content_forbidden`) passes it
-untouched. Without a new gate, an `extends:`-ed ruleset could ship a fix that silently rewrites
-the user's files or shells out on a default `alint fix`, which is the file-writing and RCE
-analogue of the spawning-kind hazard the repo already takes seriously. The rules:
+it: that gate checks the rule **kind** (its `.contains(&kind)` sites are at
+`crates/alint-dsl/src/lib.rs:271` / `545` / `579`), so a spawning or content-injecting **fixer**
+attached to a non-spawning kind (a `git_untrack` fix on `file_absent`, or a `replace` fix on
+`file_content_forbidden`) passes it untouched. Without a new gate, a remote `extends:`-ed ruleset
+could ship a fix that silently injects bytes into the user's files or shells out on a default
+`alint fix`, the file-writing and RCE analogue of the spawning-kind hazard. The gate keys on
+**what the fixer can do** and **where it came from** (the loader already tracks
+top-level-versus-`extends:` provenance and threads a per-rule permission to the fixer, the same
+mechanism that forces `allow_out_of_root` off for inherited rules):
 
-- **Spawning fix ops** (`git_untrack`, a `command`-backed fix, regenerate-from-command) are
-  **refused at load** from an `extends:`-ed ruleset, mirroring how the kind-level
-  `SPAWNING_RULE_KINDS` hard-rejects a spawning kind. This needs a new **fix-level** allowlist,
-  because the kind-level gate does not see a spawning fixer attached to a non-spawning kind.
-- **Content-mutating fix ops** (`replace`, `set_value`, `remove_value`, `sync_from`,
-  `insert_header`, and any future op that rewrites existing bytes) are, when inherited from an
-  `extends:`-ed ruleset, **demoted to Suggestion** rather than refused, so an untrusted ruleset
-  can propose an edit but never auto-write on a default `alint fix`. Whether inherited content
-  fixers should be honored at all (versus dropped) is open question 2.
-- **Applicability promotion is top-level-only.** An inherited fixer may be demoted but never
-  promoted toward Safe/Unsafe. The gate is implementable on existing plumbing: the loader
-  already tracks top-level-versus-`extends:` provenance and threads a per-rule permission to the
-  fixer (the same mechanism that forces `allow_out_of_root` off for inherited rules), so the fix
-  op and its origin are both known at rule-build time.
-- `allow_out_of_root` remains top-level-only, unchanged.
+- **Fixed-behavior fixers** (the seven hygiene normalizers, rename-to-case, `file_remove`, `chmod`,
+  `dir_create`) carry no ruleset-supplied bytes and do not spawn, so there is no injection surface;
+  they are honored at their own tier from any source. This is what keeps the bundled rulesets'
+  trailing-whitespace / final-newline fixes auto-applying (they arrive via
+  `extends: alint://bundled/...`); a destructive one like `file_remove` is already gated by its
+  Unsafe tier, independent of source.
+- **Content-injecting fixers** (`replace`, `set_value`, `sync_from`, `insert_header`, and
+  `file_create` / `file_prepend` / `file_append` with inline content) are honored at their tier
+  from the user's own top-level config, local-path `extends:`, and first-party **bundled**
+  rulesets. From a **remote-URL `extends:`** they are **demoted to Suggestion** by default (they
+  can propose an edit, never auto-write), because the content is authored by a third party. A
+  top-level `trusted_extends:` allowlist opts specific remote URLs (a company's internal ruleset
+  host) into honoring their content fixers at tier.
+- **Spawning fixers** (`git_untrack`, a `command`-backed fix, regenerate-from-command) are
+  **refused at load** from any non-top-level source (bundled included), matching the
+  top-level-only posture of `SPAWNING_RULE_KINDS`.
+- **Applicability promotion** toward Safe/Unsafe is top-level-only: an inherited fixer may be
+  demoted but never promoted. `allow_out_of_root` remains top-level-only, unchanged.
 
 ### 5.6 DSL and CLI surface
 
@@ -600,7 +611,11 @@ analogue of the spawning-kind hazard the repo already takes seriously. The rules
   `git_untrack` (spawning, top-level-only); `sync_from` (whole-file copy from a canonical
   source, 2.2); `insert_header` (comment-style-aware). Each declares a default applicability.
 - **Per-rule reclassification.** `fix: { op: ..., applicability: safe | unsafe | suggestion }`
-  (Ruff's `extend-safe-fixes` model), subject to the promotion rule of 5.5.
+  (Ruff's `extend-safe-fixes` model), subject to the promotion rule of 5.5. This is also how a
+  user promotes `file_remove` back to Safe on a chosen rule.
+- **Trust config.** A top-level `trusted_extends:` list (URL prefixes) opts specific remote
+  `extends:` sources into having their content-injecting fixers honored at tier rather than
+  demoted to Suggestion (5.5), for teams that trust their own internal ruleset host.
 - **`command` rule fixability.** The `command` plugin rule may carry a user-supplied fix
   command; it is a spawning fixer, so top-level-only and gated as in 5.5. Its name is distinct
   from the agent output's existing `fix_command` field (5.7).
@@ -612,9 +627,9 @@ analogue of the spawning-kind hazard the repo already takes seriously. The rules
 
 - **Baseline.** `alint fix` rejects `--baseline` today, so it acts on the unsuppressed set;
   after Phase 2 that would auto-rewrite a structured value a team deliberately grandfathered.
-  The proposal makes `fix` **baseline-aware**: with a baseline, suppressed violations are
-  skipped by the apply set and surfaced only as Suggestions. This is a behavior addition, called
-  out as an open question.
+  `fix` becomes **baseline-aware**: with a baseline, suppressed (grandfathered) violations are
+  skipped by the apply set and surfaced only as Suggestions, mirroring `check --baseline`; only
+  new violations are fixed. (Resolved; was an open question.)
 - **`--changed`.** `Engine::fix` already honors `--changed`. The fixpoint can require writes to
   files outside the changed set (cross-file consistency, or a file a prior pass created); the
   proposal confines writes to the changed set plus files a fix in scope created, and treats a
@@ -629,16 +644,17 @@ analogue of the spawning-kind hazard the repo already takes seriously. The rules
   drift; this is the one place true concurrency appears, and version-pinning, not operational
   transformation, is the right tool (5.8).
 - **Agent output and the Suggestion data model.** The report types carry no tier today
-  (`FixStatus` is `Applied | Skipped | Unfixable`) and the agent format emits `fix_available:
-  bool` plus `fix_command: ["fix","--only",<id>]`. The proposal adds a `Suggested(edit)`
-  outcome (or a tier field on `FixItem`), an `applicability` field on the agent violation, a
-  `proposed_edit: {path, range, content}[]` payload for Suggestions, and gates `fix_command` to
-  Safe/Unsafe (appending `--unsafe-fixes` for Unsafe). Crucially, a Suggestion is **never
-  applied**, so an error-level violation whose only fix is a Suggestion **still stands** after
-  `alint fix` and must **still drive a nonzero exit** (`has_unresolved` continues to count it,
-  preserving the "fix and fail nonzero" posture of section 7). The reframing is confined to the
-  agent output: such a violation is surfaced as a `proposed_edit` rather than a bare
-  `unfixable`, not exempted from the exit-code predicate.
+  (`FixStatus` is `Applied | Skipped | Unfixable`, and `has_unresolved` at
+  `crates/alint-core/src/report.rs:106-110` counts only `Skipped | Unfixable`, which drives the
+  nonzero `fix` exit). The proposal adds a **`FixStatus::Suggested(edit)`** variant, an
+  `applicability` field on the agent violation, a `proposed_edit: {path, range, content}[]`
+  payload, and gates `fix_command` to Safe/Unsafe (appending `--unsafe-fixes` for Unsafe). Because
+  a Suggestion is **never applied**, an error-level violation whose only fix is a Suggestion still
+  stands after `alint fix`, so **`has_unresolved` is extended to count `Suggested` as unresolved**
+  for exit-code purposes: the report distinguishes a proposed edit from a bare `unfixable`, while
+  the "fix and fail nonzero" posture of section 7 is preserved (an error-level Suggestion still
+  fails the run). This resolves the earlier ambiguity between "a new status variant" and "reframe
+  the serialization": it is a new variant *and* the `has_unresolved` extension, together.
 
 ### 5.8 Formal model: the guarantees the engine can and cannot make
 
@@ -652,30 +668,39 @@ content edit can reintroduce another rule's violation, so different orders can r
 results and the relation is not terminating in general. The total order of 5.2.2 therefore makes
 the engine a **deterministic strategy over a non-confluent system**, which buys
 **reproducibility** (a fixed order gives one result every run), **not canonicity** (that result
-is not an order-independent normal form). The one positive law that holds is **orthogonality**:
-edits with disjoint byte ranges commute (Rosen 1973), which is exactly why applying a
-pairwise-disjoint subset and skipping overlaps is sound. The seven whole-file normalizers are a
-good special case: among themselves they are confluent and terminating (trailing-whitespace
-stripping and final-newline insertion reach the same normal form in either order), which is why
-Phase 0's functional composition is order-independent up to that normal form. (Newman 1942;
-Baader and Nipkow 1998; Rosen 1973.)
+is not an order-independent normal form). The one positive law that holds is the analogue of
+**orthogonality**: edits with disjoint byte ranges commute, so applying a pairwise-disjoint set is
+order-independent (the property proved for non-overlapping / left-linear systems by Rosen 1973,
+and later termed orthogonality), which is exactly why applying a pairwise-disjoint subset and
+skipping overlaps is sound. The whole-file normalizers do **not** have this property among
+themselves: they compose single-pass and do not all commute (for example `final_newline` appends a
+bare `\n`, so on interior-CRLF input it does not commute with `line_endings: crlf`; a trailing
+zero-width character shields preceding spaces from the trailing-whitespace trim). Phase 0 does not
+rely on their commuting; it reproduces today's single-pass config-order composition exactly, which
+is a no-op whether or not that order is canonical. (Newman 1942; Baader and Nipkow 1998; Rosen
+1973.)
 
 **Termination of the Safe tier.** Uniform termination of a rewriting system is undecidable (Huet
 and Lankford 1978), which is why the fixpoint carries a hard cap and bails loudly. But the Safe
-tier can terminate by construction: require every Safe fixer to **strictly decrease the multiset
-of outstanding violations** (remove at least one, introduce none of any rule), under the
-Dershowitz-Manna multiset extension of a well-founded order (Dershowitz and Manna 1979). Then a
-Safe-only fixpoint reaches a fixed point in at most `|V|` passes with no reliance on the cap; the
-cap guards only Unsafe and user-promoted fixers, which carry no such guarantee (an arbitrary
-regex `replace` can loop). This makes "a Safe fixer" a checkable contract.
+tier can terminate by construction: require every Safe fixer to **strictly shrink the set of
+outstanding violations** (resolve at least one, introduce none of any rule). The count then falls
+by at least one each non-final pass, so a Safe-only fixpoint reaches a fixed point in at most `|V|`
+passes with no reliance on the cap. (The full Dershowitz-Manna multiset ordering, 1979, is only
+needed if the contract is relaxed to "replace a violation with strictly-lower-ranked ones"; under
+the strict "introduce none" contract a plain cardinality argument suffices.) The cap guards only
+Unsafe and user-promoted fixers, which carry no such guarantee (an arbitrary regex `replace` can
+loop). This makes "a Safe fixer" a checkable contract.
 
 **Not a least fixed point (a caveat, not a theorem).** It is tempting to call the loop a
 least-fixed-point computation (Kleene / Knaster-Tarski). In general it is not: the apply operator
 is non-monotone (an Unsafe fix can add violations) and the state space is not a complete lattice.
-The fixed-point reading holds **only** under the Safe remove-only contract above, on the finite
-lattice of violation sets ordered by inclusion, where Kleene iteration converges in at most `|V|`
-steps. The failure of monotonicity for the general operator is precisely *why* the cap exists;
-the cap is not an implementation detail of an otherwise-guaranteed convergence.
+Even under the Safe remove-only contract the reading is only partial: the loop is a
+strictly-**descending** iteration from the top (all of `V`) on the finite violation-inclusion
+lattice, so it reaches **a** fixed point in at most `|V|` steps (the lattice height), but this is a
+greatest-fixed-point-flavored descent, not the ascending-from-bottom Kleene least fixed point, and
+without confluence that fixed point need not be unique. The failure of monotonicity for the general
+operator is precisely *why* the cap exists; the cap is not an implementation detail of an
+otherwise-guaranteed convergence.
 
 **The structured write-back is a lens.** A structured read (`*_path_equals`, the query) and its
 write-back (`set_value`, the splice) form an asymmetric **lens** (Foster et al. 2007; the
@@ -684,8 +709,9 @@ database view-update problem, Bancilhon and Spyratos 1981): `get(source) = value
 oracle**, and they line up with the acceptance checks:
 
 - **GetPut** (`put(get(s), s) = s`): writing back the value already present is a no-op. This is
-  format-preservation stated precisely, strictly stronger than "apply twice is a no-op" because
-  it forbids touching any byte the edit did not mean to change.
+  format-preservation stated precisely: byte-exact stability that forbids touching any byte the
+  edit did not mean to change (idempotence alone permits gratuitous byte changes on a first
+  application). GetPut and PutGet together in fact imply the fixer is idempotent.
 - **PutGet** (`get(put(v, s)) = v`): after the fix, the query returns the intended value. This is
   the localized-equivalence half of the acceptance test (5.2 step 4).
 - **PutPut** (the "very-well-behaved" law) does **not** hold in general for format-preserving
@@ -699,8 +725,10 @@ constrains the write, which is the formal statement of "there is no well-behaved
 
 **Why re-serialization is lossy, and what re-parse guarantees.** `Format::parse` is a
 **non-injective** function (many byte strings, differing in whitespace, comments, and key order,
-map to one `serde_json::Value`), so it has no right inverse: there is no serializer `Q` with
-`Q . parse = id`. That is the formal reason the value tree cannot preserve format and a lossless
+map to one `serde_json::Value`), so it has no **left inverse**: no serializer `Q` recovers the
+original bytes (`Q . parse = id`). (It does have right inverses: an ordinary serializer `Q'`
+satisfies `parse . Q' = id` on the value; what is impossible is recovering the discarded bytes.)
+That is the formal reason the value tree cannot preserve format and a lossless
 CST or a spanned splice is required (Roslyn red-green trees; rust-analyzer's Rowan; the `cstree`
 crate). The re-parse in the acceptance test is a **decidable membership check** in the format
 language, a real guarantee that no file outside the language is ever written, but it is
@@ -717,8 +745,9 @@ validation on unverified fixers**, backed by property tests, not a proof that ev
 semantics-preserving.
 
 **What the engine does not guarantee** (the honest ledger): the fix result is not independent of
-rule order (only reproducible for a fixed order); the loop is not a least fixed point of the
-general operator (only under the Safe remove-only contract); the write-back is well-behaved but
+rule order (only reproducible for a fixed order); the loop is not a Kleene least fixed point (even
+under the Safe contract it is a strictly-descending iteration to a fixed point, not an ascending
+least one); the write-back is well-behaved but
 not very-well-behaved (no PutPut); "re-parses" is syntactic, not semantic; the Safe tier is
 validated per run, not proven; and no operational transformation or CRDT is needed, because a
 single-writer total order is stronger than eventual convergence (OT is a future LSP-only concern,
@@ -767,7 +796,7 @@ per format: firing + silent + idempotence + a comment/order-preservation golden 
 "produces invalid document -> demoted to Suggestion" case + a value-serialization matrix
 (quoting, type fidelity, entity-encoding).
 
-### Phase 3: metadata, VCS, and cross-file (classes 2.2 + metadata)
+### Phase 3: metadata, VCS, and the repo-scale cross-file classes (2.2)
 
 - **chmod (`SetMode`):** `shebang_has_executable` -> add +x (Safe); `executable_bit` -> set/clear
   (Unsafe); `executable_has_shebang` -> Suggestion.
@@ -854,23 +883,28 @@ committed nothing).
 `gen-roadmap --check` gate). Proposed placement is a dedicated post-v0.16 cut, "Auto-fix
 expansion"; wiring it in is a follow-up.
 
-## 9. Open questions
+## 9. Resolved decisions and open questions
 
-1. **Reclassifying `file_remove`.** Deleting a whole file by default with no `--unsafe-fixes` is a
-   poor safety default regardless of semver. Lean toward Unsafe with a one-release migration note;
-   confirm before Phase 0 ships the tiers.
-2. **Inherited fixers by default.** Should an `extends:`-ed ruleset's content-mutating fixer apply
-   at all by default (as a Suggestion), or require the user to opt in per rule? 5.5 defaults it to
-   Suggestion; the stricter option is "not honored unless re-declared top-level."
-3. **`ReplaceRange` versus `SetContent` for class 3.** True ranged edits (best LSP diffs, real
-   conflict detection) or `SetContent`-of-spliced-bytes? Leaning ranged, since Phases 1 and 3 need
-   `ReplaceRange` regardless.
-4. **YAML depth.** Is scalar-only YAML write-back (Unsafe, re-parse-guarded) enough for the real
-   configs users care about, or is a heavier round-trip approach warranted later?
-5. **Baseline-and-fix semantics.** Skip suppressed violations from the apply set (the proposal),
-   refuse to run `fix` when a baseline exists, or surface suppressed findings as Suggestions only?
-6. **Network-gated fixes.** Is a top-level-config-only, explicitly-opted-in network fix (SHA
-   pinning) acceptable within the telemetry-free posture, or must it wait for the WASM sandbox?
+Resolved after review (folded into the sections above):
+
+- **`file_remove` default:** reclassified **Unsafe** with a one-release migration and a per-rule
+  Safe override (3, 5.6).
+- **Inherited fixers:** gated by capability and provenance: fixed-behavior fixers are honored from
+  any source (so bundled hygiene keeps auto-applying), remote-URL content-injecting fixers are
+  **demoted to Suggestion** with a `trusted_extends:` opt-in, and spawning fixers are refused from
+  any non-top-level source (5.5).
+- **`ReplaceRange` vs `SetContent`:** **ranged**, since the multi-node structured fan-out requires
+  it (5.1, 5.2.1).
+- **Baseline and `fix`:** **baseline-aware**; skip suppressed violations, surface them as
+  Suggestions, fix only new ones (5.7).
+- **Network-gated fixes:** the core stays network-free; SHA-pinning is a separate, top-level-only,
+  explicitly-opted-in fix or a future WASM plugin, never a bare `alint fix` (6, Deferred).
+
+Still open:
+
+1. **YAML edit depth.** Is scalar-only YAML write-back (Unsafe, re-parse-guarded) enough for the
+   real configs users care about, or is a heavier round-trip approach warranted later? Decide with
+   corpus evidence before scheduling sub-phase 2e.
 
 ## References and prior art
 
@@ -919,14 +953,18 @@ hierarchy, relational dependency theory) lives in the companion
 
 ---
 
-*Revision note: revised twice after independent adversarial audits. Round 1 (technical + design)
-added the rule-level `collect_edits` binding (5.2.1), a total edit order (5.2.2), multi-file
-transactions (5.2.4), the locate/serialize split (5.3, 5.4), the fixer trust boundary (5.5), the
-interaction surfaces (5.7), the recount to seven normalizers, and dropped the undefined
+*Revision note: revised three times after independent adversarial audits. Round 1 (technical +
+design) added the rule-level `collect_edits` binding (5.2.1), a total edit order (5.2.2),
+multi-file transactions (5.2.4), the locate/serialize split (5.3, 5.4), the fixer trust boundary
+(5.5), the interaction surfaces (5.7), the recount to seven normalizers, and dropped the undefined
 `MoveFile`. Round 2 (a second audit plus a mathematical-foundations pass) corrected the Phase 0
-"zero behavior change" claim (whole-file transforms compose functionally in config order; located
-edits and the fixpoint are Phase 1, per 5.1 and 5.2), fixed the `Suggested`-outcome exit-code
-semantics (5.7), and added the formal model (5.8): the engine as a non-confluent rewriting system
-driven by a deterministic strategy, the Dershowitz-Manna termination contract for Safe fixers,
-the lens laws as the write-back correctness spec, and the translation-validation verification plan
-(section 8).*
+"zero behavior change" claim (whole-file transforms compose in config order; located edits and the
+fixpoint are Phase 1) and the `Suggested`-outcome exit code, and added the formal model (5.8).
+Round 3 (a third audit, a theory-correctness referee pass, and a resolved-decisions pass with the
+maintainer) corrected a false "the normalizers are confluent" claim (they are not; Phase 0 relies
+only on replaying today's config order, 5.1 and 5.8) and a swapped inverse term (left, not right,
+inverse, 5.8), sharpened the fixed-point and counting framings, specified whole-file-vs-located
+sequencing (5.1, 5.2.3) and the `Suggested` exit-code plumbing (5.7), refined the trust boundary to
+gate content-injecting fixers by provenance with a `trusted_extends:` opt-in while leaving
+fixed-behavior fixers untouched (5.5), and recorded the maintainer's decisions: `file_remove`
+Unsafe-by-default with a per-rule override, baseline-aware `fix`, and a network-free core (3, 9).*

--- a/docs/design/auto-fix.md
+++ b/docs/design/auto-fix.md
@@ -127,16 +127,16 @@ non-writing `fix_edit` path, which is deliberately un-guarded), out-of-root path
 confinement, a binary-content guard, atomic temp-then-rename writes, and skip-on-collision
 for rename.
 
-### 1.4 The gap is structural, and the maintainer already reasons about it
+### 1.4 The gap is structural, not incidental
 
-The catalog of unfixed kinds is not random. Reading the "why no fixer" notes across
-`docs/rules.md`, the unfixed kinds already sort into five buckets that map one-to-one onto
-the applicability model formalized later:
+The catalog of unfixed kinds is not random. Several unfixed kinds carry an explicit rationale
+in `docs/rules.md`; the rest fit the taxonomy on inspection. Grouped, they sort into five
+buckets that map onto the applicability model formalized later:
 
-1. **Deferred / not-yet-built, low ambiguity:** `executable_bit`,
-   `shebang_has_executable`, `executable_has_shebang` ("chmod auto-apply is deferred"),
-   `ordered_block` (sort the marked lines), `indent_style` ("tab-width-aware reindentation
-   is deferred"), `dir_exists` / `dir_absent` (no directory-level op exists).
+1. **Deferred / not-yet-built, low ambiguity:** `executable_bit` (which notes "chmod auto-apply
+   is deferred"), `shebang_has_executable`, `executable_has_shebang`, `ordered_block` (sort the
+   marked lines), `indent_style` (deferred as "language-specific"), `dir_exists` / `dir_absent`
+   (no directory-level op exists).
 2. **Deliberately check-only because a fix is destructive:** `file_content_forbidden`,
    `commented_out_code`, `git_no_denied_paths` ("git rm --cached is too destructive to
    automate"), `git_blame_age`, `no_merge_conflict_markers` (a fix cannot know which side to
@@ -151,10 +151,10 @@ the applicability model formalized later:
 
 That is, in miniature, exactly the applicability taxonomy this document formalizes (bucket 1
 becomes Safe/Unsafe once built; bucket 2 becomes Unsafe; bucket 3 becomes Suggestion;
-buckets 4 and 5 stay Never). The framework is a natural fit, not an imposition. What is
-missing is (a) the edit primitive to express located and structured changes, (b) an engine
-that can batch and verify them safely, and (c) a first-class way to say "this fix exists but
-is not safe to apply unattended."
+buckets 4 and 5 stay Never). That the existing rationales line up with the taxonomy is a good
+sign the model is not an imposition. What is missing is (a) the edit primitive to express
+located and structured changes, (b) an engine that can batch and verify them safely, and (c) a
+first-class way to say "this fix exists but is not safe to apply unattended."
 
 ## 2. The universe of auto-fixable classes
 
@@ -271,9 +271,13 @@ re-parses) are the **inputs** a fixer author uses to pick the tier, not the defi
 
 - **Safe.** Applied by `alint fix` with no flag. A fixer may declare Safe only when it sets
   exactly the declared or derived target, discards no human-authored content (comments,
-  code), is idempotent, and (for content/structured edits) its output re-parses. Example:
-  the seven hygiene normalizers; setting a structured value to an exact declared **scalar**
-  via a format-preserving edit that re-parses.
+  code), is **idempotent** (the lens GetPut law, 5.8), passes the localized-equivalence
+  acceptance test where it edits content (5.2 step 4), and **strictly reduces the violation
+  multiset** without introducing violations of other rules (the Dershowitz-Manna termination
+  contract, 5.8, which is what lets a Safe-only fixpoint terminate without relying on the cap).
+  Example: the seven hygiene normalizers; setting a structured value to an exact declared
+  **scalar** via a format-preserving edit. For a structured fix, Safe means the write-back is a
+  **well-behaved lens** on that input (GetPut and PutGet hold at apply time, 5.8).
 - **Unsafe.** Applied only with `--unsafe-fixes`. Example: regex search-and-replace,
   structured key removal, chmod, git untrack, tab/space conversion, deleting a whole file.
 - **Suggestion.** Never written by `alint fix`. Surfaced as a concrete proposed edit
@@ -374,19 +378,36 @@ pub enum FixEdit {
 `ReplaceRange` is the ESLint `{range, text}` primitive. Three payoffs: minimal diffs (the LSP
 maps it straight to a `TextEdit` instead of replacing the whole document, which the current
 `SetContent` path does with a full-document range at `crates/alint-lsp/src/lib.rs:779-782`);
-mechanical overlap detection (two edits conflict iff their ranges intersect); and composition
-(many edits to one file merge into one write). A structured splice can also be delivered as a
-`SetContent` whose bytes differ only in the target span, so `ReplaceRange` is a
-correctness-and-diff-quality optimization, not a hard prerequisite for shipping class 3; for
-overlap and determinism purposes a whole-file `SetContent` is treated as a `ReplaceRange`
-over `0..len`.
+mechanical overlap detection (two located edits conflict iff their ranges intersect); and
+composition (many located edits to one file merge into one write). Normalizers can be lowered
+from a whole-file `SetContent` to minimal `ReplaceRange`s with an O(ND) Myers diff (Myers
+1986), which tightens both the LSP diff and the overlap footprint.
+
+Two edit shapes must not be conflated, and conflating them was a round-1 error this revision
+corrects. A **whole-file transform** (the seven normalizers, or a create/remove/rename path
+op) is a function of the file's bytes, not an edit at a span. Whole-file transforms compose by
+**function composition in config order** (exactly today's behavior), and the seven pure
+normalizers additionally form a confluent, terminating sub-system (5.8), so their composite
+normal form is order-independent. A **located edit** (`ReplaceRange` from `replace` /
+`set_value` / `remove_value`) targets a computed span and can genuinely overlap another, so it
+is the range/overlap machinery's job. A whole-file `SetContent` is therefore **not** modeled as
+a `0..len` range for overlap purposes; a file that receives both a whole-file transform and
+located edits has them sequenced across fixpoint passes (5.2.3). And because a single
+`*_path_absent` violation expands to N node deletions (5.2.1), the multi-node structured
+fan-out **requires** true `ReplaceRange`s, since N whole-file `SetContent`s would each claim
+`0..len` and mutually conflict; `ReplaceRange` is load-bearing for class 3, not optional
+(open question 3).
 
 ### 5.2 The batched apply engine
 
 Replace the single-pass loop with a batched model, keeping the "serial filesystem mutation"
-guarantee. In **Phase 0 the engine runs exactly one pass** (behavior-preserving); the
-**fixpoint loop is introduced in Phase 1**, where the first fixers that can unblock one
-another appear. One pass:
+guarantee. The engine has two composition regimes (5.1): **whole-file transforms** compose
+functionally in config order, and **located edits** go through the collect / sort /
+skip-overlap batch below. **Phase 0 ships only whole-file ops** (the existing 12), so it
+composes them in config order in memory (one write per file), reproducing today's
+disk-round-trip result exactly. The **located-edit batch, the overlap-skip, and the fixpoint
+are built in Phase 0 but first exercised in Phase 1**, when located edits (and fixers that can
+unblock one another) arrive. One located-edit pass:
 
 1. **Collect (read-only, not pure).** Each rule's fixer yields its edits as data, tagged with
    an `Applicability`. This reads and parses files, so it is read-only I/O, not pure; the
@@ -401,14 +422,20 @@ another appear. One pass:
    left-to-right tracking the last applied end, skip any edit overlapping one already taken
    (deferred to the next fixpoint pass, once Phase 1 adds it). Adopt Ruff's isolation-group
    idea for edits that must not co-apply even when disjoint.
-4. **Apply in memory and verify the postcondition.** For structured and regex edits, re-parse
-   the buffer and confirm it still parses and the target now satisfies the rule. This is the
-   Black-style equivalence check adapted to structured data: an edit that would produce an
-   unparseable file is rejected and **demoted to Suggestion, memoized per (file, edit) for the
-   run** so a stateless rule does not re-derive and re-demote it every pass.
+4. **Apply in memory and verify the acceptance test.** The Safe acceptance test is
+   **translation validation** (Pnueli et al. 1998), in two parts: (i) a **decidable re-parse**
+   proving the output is still in the format language (syntactic; 5.8), and (ii) a **localized
+   equivalence** proving the parsed tree equals the original everywhere except the targeted
+   path and the target now holds the intended value (semantic; this is the lens PutGet law,
+   5.8). Re-parse alone is insufficient: a splice can parse yet be wrong (a value that parses
+   as the wrong type, a removal that deletes the wrong separator). An edit that fails either
+   part is rejected and **demoted to Suggestion, memoized per (file, edit) for the run** so a
+   stateless rule does not re-derive and re-demote it every pass.
 5. **Write atomically**, once per file, via the existing `write_atomic`.
-6. **Idempotence as a tested contract.** Every fixer gets a property test: apply twice, the
-   second run is a no-op.
+6. **Idempotence as a tested contract for Safe fixers.** Every Safe fixer gets a property
+   test: apply twice, the second run is a no-op (the lens GetPut law, 5.8). A configurable
+   Unsafe `replace` (for example `a` to `aa`) is not idempotent by construction; it relies on
+   the bounded fixpoint and the loud non-convergence cap, not on idempotence.
 
 The `allow_out_of_root` confinement, binary guard, and dry-run guards carry over.
 
@@ -427,23 +454,28 @@ fn collect_edits(&self, violations: &[Violation], file: &Path, bytes: &[u8], roo
     -> Vec<(FixEdit, Applicability)>;
 ```
 
-so a fan-out rule computes the full match set once, re-runs its own query with a **located**
-API (RFC 9535 normalized paths via `serde_json_path`'s `query_located`, which yields a
-per-node location) and emits exactly one edit per node: N deletions for one `*_path_absent`
-violation, one edit per failing node for `*_path_equals` (de-duplicated so M violations do not
-produce M identical edit batches). Simple per-file fixers keep the one-liner `apply` /
-`fix_edit` path; only rules that fan out over matches implement `collect_edits`. This is a
-Phase 2 prerequisite, not a Phase 2 detail.
+so a fan-out rule computes the full match set once and re-runs its own query with a **located**
+API (`serde_json_path`'s `query_located`, which yields each match's RFC 9535 **normalized
+path**). A normalized path is a *logical* node identity, not a byte offset: it both
+disambiguates the N-node binding and is the navigation key handed to the per-format bridge of
+5.3, which recovers the actual byte span to splice. The rule then emits one edit per node: N
+deletions for one `*_path_absent` violation, one edit per *failing* node for `*_path_equals`
+(de-duplicated so M violations do not produce M identical edit batches). Simple per-file fixers
+keep the one-liner `apply` / `fix_edit` path; only rules that fan out over matches implement
+`collect_edits`. This is a Phase 2 prerequisite, not a Phase 2 detail.
 
 #### 5.2.2 Determinism and total edit order
 
-Constitution invariant 1 requires byte-identical fixes across runs. Sorting "by start then
-end" is not a total order when two edits share both offsets (two rules rewriting one span; two
-whole-file retrofits both spanning `0..len`). The engine sorts by the total key
+Constitution invariant 1 requires byte-identical fixes across runs. This is **reproducibility,
+not canonicity**: the located-edit relation is not confluent (5.8), so the result is the unique
+output of a fixed strategy, not an order-independent normal form. The strategy is a total order
+on located edits. Sorting "by start then end" is not total when two edits share both offsets
+(two rules rewriting one span), so the engine sorts by the total key
 `(start, end, rule_index, violation_index)` with a stable sort, where `rule_index` is config
 order and `violation_index` is the rule's deterministic emission order (JSONPath match order).
-Ties therefore resolve by config order, which is already the determinism anchor elsewhere in
-the engine.
+Ties resolve by config order, the determinism anchor elsewhere in the engine. The applied
+subset is always pairwise byte-disjoint, and disjoint edits commute (5.8), which is what makes
+skip-overlap sound.
 
 #### 5.2.3 The fixpoint and index invalidation (Phase 1)
 
@@ -460,24 +492,32 @@ a cap is hit (match Ruff; bail loudly on non-convergence). Two subtleties the si
 - **Termination.** The per-fixer idempotence test catches **self**-oscillation only.
   **Cross-fixer** oscillation (fixer A reintroduces what fixer B removed) is caught solely by
   the iteration cap, which is why the cap exists and why non-convergence is a loud error, not a
-  silent stop. 5.7 (isolation groups) and careful tier assignment reduce, but cannot eliminate,
-  cross-fixer cycles.
+  silent stop. The isolation groups of 5.2 (step 3) and careful tier assignment reduce, but
+  cannot eliminate, cross-fixer cycles; a Safe-only fixpoint, by contrast, is guaranteed to
+  terminate (5.8).
 
 #### 5.2.4 Multi-file transactions
 
 A single logical fix can span files (create-and-register, sync-from-canonical to N targets,
 version propagation). "Write once per file" gives no cross-file atomicity, so a fix that emits
 edits to multiple files is applied **all-or-nothing**: stage every file's new bytes in memory,
-verify every postcondition, and only then write them (each file still atomically). A failure on
-any file aborts the whole group and writes nothing, so a half-applied create-without-register
-cannot occur.
+verify every postcondition **against the staged set** (a cross-file postcondition, such as "the
+created crate now resolves in `workspace.members`", is checked over the staged buffers, not a
+single file's), and only then write them (each file still atomically). A failure on any file
+aborts the whole group and writes nothing, so a half-applied create-without-register cannot
+occur.
 
 ### 5.3 The structured bridge: locating the span
 
-Class 3 needs, per format, a resolver from a JSONPath (or its normalized path) to the target
-value's byte range. There is no shared abstraction to reuse, because the current shared
-abstraction (`Format::parse -> serde_json::Value`) is exactly what throws spans away. The
-feasibility verdicts, in build order by cost:
+Class 3 needs, per format, a resolver from a normalized path (5.2.1) to the target value's byte
+range. There is no shared abstraction to reuse: the current `Format::parse -> serde_json::Value`
+is a **non-injective** parse, so no serializer inverts it (5.8), which is precisely why the
+spans are gone and a re-serialize cannot preserve format. Two mechanisms recover the span: a
+**round-tripping CST** (mutate a lossless tree, then re-serialize, so untouched nodes reproduce
+their source verbatim) or a **spanned splice** (locate the node's byte range, splice the
+original bytes). The verdicts below say which each format gets; the YAML "scalar-only"
+restriction is a *consequence* of having only a spanned scalar parser there, not an ad hoc
+caution. In build order by cost:
 
 | Format | Verdict | Technique and dependency |
 |---|---|---|
@@ -521,8 +561,11 @@ Safe and route to Suggestion:
 - **Any edit whose re-parse postcondition the fixer cannot verify.**
 
 Safe `set_value` is therefore restricted to a **scalar** expected value replacing an
-**existing** scalar node, verified by re-parse. Everything else is Unsafe (removals) or
-Suggestion (structures, insertion, nested creation).
+**existing** scalar node, verified by the acceptance test (5.2 step 4). Everything else is
+Unsafe (removals) or Suggestion (structures, insertion, nested creation). The lens view (5.8)
+makes this principled rather than arbitrary: on the zero-match creation case the lens `get` is
+undefined, so its GetPut law is vacuous and PutPut unconstrained, which is exactly the "no
+well-behaved fix here" signal that routes creation to Suggestion.
 
 ### 5.5 Trust boundary for fixers
 
@@ -534,14 +577,20 @@ untouched. Without a new gate, an `extends:`-ed ruleset could ship a fix that si
 the user's files or shells out on a default `alint fix`, which is the file-writing and RCE
 analogue of the spawning-kind hazard the repo already takes seriously. The rules:
 
-- **Content-mutating fix ops** (`replace`, `set_value`, `remove_value`, `insert_header`, and
-  any future op that rewrites existing bytes) and **spawning fix ops** (`git_untrack`, a
-  `command`-backed fix, regenerate-from-command) are honored **only from the user's own
-  top-level config**, never from an `extends:`-ed ruleset. This needs a new fix-level allowlist
-  distinct from the kind-level `SPAWNING_RULE_KINDS`.
-- **Applicability promotion is top-level-only.** An inherited fixer may be **demoted** (toward
-  Suggestion) but never **promoted** (toward Safe/Unsafe). An inherited content-mutating fixer,
-  if honored at all, defaults to Suggestion.
+- **Spawning fix ops** (`git_untrack`, a `command`-backed fix, regenerate-from-command) are
+  **refused at load** from an `extends:`-ed ruleset, mirroring how the kind-level
+  `SPAWNING_RULE_KINDS` hard-rejects a spawning kind. This needs a new **fix-level** allowlist,
+  because the kind-level gate does not see a spawning fixer attached to a non-spawning kind.
+- **Content-mutating fix ops** (`replace`, `set_value`, `remove_value`, `sync_from`,
+  `insert_header`, and any future op that rewrites existing bytes) are, when inherited from an
+  `extends:`-ed ruleset, **demoted to Suggestion** rather than refused, so an untrusted ruleset
+  can propose an edit but never auto-write on a default `alint fix`. Whether inherited content
+  fixers should be honored at all (versus dropped) is open question 2.
+- **Applicability promotion is top-level-only.** An inherited fixer may be demoted but never
+  promoted toward Safe/Unsafe. The gate is implementable on existing plumbing: the loader
+  already tracks top-level-versus-`extends:` provenance and threads a per-rule permission to the
+  fixer (the same mechanism that forces `allow_out_of_root` off for inherited rules), so the fix
+  op and its origin are both known at rule-build time.
 - `allow_out_of_root` remains top-level-only, unchanged.
 
 ### 5.6 DSL and CLI surface
@@ -574,14 +623,106 @@ analogue of the spawning-kind hazard the repo already takes seriously. The rules
   by a human, so Suggestions **should** be offered there (with Unsafe/Safe distinguished in the
   action title). Multi-edit and multi-file fixes become a multi-document `WorkspaceEdit`. The
   LSP applies the edit and re-lints the buffer; it does not re-run the whole engine per
-  keystroke, so the re-parse postcondition runs against the open buffer.
+  keystroke, so the re-parse postcondition runs against the open buffer. Because a code action
+  is computed against one buffer version and applied against another, edits carry a pinned
+  document version (`OptionalVersionedTextDocumentIdentifier`) and are rejected on version
+  drift; this is the one place true concurrency appears, and version-pinning, not operational
+  transformation, is the right tool (5.8).
 - **Agent output and the Suggestion data model.** The report types carry no tier today
   (`FixStatus` is `Applied | Skipped | Unfixable`) and the agent format emits `fix_available:
   bool` plus `fix_command: ["fix","--only",<id>]`. The proposal adds a `Suggested(edit)`
   outcome (or a tier field on `FixItem`), an `applicability` field on the agent violation, a
   `proposed_edit: {path, range, content}[]` payload for Suggestions, and gates `fix_command` to
-  Safe/Unsafe (appending `--unsafe-fixes` for Unsafe). `has_unfixable_errors` is reconciled so a
-  Suggested outcome is not counted as an unresolved error.
+  Safe/Unsafe (appending `--unsafe-fixes` for Unsafe). Crucially, a Suggestion is **never
+  applied**, so an error-level violation whose only fix is a Suggestion **still stands** after
+  `alint fix` and must **still drive a nonzero exit** (`has_unresolved` continues to count it,
+  preserving the "fix and fail nonzero" posture of section 7). The reframing is confined to the
+  agent output: such a violation is surfaced as a `proposed_edit` rather than a bare
+  `unfixable`, not exempted from the exit-code predicate.
+
+### 5.8 Formal model: the guarantees the engine can and cannot make
+
+Several tempting guarantees do not hold, and the doc must not claim them. Each paragraph gives
+the model, what it buys, and the honest limit.
+
+**The fix relation as an abstract rewriting system.** The located-edit engine is an abstract
+rewriting system: a state is a repository, a fixer application is a rewrite step. It is **not
+confluent**, because two fixers can target overlapping spans (an unjoined critical pair) and a
+content edit can reintroduce another rule's violation, so different orders can reach different
+results and the relation is not terminating in general. The total order of 5.2.2 therefore makes
+the engine a **deterministic strategy over a non-confluent system**, which buys
+**reproducibility** (a fixed order gives one result every run), **not canonicity** (that result
+is not an order-independent normal form). The one positive law that holds is **orthogonality**:
+edits with disjoint byte ranges commute (Rosen 1973), which is exactly why applying a
+pairwise-disjoint subset and skipping overlaps is sound. The seven whole-file normalizers are a
+good special case: among themselves they are confluent and terminating (trailing-whitespace
+stripping and final-newline insertion reach the same normal form in either order), which is why
+Phase 0's functional composition is order-independent up to that normal form. (Newman 1942;
+Baader and Nipkow 1998; Rosen 1973.)
+
+**Termination of the Safe tier.** Uniform termination of a rewriting system is undecidable (Huet
+and Lankford 1978), which is why the fixpoint carries a hard cap and bails loudly. But the Safe
+tier can terminate by construction: require every Safe fixer to **strictly decrease the multiset
+of outstanding violations** (remove at least one, introduce none of any rule), under the
+Dershowitz-Manna multiset extension of a well-founded order (Dershowitz and Manna 1979). Then a
+Safe-only fixpoint reaches a fixed point in at most `|V|` passes with no reliance on the cap; the
+cap guards only Unsafe and user-promoted fixers, which carry no such guarantee (an arbitrary
+regex `replace` can loop). This makes "a Safe fixer" a checkable contract.
+
+**Not a least fixed point (a caveat, not a theorem).** It is tempting to call the loop a
+least-fixed-point computation (Kleene / Knaster-Tarski). In general it is not: the apply operator
+is non-monotone (an Unsafe fix can add violations) and the state space is not a complete lattice.
+The fixed-point reading holds **only** under the Safe remove-only contract above, on the finite
+lattice of violation sets ordered by inclusion, where Kleene iteration converges in at most `|V|`
+steps. The failure of monotonicity for the general operator is precisely *why* the cap exists;
+the cap is not an implementation detail of an otherwise-guaranteed convergence.
+
+**The structured write-back is a lens.** A structured read (`*_path_equals`, the query) and its
+write-back (`set_value`, the splice) form an asymmetric **lens** (Foster et al. 2007; the
+database view-update problem, Bancilhon and Spyratos 1981): `get(source) = value`,
+`put(value, source) = source'`. The **lens laws are the correctness specification and the test
+oracle**, and they line up with the acceptance checks:
+
+- **GetPut** (`put(get(s), s) = s`): writing back the value already present is a no-op. This is
+  format-preservation stated precisely, strictly stronger than "apply twice is a no-op" because
+  it forbids touching any byte the edit did not mean to change.
+- **PutGet** (`get(put(v, s)) = v`): after the fix, the query returns the intended value. This is
+  the localized-equivalence half of the acceptance test (5.2 step 4).
+- **PutPut** (the "very-well-behaved" law) does **not** hold in general for format-preserving
+  edits; treat its failure as a **demotion signal**, never a guarantee.
+
+A **Safe structured fix is defined as a well-behaved lens on that input** (GetPut and PutGet hold,
+checked at apply time). The degenerate cases justify the Suggestion routing of 5.4 rather than
+merely cautioning it: on a zero-match path there is no `get`, so GetPut is vacuous and nothing
+constrains the write, which is the formal statement of "there is no well-behaved fix here."
+(Foster, Greenwald, Moore, Pierce, Schmitt 2007; Boomerang, Bohannon et al. 2008.)
+
+**Why re-serialization is lossy, and what re-parse guarantees.** `Format::parse` is a
+**non-injective** function (many byte strings, differing in whitespace, comments, and key order,
+map to one `serde_json::Value`), so it has no right inverse: there is no serializer `Q` with
+`Q . parse = id`. That is the formal reason the value tree cannot preserve format and a lossless
+CST or a spanned splice is required (Roslyn red-green trees; rust-analyzer's Rowan; the `cstree`
+crate). The re-parse in the acceptance test is a **decidable membership check** in the format
+language, a real guarantee that no file outside the language is ever written, but it is
+**syntactic only**: "re-parses" does not imply "correct" (a splice can produce a valid document
+with the wrong value), which is why the acceptance test pairs it with the PutGet check.
+
+**The Safe tier is translation validation, not verified transformation.** The right posture is
+**translation validation** (Pnueli, Siegel, Singerman 1998): rather than prove each fixer correct
+for all inputs (CompCert-grade, Leroy 2009, a cost `formal-methods.md` explicitly declines for a
+batch linter), validate **each run** by checking a localized equivalence between input and
+output, exactly as Black's `--safe` re-parses its own output and diffs the AST (adapted here to
+"equal everywhere except the declared change-set"). The guarantee is therefore **per-run
+validation on unverified fixers**, backed by property tests, not a proof that every fixer is
+semantics-preserving.
+
+**What the engine does not guarantee** (the honest ledger): the fix result is not independent of
+rule order (only reproducible for a fixed order); the loop is not a least fixed point of the
+general operator (only under the Safe remove-only contract); the write-back is well-behaved but
+not very-well-behaved (no PutPut); "re-parses" is syntactic, not semantic; the Safe tier is
+validated per run, not proven; and no operational transformation or CRDT is needed, because a
+single-writer total order is stronger than eventual convergence (OT is a future LSP-only concern,
+5.7).
 
 ## 6. The phased plan
 
@@ -593,15 +734,17 @@ scheduled.
 
 The substrate. Add `ReplaceRange` and `SetMode` to `FixEdit`; add `Applicability` to the fixer
 contract (default Safe); add the rule-level `collect_edits` path alongside the existing
-`apply` / `fix_edit`; replace the apply loop with **single-pass** collect / tier-filter / sort
-(total order) / skip-overlap / verify / write; add `--unsafe-fixes`, `--diff`, `--fix-only`;
-relocate the `fix_size_limit` guard onto the collect step. The **fixpoint is deliberately not in
-Phase 0**, so the pass is a genuine no-op for existing configs. Retrofit all 12 existing ops onto
-the engine with **zero behavior change for single-pass-convergent configs**, proven by
-byte-identical fix-report snapshots including the adversarial same-file pairs (`file_header`
-prepend plus `no_trailing_whitespace` trim; `final_newline` plus `max_consecutive_blank_lines`,
-both touching EOF). Tier machinery ships but is not exercised end-to-end until Phase 1, so the
-Phase 0 test plan does not over-claim tier coverage. Risk: low.
+`apply` / `fix_edit`; build the located-edit machinery (collect / tier-filter / total-order sort
+/ skip-overlap / verify / write) and the fixpoint; add `--unsafe-fixes`, `--diff`, `--fix-only`;
+relocate the `fix_size_limit` guard onto the collect step. Because Phase 0 ships **only whole-file
+ops**, the engine applies them by **functional composition in config order** (5.1, 5.2), which
+reproduces today's disk-round-trip result exactly, so Phase 0 is a **genuine no-op** for existing
+configs, including the adversarial same-file pairs (`no_trailing_whitespace` trim plus
+`final_newline`; `file_header` prepend plus `max_consecutive_blank_lines`, both touching EOF)
+that would each get only one fix under a naive `0..len` overlap-skip. The located-edit batch, the
+overlap-skip, and the fixpoint are built here but first *exercised* in Phase 1, so the Phase 0
+test plan is byte-identical snapshots of the whole-file composition, not a claim of tier or
+located-edit coverage. Risk: low.
 
 ### Phase 1: located content replacement + the fixpoint (classes 2 and 4)
 
@@ -689,10 +832,22 @@ schema entry and gains firing + silent scenarios, plus an idempotence test); and
 plus ADR (invariants 12 and 13).
 
 **ADR-0017** (proposed) records: (1) the ranged edit primitive plus the batched,
-conflict-resolving, postcondition-verifying apply engine (single-pass in Phase 0, fixpoint from
-Phase 1); (2) the four-state applicability model with safe-by-default and `--unsafe-fixes`
-opt-in; and (3) the fixer trust boundary (content and spawning fix ops top-level-only, promotion
-top-level-only).
+conflict-resolving, postcondition-verifying apply engine (whole-file ops composed in config
+order in Phase 0; the located-edit batch and the fixpoint arrive in Phase 1); (2) the four-state
+applicability model with safe-by-default and `--unsafe-fixes` opt-in, including the
+Dershowitz-Manna termination contract for Safe fixers and the well-behaved-lens acceptance test
+for structured fixes (5.8); and (3) the fixer trust boundary (spawning fix ops refused from
+`extends:`, content fix ops demoted to Suggestion, promotion top-level-only).
+
+**Verification plan.** The formal model of 5.8 maps onto the repo's existing verification tiers
+(`docs/design/formal-methods.md`): proptest for the algebraic laws (GetPut, PutGet,
+disjoint-edit commutativity, overlap-skip disjointness, total-order well-formedness, localized
+semantic preservation, and Safe-tier termination in at most `|V|` passes); one bounded Kani proof
+for the load-bearing combinatorial invariant (the splice primitive is byte-correct, or the
+overlap detector yields a pairwise-disjoint applied set), the natural sequel to the existing
+`confine_steps_is_sound` path-confinement proof; and debug_assert runtime contracts (the applied
+set was disjoint; PutGet holds on the buffer after a Safe structured edit; a multi-file abort
+committed nothing).
 
 **Not touched in the companion PR, to keep it green:** `ROADMAP.md` and the generated
 `roadmap.json` (adding a `roadmap-public` marker requires regenerating `roadmap.json` under the
@@ -741,13 +896,37 @@ The state-of-the-art survey behind Part I, with primary sources.
   prepend/append only, file-remove), with no diff preview and most rules unfixable. That is
   precisely the gap alint fills.
 
+The theoretical foundations behind section 5.8:
+
+- **Abstract rewriting** (confluence, termination, critical pairs, strategies): Newman 1942;
+  Baader and Nipkow, *Term Rewriting and All That*, 1998; Rosen, "Tree-manipulating systems and
+  Church-Rosser theorems," JACM 1973; Dershowitz and Manna, "Proving termination with multiset
+  orderings," CACM 1979; Huet and Lankford 1978 (undecidability of termination).
+- **Bidirectional transformations / lenses**: Foster, Greenwald, Moore, Pierce, Schmitt,
+  "Combinators for bidirectional tree transformations," ACM TOPLAS 2007; Bancilhon and Spyratos,
+  "Update semantics of relational views," ACM TODS 1981; Bohannon, Foster, Pierce, Pilkiewicz,
+  Schmitt, "Boomerang," POPL 2008.
+- **Minimal edits**: Myers, "An O(ND) difference algorithm," Algorithmica 1986; Zhang and Shasha,
+  tree edit distance, SIAM J. Comput. 1989.
+- **Lossless syntax trees**: Roslyn red-green trees; rust-analyzer's Rowan; the `cstree` crate.
+- **Semantics preservation**: Pnueli, Siegel, Singerman, "Translation validation," TACAS 1998;
+  Leroy, "Formal verification of a realistic compiler" (CompCert), CACM 2009; Black's `--safe`
+  AST-equivalence check.
+
+The completeness-theory grounding for the detection surface (finite model theory, the Chomsky
+hierarchy, relational dependency theory) lives in the companion
+[`rule-coverage-gaps.md`](rule-coverage-gaps.md).
+
 ---
 
-*Revision note: this draft was revised after an independent adversarial audit (technical +
-design). Material changes from the first draft: the rule-level `collect_edits` violation-to-edit
-binding (5.2.1); a total edit order (5.2.2); the fixpoint moved out of Phase 0 with an
-index-invalidation story (5.2.3); multi-file transactions (5.2.4); the structured bridge split
-into locate (5.3) and serialize (5.4) with Safe restricted to scalars; a fixer trust boundary
-distinct from the kind-level `SPAWNING_RULE_KINDS` (5.5); baseline / `--changed` / LSP / agent
-interaction surfaces and the Suggestion data model (5.7); the recount of the hygiene normalizers
-to seven; and the removal of the undefined `MoveFile` primitive in favor of `RenameFile`.*
+*Revision note: revised twice after independent adversarial audits. Round 1 (technical + design)
+added the rule-level `collect_edits` binding (5.2.1), a total edit order (5.2.2), multi-file
+transactions (5.2.4), the locate/serialize split (5.3, 5.4), the fixer trust boundary (5.5), the
+interaction surfaces (5.7), the recount to seven normalizers, and dropped the undefined
+`MoveFile`. Round 2 (a second audit plus a mathematical-foundations pass) corrected the Phase 0
+"zero behavior change" claim (whole-file transforms compose functionally in config order; located
+edits and the fixpoint are Phase 1, per 5.1 and 5.2), fixed the `Suggested`-outcome exit-code
+semantics (5.7), and added the formal model (5.8): the engine as a non-confluent rewriting system
+driven by a deterministic strategy, the Dershowitz-Manna termination contract for Safe fixers,
+the lens laws as the write-back correctness spec, and the translation-validation verification plan
+(section 8).*

--- a/docs/design/rule-coverage-gaps.md
+++ b/docs/design/rule-coverage-gaps.md
@@ -109,17 +109,20 @@ Classifying the current kinds by finite-model-theory level:
   Reachability, connectivity, and acyclicity are provably **not** first-order-definable
   (Ehrenfeucht-Fraisse games; Gaifman locality 1982; Aho-Ullman 1979), so acyclicity cannot be
   desugared into the FO cross-file kinds. This is the theorem that earns `file_graph` its keep.
-  Honest correction: only `acyclic` is non-FO; `no_dangling` / `no_orphans` / `forbidden_edges` are
-  FO over the materialized edge relation, bundled with it for ergonomics, not expressiveness.
+  Honest correction: only `acyclic` is non-FO; `no_dangling` / `forbidden_edges` are FO over the
+  materialized edge relation, and `no_orphans` is FO under its in-degree-zero reading ("a file
+  nothing references"); a reachability reading ("unreachable from any root") would be non-FO like
+  `acyclic`. These are bundled with `acyclic` for ergonomics, not expressiveness.
 - **Path-query expressiveness:** the navigational core of XPath is characterized as FO2 over trees
   (Marx and de Rijke 2005); JSONPath (RFC 9535) has no such published theorem, so FO2 is a grounded
   analogy, not a proof, for alint's `*_path_*` family. The family asserts a
   universal-over-a-selected-set predicate, which structurally cannot compare cardinalities across
   nodes, assert key-set equality, or see duplicate keys.
-- **Counting:** the engine does *fixed* aggregations (`max_files_per_directory`, and the size,
-  depth, line, and path-length caps), FO-with-counting in practice, but exposes no *general*
+- **Counting:** comparing a count to a *fixed constant* (`max_files_per_directory`, and the size,
+  depth, line, and path-length caps) is already plain **FO** (a threshold to a constant needs no
+  counting quantifier). What the engine lacks is **general FO+COUNT**: comparing two counts, or an
   equality-of-counts over an extracted relation. (Parity is the classic witness that FO alone
-  cannot count.) That general fragment underlies several gaps below.
+  cannot count.) That general fragment, not the fixed caps, underlies several gaps below.
 
 ### 2.4 The unifying lens: a repository is a database with integrity constraints
 
@@ -205,8 +208,8 @@ single-source candidates): `json_key_sort_order`, `column_alignment`, `not_execu
 `directory_hash`, `case_collision_safe`, `dir_name_matches_field`, `balanced_delimiters`, and
 the backlogged `duplicate_blocks` (copy-paste) and WASM plugins. The `detect: linguist` /
 `detect: askalono` facts were planned for an early cut and **never shipped** (verified: no
-`licensee` or `askalono` reference exists in `crates/`; the only mentions are in ROADMAP and
-this analysis).
+`licensee` or `askalono` crate reference exists in `crates/` source; the remaining mentions are a
+ROADMAP entry and a `detect: linguist` test comment).
 
 ## 4. The gap families
 
@@ -500,8 +503,9 @@ Four reusable substrates unlock disproportionate coverage, so they should be seq
 
 - **The format-preserving structured-value write-back engine** (auto-fix Phase 2) turns the
   version-SSOT, structured-key-sort, and the whole `*_path_equals`-backed set of gaps fixable.
-- **A bundled SPDX id table plus a small expression parser** turns the entire BORDERLINE
-  license tier (F2, F3, F4) green with no network.
+- **A bundled SPDX id table plus a small expression parser** turns the BORDERLINE license-validity
+  checks (F2, and F4's validity half) green with no network, and underpins F3's REUSE completeness
+  (an IN cross-file check).
 - **A duplicate-aware / spanned structured parser** (shared with the auto-fix bridge) unlocks
   `no_duplicate_keys` (B1).
 - **A markdown link / heading / front-matter scanner** (one light line-scanner with a

--- a/docs/design/rule-coverage-gaps.md
+++ b/docs/design/rule-coverage-gaps.md
@@ -13,14 +13,15 @@ Demand evidence: cross-checked against Repolinter, OpenSSF Scorecard, syncpack /
 ## Contents
 
 - [1. The scope boundary](#1-the-scope-boundary)
-- [2. What alint already covers](#2-what-alint-already-covers)
-- [3. The gap families](#3-the-gap-families)
-- [4. Borderline: route to `command` or a WASM plugin](#4-borderline-route-to-command-or-a-wasm-plugin)
-- [5. Clearly out of scope](#5-clearly-out-of-scope)
-- [6. Auto-fix tie-in](#6-auto-fix-tie-in)
-- [7. Prioritized shortlist](#7-prioritized-shortlist)
-- [8. Strategic read and reusable substrates](#8-strategic-read-and-reusable-substrates)
-- [9. References](#9-references)
+- [2. A completeness framework](#2-a-completeness-framework)
+- [3. What alint already covers](#3-what-alint-already-covers)
+- [4. The gap families](#4-the-gap-families)
+- [5. Borderline: route to `command` or a WASM plugin](#5-borderline-route-to-command-or-a-wasm-plugin)
+- [6. Clearly out of scope](#6-clearly-out-of-scope)
+- [7. Auto-fix tie-in](#7-auto-fix-tie-in)
+- [8. Prioritized shortlist](#8-prioritized-shortlist)
+- [9. Strategic read and reusable substrates](#9-strategic-read-and-reusable-substrates)
+- [10. References](#10-references)
 
 ## 1. The scope boundary
 
@@ -30,7 +31,8 @@ and the language toolchains)**. Everything proposed here sits in that band: it i
 from the local files with no network, no language AST or type checker, no `node_modules`
 metadata, no Git host API, and no cryptography. The non-goals from the README still hold
 (alint is not a code/AST linter, not SAST, not a semantic IaC scanner, not a secret scanner),
-and section 5 draws that line explicitly and honestly.
+and section 6 draws that line explicitly and honestly. Section 2 makes the boundary a theorem
+rather than a taste.
 
 Three axes classify every candidate:
 
@@ -45,7 +47,132 @@ Three axes classify every candidate:
 - **Auto-fix applicability**, using the [`auto-fix.md`](auto-fix.md) four-state model: Safe,
   Unsafe, Suggestion, Never.
 
-## 2. What alint already covers
+## 2. A completeness framework
+
+"Is the rule set complete?" has no absolute answer; completeness is only ever **relative to a
+fixed class**. This section fixes that class and locates the covered fragment and the gaps inside
+it, which turns the family list below from a wishlist into the boundary of a defined fragment.
+
+### 2.1 Two layers: recognition and assertion
+
+A repository is a finite labeled structure (a path tree; the filesystem a partial map
+`path -> bytes`; each structured file a further finite tree). alint is two composed machines, and
+confusing them is the main source of loose reasoning about coverage:
+
+- **Recognition layer (the Chomsky hierarchy).** From raw bytes it materializes *labels* (unary
+  predicates: "matches regex R", "is valid UTF-8", "has +x") and *relations* (edges, key/value
+  tuples, path lists). Content matching is *exactly* the regular languages: the RE2-style `regex`
+  engine has no backreferences, a precise ceiling, not an analogy, so a content rule cannot
+  recognize `a^n b^n`, balanced brackets, or "the same identifier twice". Format recognition is
+  roughly context-free (balanced-bracket well-formedness is the Dyck language; the honest caveat
+  is that YAML is not context-free, so the real parsers sit around or just above CF). Duplicate-code
+  detection is *fingerprinting* (winnowing over Rabin-Karp hashes; Schleimer, Wilkerson, Aiken
+  2003), not parsing, which is why it stays in scope.
+- **Assertion layer (finite model theory + dependency theory).** Over the resulting finite
+  structure it *asserts* a predicate: a first-order combination, a bounded slice of monadic
+  second-order or transitive closure, integrity constraints, and bounded counting.
+
+Every gap is then precisely a **recognition gap** (the layer that builds the structure throws the
+needed information away, or never builds it), an **assertion gap** (the structure is present but
+no kind expresses the predicate over it), or **out of band** (not a decidable function of the
+local bytes). Tagging each gap this way splits the doc's undifferentiated "needs a new kind" (K)
+verdicts into "needs a parser or scanner" versus "needs new constraint logic", which are
+different engineering.
+
+### 2.2 The scope boundary is a computability statement
+
+Every alint rule is a decidable, polynomial predicate over the given finite structure. A candidate
+is OUT on exactly one of two grounds:
+
+1. **Undecidable or semantics-dependent in general.** "Is this the same code?" is program
+   equivalence, undecidable (a corollary of Rice's theorem, 1953); full type inference, dataflow,
+   and taint need a language model alint deliberately lacks.
+2. **Not a function of the local bytes.** Branch protection, CI outcomes, advisory status,
+   registry existence, true lockfile resolution, and signature crypto depend on external or global
+   state that is not present in the committed tree.
+
+The IN band is therefore: predicates that are a decidable, deterministic function of the committed
+bytes alone, **including the local `.git` object store**. That last clause is exactly why local
+git-tag and commit-history checks are IN while the GitHub API is OUT, and why a date rule must take
+a pinned `--as-of` clock rather than reading the wall clock (a wall-clock read is not a function of
+the local bytes, violating clause 2 and the determinism invariant). This grounds the intuitive
+"between file-exists and resolve-the-dep-graph" band of section 1 as a theorem.
+
+### 2.3 What the assertion layer expresses, and the one primitive that escapes it
+
+Classifying the current kinds by finite-model-theory level:
+
+- **First-order (FO):** existence, naming, and hygiene (Gaifman-local, radius at most one), the
+  per-file structured queries, and the one-level cross-file kinds (`pair`, `cross_file`,
+  `registry_paths_resolve`, `import_gate`) that quantify over files and tuples with no recursion.
+- **The one genuine jump to MSO / transitive closure:** `file_graph`'s `acyclic` mode.
+  Reachability, connectivity, and acyclicity are provably **not** first-order-definable
+  (Ehrenfeucht-Fraisse games; Gaifman locality 1982; Aho-Ullman 1979), so acyclicity cannot be
+  desugared into the FO cross-file kinds. This is the theorem that earns `file_graph` its keep.
+  Honest correction: only `acyclic` is non-FO; `no_dangling` / `no_orphans` / `forbidden_edges` are
+  FO over the materialized edge relation, bundled with it for ergonomics, not expressiveness.
+- **Path-query expressiveness:** the navigational core of XPath is characterized as FO2 over trees
+  (Marx and de Rijke 2005); JSONPath (RFC 9535) has no such published theorem, so FO2 is a grounded
+  analogy, not a proof, for alint's `*_path_*` family. The family asserts a
+  universal-over-a-selected-set predicate, which structurally cannot compare cardinalities across
+  nodes, assert key-set equality, or see duplicate keys.
+- **Counting:** the engine does *fixed* aggregations (`max_files_per_directory`, and the size,
+  depth, line, and path-length caps), FO-with-counting in practice, but exposes no *general*
+  equality-of-counts over an extracted relation. (Parity is the classic witness that FO alone
+  cannot count.) That general fragment underlies several gaps below.
+
+### 2.4 The unifying lens: a repository is a database with integrity constraints
+
+Model the repository, plus the relations the recognition layer extracts from its structured files,
+as a relational database. Then most cross-file rules and the version/key-consistency gaps are,
+formally, **database integrity constraints** (Abiteboul, Hull, Vianu 1995):
+
+- `unique_by` = a **functional dependency (FD) / key** (no two files share the key value);
+  `no_case_conflicts` = a case-folded key.
+- `pair`, `registry_paths_resolve`, `markdown_paths_resolve` = **inclusion dependencies (IND)**,
+  i.e. referential integrity / foreign keys (Casanova, Fagin, Papadimitriou 1984);
+  `registry_paths_resolve` with `orphans` is a two-way IND.
+- `cross_file ... equals` / `identical` = **equality-generating dependencies (EGD)**; `set_equals`
+  = a two-way IND; `forbidden_edges` / `import_gate` = an **exclusion dependency**.
+- `file_graph acyclic` is the deliberate exception again: embedded dependencies are FO sentences,
+  acyclicity is not, so it is not a dependency and correctly stays bespoke. Two independent lenses
+  (FO-definability and dependency theory) agree on the same boundary.
+
+The **coverage gaps are the same dependency classes over *dynamically-extracted* relations**
+(schema-on-read, rather than a pinned file pair): `dependency_version_consistency` is an FD
+`name -> version`; `key_parity` is a two-way IND on key sets; `reuse_license_completeness` is a
+two-way IND on SPDX ids. This motivates a single, theory-grounded **`constraint` kind**: an
+`extract` spec (pull tuples from a glob via JSONPath / `lines` / `regex`, tagged by source)
+composed with a dependency to assert (`key`, `references`, `set_equals`, `equal`, `disjoint`,
+optionally a `count` / `distinct` operator for the counting fragment). It would subsume `unique_by`,
+`cross_file`, and `registry_paths_resolve` and unlock `key_parity`,
+`dependency_version_consistency`, and the toolchain-pin family as *configurations* rather than
+bespoke kinds. Guardrail: **check only, never infer**, because FD+IND implication is undecidable
+(Chandra-Vardi 1985); alint evaluates a declared constraint against an instance (polynomial), and
+must never entail or minimize a constraint set.
+
+Two caveats keep this a design vocabulary rather than an overclaim: the extracted "relations" are
+computed by heuristic extractors (the regex import-edge caveat generalizes, so a satisfied
+constraint is only as sound as its extractor), and classical dependency theory assumes a fixed
+schema whereas alint's relations are discovered per run.
+
+### 2.5 Covered versus missing, by class
+
+- **Covered (the realized fragment):** FO over the file tree and statically-declared extraction
+  points; regular content recognition (exactly); context-free format recognition into a queryable
+  tree; the FD / IND / EGD / exclusion dependency classes with *fixed* relations; exactly one
+  MSO/TC property (acyclicity); and fixed bounded counting.
+- **Missing (the gap list is the boundary of that fragment):**
+
+| Missing class | Gaps | Kind of work |
+|---|---|---|
+| Recognition upgrade (build a structure the parser drops or never builds) | B1 duplicate keys, B2 well-formed, E1/E3/E6 markdown grammar, G1 tabular, H2 Dockerfile, F2 SPDX-expression | a parser or scanner |
+| Dependency over a *dynamically-extracted* relation | C3 version consistency, D1 key parity, D2 placeholder parity, F3 REUSE completeness | new constraint logic (the `constraint` kind of 2.4) |
+| General FO+COUNT (equality-of-counts / threshold over an extracted relation) | C3 count-distinct, key-count parity, B4 mutually-exclusive (= 1), dead-pattern (= 0) | a `count` operator on the `constraint` kind |
+| A small offline decision procedure | C4 semver-range algebra | a self-contained solver |
+| Out of band (the computability boundary of 2.2) | Scorecard-via-API, dependency-graph resolution, code semantics, SAST, secrets, crypto | deliberately excluded |
+
+## 3. What alint already covers
 
 To keep the gap list honest, these are covered today and are **not** gaps (they are cited so
 a reader does not re-propose them):
@@ -78,9 +205,10 @@ single-source candidates): `json_key_sort_order`, `column_alignment`, `not_execu
 `directory_hash`, `case_collision_safe`, `dir_name_matches_field`, `balanced_delimiters`, and
 the backlogged `duplicate_blocks` (copy-paste) and WASM plugins. The `detect: linguist` /
 `detect: askalono` facts were planned for an early cut and **never shipped** (verified: no
-`licensee` or `askalono` reference exists in `crates/`; only a ROADMAP mention remains).
+`licensee` or `askalono` reference exists in `crates/`; the only mentions are in ROADMAP and
+this analysis).
 
-## 3. The gap families
+## 4. The gap families
 
 Ten families, ranked. Within each, the table columns are: gap (working kind name), what it
 detects, scope-fit, expressibility, and default auto-fix tier. The standouts carry a
@@ -126,9 +254,10 @@ itself, which a path query structurally cannot see.
 | `*_path_casing` / `*_path_mutually_exclusive` | a queried value obeys a naming case; exactly one of two paths is present | IN | K (small) | Unsafe / Never |
 
 **`no_duplicate_keys` is a gap alint's own reference documents.** `docs/rules.md` states that
-a "detect duplicate key" rule is only expressible for XML and INI (which array-collect),
-because for JSON / YAML / dotenv / properties the `Format::parse -> serde_json::Value` pipeline
-keeps the last duplicate and discards the earlier ones before any rule runs. A duplicate key
+a "detect duplicate key" rule is only expressible for XML and INI (which array-collect the
+duplicates) and TOML and HCL (which reject the file as a parse error), because for JSON / YAML /
+dotenv / properties the `Format::parse -> serde_json::Value` pipeline silently keeps the last
+duplicate and discards the earlier ones before any rule runs. A duplicate key
 from a bad merge in a large Kubernetes, Ansible, or CI file silently changes behavior;
 yamllint's `key-duplicates` is on by default. Closing this needs a duplicate-aware or spanned
 parse, which is the same substrate the auto-fix structured bridge builds.
@@ -270,7 +399,7 @@ must take a fixed "now" (a `--as-of` input or a per-run pinned clock) rather tha
 wall clock. A Keep-a-Changelog structural ruleset and a `no_committed_binaries` discovery kind
 (magic-byte scan plus allowlist, fix = git-untrack) round out the (P) composition wins.
 
-## 4. Borderline: route to `command` or a WASM plugin
+## 5. Borderline: route to `command` or a WASM plugin
 
 These are real but better served by wrapping an existing tool via the `command` rule (or a
 future WASM plugin) than by growing the core binary:
@@ -287,7 +416,7 @@ future WASM plugin) than by growing the core binary:
   secret-scanning, a stated non-goal; the defensible slice (`git_no_denied_paths`,
   `git_blame_age`) is already covered.
 
-## 5. Clearly out of scope
+## 6. Clearly out of scope
 
 Named honestly, these belong to the tools the README already points at:
 
@@ -305,7 +434,7 @@ Named honestly, these belong to the tools the README already points at:
 - **Fuzzy license classification, signature/attestation crypto, and numeric quality scores.**
 - **Whole-file reformatting:** alint is not a formatter.
 
-## 6. Auto-fix tie-in
+## 7. Auto-fix tie-in
 
 Most high-value gaps map onto the [`auto-fix.md`](auto-fix.md) four-state model, and the
 highest-value new fixes ride substrates that document already plans:
@@ -325,7 +454,7 @@ The flagship structured-value write-back engine (auto-fix Phase 2) is the enable
 highest-value new fixes here: version SSOT, structured key sort, and any `*_path_equals`-backed
 gap all ride the same path-to-span bridge.
 
-## 7. Prioritized shortlist
+## 8. Prioritized shortlist
 
 1. `editorconfig_conforms` (A1): config-as-SSOT; every primitive exists, zero conformance
    awareness; Safe auto-fix. (K)
@@ -353,7 +482,7 @@ Second tier: `well_formed`, `frontmatter_schema`, `spdx_identifier_valid`,
 `max_path_length`, `lfs_pointer_valid`, the community-schema pack, `field_date_valid`,
 `structured_key_sort` (already on the radar).
 
-## 8. Strategic read and reusable substrates
+## 9. Strategic read and reusable substrates
 
 Two clusters dominate the high-value gaps, and both are almost entirely un-owned by any single
 language-agnostic tool:
@@ -377,6 +506,11 @@ Four reusable substrates unlock disproportionate coverage, so they should be seq
   `no_duplicate_keys` (B1).
 - **A markdown link / heading / front-matter scanner** (one light line-scanner with a
   fenced-code toggle) unlocks all of Family E.
+- **A single `constraint` kind** (extract relations from a glob, then assert a dependency;
+  section 2.4) generalizes `unique_by` / `cross_file` / `registry_paths_resolve` and unlocks the
+  whole cross-file consistency vein (`dependency_version_consistency`, `key_parity`,
+  `placeholder_parity`) as configurations rather than bespoke kinds, subject to the
+  check-only-never-infer guardrail.
 
 Sequencing suggestion: ship `editorconfig_conforms` and `no_duplicate_keys` first (highest
 leverage, each a self-contained kind on an existing evaluator), package the version-SSOT and
@@ -384,7 +518,7 @@ toolchain-pins bundled rulesets (mostly (P), immediate value), then build the ma
 (Family E) and the SPDX table (Family F) as shared substrates, with `semver_range` and the
 cross-file consistency kinds following as engine capabilities.
 
-## 9. References
+## 10. References
 
 Repolinter rules; OpenSSF Scorecard checks, Allstar, Best Practices, OSPS Baseline;
 CNCF / Apache maturity models; GitHub community health files; syncpack, manypkg, knip, Nx and
@@ -395,3 +529,14 @@ eslint-plugin-i18n-json, i18n-tasks, compare-locales, gettext `msgfmt`; csvlint 
 Frictionless Table Schema; Keep a Changelog; SemVer 2.0.0; codeowners-validator;
 remark-lint-frontmatter-schema; the pre-commit-hooks battery. Full URLs are collected in the
 research artifact this doc is distilled from.
+
+The theoretical foundations behind section 2: Libkin, *Elements of Finite Model Theory*, 2004
+(FO/MSO locality, Ehrenfeucht-Fraisse games, FO+COUNT); Gaifman 1982 (locality); Aho and Ullman
+1979 (transitive closure is not first-order); Immerman, *Descriptive Complexity* (FO+TC captures
+NL); Thatcher-Wright and Doner (MSO = regular tree languages), Courcelle 1990; Marx and de Rijke
+2005 (the navigational core of XPath is FO2 over trees); IETF RFC 9535 (JSONPath); Chomsky 1956
+(the hierarchy); Schleimer, Wilkerson, Aiken 2003 (winnowing) and Karp and Rabin 1987
+(rolling-hash fingerprinting); Rice 1953 (program equivalence is undecidable); Abiteboul, Hull,
+Vianu, *Foundations of Databases*, 1995 (FD / IND / EGD / TGD, the chase); Casanova, Fagin,
+Papadimitriou 1984 (inclusion dependencies); Chandra and Vardi 1985 (FD+IND implication is
+undecidable).

--- a/docs/design/rule-coverage-gaps.md
+++ b/docs/design/rule-coverage-gaps.md
@@ -147,10 +147,13 @@ The **coverage gaps are the same dependency classes over *dynamically-extracted*
 two-way IND on SPDX ids. This motivates a single, theory-grounded **`constraint` kind**: an
 `extract` spec (pull tuples from a glob via JSONPath / `lines` / `regex`, tagged by source)
 composed with a dependency to assert (`key`, `references`, `set_equals`, `equal`, `disjoint`,
-optionally a `count` / `distinct` operator for the counting fragment). It would subsume `unique_by`,
-`cross_file`, and `registry_paths_resolve` and unlock `key_parity`,
-`dependency_version_consistency`, and the toolchain-pin family as *configurations* rather than
-bespoke kinds. Guardrail: **check only, never infer**, because FD+IND implication is undecidable
+optionally a `count` / `distinct` operator for the counting fragment). It would subsume `cross_file`
+and `registry_paths_resolve` (both already extract-then-assert-a-dependency kinds built on the
+shared `crate::extract` module) and unlock `key_parity`, `dependency_version_consistency`, and the
+toolchain-pin family as *configurations* rather than bespoke kinds. It would **not** subsume
+`unique_by`, which keys on a path-*template* (`key: "{stem}"`) over file paths rather than on any
+content extraction, a form the `Extract` enum (`Structured` / `Lines` / `Regex` / `WholeFile`) does
+not have; folding it in would need a new path-template extractor. Guardrail: **check only, never infer**, because FD+IND implication is undecidable
 (Chandra-Vardi 1985); alint evaluates a declared constraint against an instance (polynomial), and
 must never entail or minimize a constraint set.
 
@@ -170,7 +173,7 @@ schema whereas alint's relations are discovered per run.
 | Missing class | Gaps | Kind of work |
 |---|---|---|
 | Recognition upgrade (build a structure the parser drops or never builds) | B1 duplicate keys, B2 well-formed, E1/E3/E6 markdown grammar, G1 tabular, H2 Dockerfile, F2 SPDX-expression | a parser or scanner |
-| Dependency over a *dynamically-extracted* relation | C3 version consistency, D1 key parity, D2 placeholder parity, F3 REUSE completeness | new constraint logic (the `constraint` kind of 2.4) |
+| Dependency over a *dynamically-extracted* relation | C3 version consistency, D1 key parity, D2 placeholder parity, F3 REUSE completeness | new constraint logic (the `constraint` kind of 2.4); the dependency shape is partly present already (`registry_paths_resolve` and `cross_file set_equals` are dynamic INDs), so the genuinely new pieces are key-*set* enumeration (D1, which JSONPath cannot express) and the extract-and-assert packaging |
 | General FO+COUNT (equality-of-counts / threshold over an extracted relation) | C3 count-distinct, key-count parity, B4 mutually-exclusive (= 1), dead-pattern (= 0) | a `count` operator on the `constraint` kind |
 | A small offline decision procedure | C4 semver-range algebra | a self-contained solver |
 | Out of band (the computability boundary of 2.2) | Scorecard-via-API, dependency-graph resolution, code semantics, SAST, secrets, crypto | deliberately excluded |
@@ -254,7 +257,7 @@ itself, which a path query structurally cannot see.
 | `no_duplicate_keys` | the same key twice in one mapping, for JSON / YAML / dotenv / properties (silent data loss) | IN | K | Suggestion |
 | `well_formed` (`parses_as`) | a file parses as valid X with no schema and no query; JSON strictness extras | IN | P+K | Never |
 | `structured_key_sort` | keys within a parsed object are in a canonical order (distinct from `ordered_block`, which sorts lines) | IN | K | Safe |
-| `*_path_casing` / `*_path_mutually_exclusive` | a queried value obeys a naming case; exactly one of two paths is present | IN | K (small) | Unsafe / Never |
+| `*_path_casing` / `*_path_mutually_exclusive` | a queried value obeys a naming case; exactly one of two paths is present | IN | P+K (casing: `*_path_matches` with a case regex works today) / K (the XOR) | Unsafe / Never |
 
 **`no_duplicate_keys` is a gap alint's own reference documents.** `docs/rules.md` states that
 a "detect duplicate key" rule is only expressible for XML and INI (which array-collect the
@@ -276,7 +279,7 @@ so this whole vein is unmined.
 | Gap | Detects | Scope | Expr | Fix |
 |---|---|---|---|---|
 | version-SSOT ruleset | one version identical across package.json / Cargo.toml / pyproject / VERSION / `__version__` / Chart appVersion / OpenAPI info.version / the top CHANGELOG entry, plus the git tag | IN (files) / BORDERLINE (tag) | P + K | Safe/Unsafe |
-| toolchain-pins ruleset | one language/tool version across `.nvmrc` / `engines` / Dockerfile `FROM` / CI setup / `.tool-versions` (Node, Rust, Python, Ruby, JVM, .NET) | IN | P | Unsafe |
+| toolchain-pins ruleset | one language/tool version across `.nvmrc` / `engines` / Dockerfile `FROM` / CI setup / `.tool-versions` (Node, Rust, Python, Ruby, JVM, .NET) | IN | P (exact pins); range pins fall to C4 | Unsafe |
 | `dependency_version_consistency` | every instance of a dynamically-discovered dependency agrees across a glob of manifests | IN (assert) / BORDERLINE (pick highest) | K | Unsafe |
 | `semver_range` awareness | range intersection, satisfaction, and `^`/`~`/exact policy consistency | BORDERLINE | K | Unsafe / Never |
 | `dependabot_ecosystem_drift` | a manifest exists but no `updates[]` entry covers its ecosystem | IN | P+K | Suggestion |
@@ -446,7 +449,7 @@ highest-value new fixes ride substrates that document already plans:
 |---|---|---|
 | `editorconfig_conforms` | Safe | reuses the existing hygiene fixers, driven by the file's declared policy |
 | `gitattributes_valid` (eol-pin) | Safe | a presence-guarded `ReplaceRange` insert |
-| `structured_key_sort` | Safe | format-preserving reorder (auto-fix Phase 4 sort) |
+| `structured_key_sort` | Safe | format-preserving key reorder via the structured bridge (auto-fix Phase 2) |
 | version SSOT | Safe/Unsafe | structured `set_value` to the SSOT (auto-fix Phase 2 flagship) |
 | toolchain / dependency drift | Unsafe | set the drifted pin to canonical |
 | `no_duplicate_keys` | Suggestion | which duplicate to keep is ambiguous |
@@ -466,7 +469,8 @@ gap all ride the same path-to-span bridge.
    territory, no general linter does it. (K)
 4. version-SSOT ruleset + config-ingest (C1): huge proven demand; mostly expressible, needs
    packaging plus a tag kind. (P+K)
-5. toolchain-pins ruleset (C2): under-served, because Dependabot ignores pin files. (P)
+5. toolchain-pins ruleset (C2): under-served, because Dependabot ignores pin files. (P for exact
+   pins; range pins are C4 `semver_range`)
 6. `semver_range` awareness (C4): the one class alint structurally cannot do. (K)
 7. `markdown_links_resolve` (E1): `markdown_paths_resolve` does only backticks. (K)
 8. `dependency_version_consistency` (C3): the syncpack/manypkg headline. (K)
@@ -511,7 +515,8 @@ Four reusable substrates unlock disproportionate coverage, so they should be seq
 - **A markdown link / heading / front-matter scanner** (one light line-scanner with a
   fenced-code toggle) unlocks all of Family E.
 - **A single `constraint` kind** (extract relations from a glob, then assert a dependency;
-  section 2.4) generalizes `unique_by` / `cross_file` / `registry_paths_resolve` and unlocks the
+  section 2.4) generalizes `cross_file` and `registry_paths_resolve` (not `unique_by`, whose
+  path-template keying needs a new extractor; 2.4) and unlocks the
   whole cross-file consistency vein (`dependency_version_consistency`, `key_parity`,
   `placeholder_parity`) as configurations rather than bespoke kinds, subject to the
   check-only-never-infer guardrail.

--- a/docs/design/rule-coverage-gaps.md
+++ b/docs/design/rule-coverage-gaps.md
@@ -1,0 +1,397 @@
+# Rule coverage gaps: detection classes alint does not yet cover
+
+Status: Draft (research and analysis; a companion to the auto-fix arc).
+Decisions: none yet; individual gaps graduate to their own `docs/design/vX.Y/` design docs (and, where a gap is a new engine capability, an ADR) when scheduled.
+Demand evidence: cross-checked against Repolinter, OpenSSF Scorecard, syncpack / manypkg / knip, the version-bump tool family, markdownlint / yamllint / editorconfig-checker, REUSE / SPDX, and the 30-repo `examples/` corpus.
+
+> This is the detection-side companion to [`auto-fix.md`](auto-fix.md). That document asks
+> "of the violations alint can already find, which can it mechanically fix?" This one asks
+> the orthogonal question: "what classes of repository state should alint be able to find at
+> all, that it cannot today?" The two share substrates (the format-preserving structured
+> write-back engine unlocks the fixes for several gaps here), so they are designed together.
+
+## Contents
+
+- [1. The scope boundary](#1-the-scope-boundary)
+- [2. What alint already covers](#2-what-alint-already-covers)
+- [3. The gap families](#3-the-gap-families)
+- [4. Borderline: route to `command` or a WASM plugin](#4-borderline-route-to-command-or-a-wasm-plugin)
+- [5. Clearly out of scope](#5-clearly-out-of-scope)
+- [6. Auto-fix tie-in](#6-auto-fix-tie-in)
+- [7. Prioritized shortlist](#7-prioritized-shortlist)
+- [8. Strategic read and reusable substrates](#8-strategic-read-and-reusable-substrates)
+- [9. References](#9-references)
+
+## 1. The scope boundary
+
+alint's fresh white space is the band **between "a file exists" (a commodity every repo
+linter does) and "resolve the dependency graph" (which belongs to cargo-deny, knip, bazel,
+and the language toolchains)**. Everything proposed here sits in that band: it is decidable
+from the local files with no network, no language AST or type checker, no `node_modules`
+metadata, no Git host API, and no cryptography. The non-goals from the README still hold
+(alint is not a code/AST linter, not SAST, not a semantic IaC scanner, not a secret scanner),
+and section 5 draws that line explicitly and honestly.
+
+Three axes classify every candidate:
+
+- **Scope-fit.** IN-SCOPE (decidable from local files with alint's existing muscle, or a
+  light stateful line-scanner that is not a real AST); BORDERLINE (needs one small
+  self-contained new capability, for example a bundled SPDX id table, a semver-range algebra,
+  a duplicate-aware structured parser, or local git-tag access, all deterministic and
+  offline); OUT (needs a resolver, an AST, a registry/API, or crypto).
+- **Expressibility.** (P) expressible today with existing primitives, so it ships as a
+  bundled ruleset with no engine change; (K) needs a new rule kind or engine capability;
+  (P+K) partly expressible, but a dedicated kind is materially cleaner.
+- **Auto-fix applicability**, using the [`auto-fix.md`](auto-fix.md) four-state model: Safe,
+  Unsafe, Suggestion, Never.
+
+## 2. What alint already covers
+
+To keep the gap list honest, these are covered today and are **not** gaps (they are cited so
+a reader does not re-propose them):
+
+- **Community-health file presence** (README / LICENSE / CONTRIBUTING / CODE_OF_CONDUCT /
+  SECURITY / SUPPORT / CODEOWNERS / GOVERNANCE / CHANGELOG / issue and PR templates /
+  FUNDING) via `oss-baseline@v1` and the existence family. Repolinter's default set and
+  Scorecard's `Security-Policy` / `License` / `Dependency-Update-Tool` reduce to this.
+- **REUSE and Apache license headers** via `compliance/reuse@v1`, `compliance/apache-2@v1`,
+  `apache/governance@v1`.
+- **GitHub Actions SHA/digest pinning and workflow least-privilege `permissions:`** via
+  `ci/github-actions@v1`, so Scorecard's `Token-Permissions` and the Actions slice of
+  `Pinned-Dependencies` are covered by composition.
+- **The whole structural pre-commit-hooks battery** (trailing whitespace, final newline,
+  mixed line ending, BOM, merge-conflict, case conflict, illegal Windows names, large files,
+  submodules, shebang/executable pairing, symlinks) maps onto existing hygiene, unicode,
+  portable-metadata, and unix-metadata kinds.
+- **Config-file schema validation** via `json_schema_passes` for any of the 8 formats.
+- **The monorepo boundary / cycle / orphan / forbidden-edge cluster** (Nx, Turborepo,
+  sheriff, dependency-cruiser) via `import_gate` + `file_graph`, with the documented
+  regex-import caveat (dynamic and aliased edges are missed).
+- **Duplicate-listing checks** via `unique_by`; **co-change gates** via
+  `pair_changed_together` / `changeset_requires_path`; **value/version equality across known
+  files** via `cross_file_value_equals` with `normalize:` bands (the dogfood
+  `install-snippets-match-workspace-version` rule proves it); **naming parity** via
+  `filename_case` / `filename_regex`.
+
+Already on alint's own radar (the `examples/README` emerging-gaps list and ROADMAP
+single-source candidates): `json_key_sort_order`, `column_alignment`, `not_executable`,
+`directory_hash`, `case_collision_safe`, `dir_name_matches_field`, `balanced_delimiters`, and
+the backlogged `duplicate_blocks` (copy-paste) and WASM plugins. The `detect: linguist` /
+`detect: askalono` facts were planned for an early cut and **never shipped** (verified: no
+`licensee` or `askalono` reference exists in `crates/`; only a ROADMAP mention remains).
+
+## 3. The gap families
+
+Ten families, ranked. Within each, the table columns are: gap (working kind name), what it
+detects, scope-fit, expressibility, and default auto-fix tier. The standouts carry a
+paragraph.
+
+### Family A: config-as-SSOT / meta-conformance (highest leverage)
+
+alint's differentiated move is "read the manifest that owns the truth" (`scope_filter` reads
+Cargo/pnpm workspaces). These gaps extend that from build manifests to the config files that
+already declare a repo's own hygiene policy, so the policy is asserted from its source of
+truth instead of re-declared (and drifting) inside `.alint.yml`.
+
+| Gap | Detects | Scope | Expr | Fix |
+|---|---|---|---|---|
+| `editorconfig_conforms` | every file obeys the repo's own `.editorconfig` (indent, EOL, charset, trim, final newline, max line length, spaces-after-tabs) | IN | K | Safe |
+| `gitattributes_valid` | `* text=auto` present; every committed `--check` artifact has an `eol=lf` line; valid `linguist-*` / `export-ignore`; contradictory attribute lines | IN | P+K | Suggestion (Safe for the eol-pin insert) |
+| `ignore_consistency` | `.dockerignore` covers the high-risk set and is a superset of `.gitignore`; dead ignore patterns matching zero paths; duplicate entries | IN | P+K | Suggestion (Safe for dedup) |
+
+**`editorconfig_conforms` is the single highest-leverage idea in the survey.** alint already
+has every underlying hygiene primitive (`indent_style`, `line_endings`, `no_trailing_whitespace`,
+`final_newline`, `line_max_width`, `no_bom`), and it already parses `.editorconfig` as an INI
+document (so its values are queryable via `ini_path_*` today). What is missing is a rule that
+treats `.editorconfig` as the **policy source** and dispatches the existing hygiene evaluators
+per glob section, so a user declares the thresholds once (in the file every editor already
+reads) rather than duplicating them in `.alint.yml` where they drift. editorconfig-checker is
+a top-tier pre-commit hook, so the demand is proven; the fix reuses the existing hygiene
+fixers (Safe), with tab/space conversion staying Unsafe per the auto-fix doc.
+
+`gitattributes_valid` targets a genuinely un-owned niche: no widely adopted `.gitattributes`
+linter exists, and the "generated `--check` artifact needs an `eol=lf` pin or Windows CI
+reports it stale" failure is one alint hit in its own history.
+
+### Family B: structured-data integrity (beyond querying a value)
+
+The structured-query family reads values at paths. These check the **shape** of the document
+itself, which a path query structurally cannot see.
+
+| Gap | Detects | Scope | Expr | Fix |
+|---|---|---|---|---|
+| `no_duplicate_keys` | the same key twice in one mapping, for JSON / YAML / dotenv / properties (silent data loss) | IN | K | Suggestion |
+| `well_formed` (`parses_as`) | a file parses as valid X with no schema and no query; JSON strictness extras | IN | P+K | Never |
+| `structured_key_sort` | keys within a parsed object are in a canonical order (distinct from `ordered_block`, which sorts lines) | IN | K | Safe |
+| `*_path_casing` / `*_path_mutually_exclusive` | a queried value obeys a naming case; exactly one of two paths is present | IN | K (small) | Unsafe / Never |
+
+**`no_duplicate_keys` is a gap alint's own reference documents.** `docs/rules.md` states that
+a "detect duplicate key" rule is only expressible for XML and INI (which array-collect),
+because for JSON / YAML / dotenv / properties the `Format::parse -> serde_json::Value` pipeline
+keeps the last duplicate and discards the earlier ones before any rule runs. A duplicate key
+from a bad merge in a large Kubernetes, Ansible, or CI file silently changes behavior;
+yamllint's `key-duplicates` is on by default. Closing this needs a duplicate-aware or spanned
+parse, which is the same substrate the auto-fix structured bridge builds.
+
+### Family C: cross-file value and version consistency (fresh white space)
+
+The band between "file exists" and "resolve the dep graph" where `cross_file`,
+`pair_changed_together`, and `json_schema_passes` are genuinely differentiated. alint has the
+muscle; the gaps are packaging plus a few capabilities. The prior PROPOSAL gap analysis mined
+ls-lint / Repolinter / Conftest but not syncpack / manypkg / knip / the version-bump family,
+so this whole vein is unmined.
+
+| Gap | Detects | Scope | Expr | Fix |
+|---|---|---|---|---|
+| version-SSOT ruleset | one version identical across package.json / Cargo.toml / pyproject / VERSION / `__version__` / Chart appVersion / OpenAPI info.version / the top CHANGELOG entry, plus the git tag | IN (files) / BORDERLINE (tag) | P + K | Safe/Unsafe |
+| toolchain-pins ruleset | one language/tool version across `.nvmrc` / `engines` / Dockerfile `FROM` / CI setup / `.tool-versions` (Node, Rust, Python, Ruby, JVM, .NET) | IN | P | Unsafe |
+| `dependency_version_consistency` | every instance of a dynamically-discovered dependency agrees across a glob of manifests | IN (assert) / BORDERLINE (pick highest) | K | Unsafe |
+| `semver_range` awareness | range intersection, satisfaction, and `^`/`~`/exact policy consistency | BORDERLINE | K | Unsafe / Never |
+| `dependabot_ecosystem_drift` | a manifest exists but no `updates[]` entry covers its ecosystem | IN | P+K | Suggestion |
+| `git_tag_matches` / `git_tag_valid` | release tag equals the manifest version; valid SemVer; annotated; signed; monotonic | BORDERLINE (local git-tag access) | K | Never |
+
+**Version SSOT has enormous, proven demand.** Every release tool ships a machine-readable
+manifest of "this version lives in files X, Y, Z" (bump-my-version, commitizen
+`--check-consistency`, cargo-release `shared-version`, release-please `extra-files`, knope,
+version-sync), and **none is language-agnostic**. The file-to-file part is expressible with
+`cross_file_value_equals` today; the gaps are a bundled `versioning@v1` ruleset, an ergonomic
+way to ingest an existing bump-tool config as the rule source, and a git-tag kind for the tag
+half. The fix is the auto-fix Phase 2 flagship (`set_value` to the SSOT).
+
+**`semver_range` is the one class alint structurally cannot do today.** `normalize:` compares
+version-band **equality**; range **intersection** and **satisfaction** (syncpack "Same Range",
+manypkg `INTERNAL_MISMATCH`) need a small self-contained semver algebra. Deterministic and
+offline, so BORDERLINE rather than OUT.
+
+### Family D: cross-file key and placeholder parity
+
+Family C compares values at known paths; Family D compares the **set of keys or tokens**
+across files with dynamic membership, a shape no surveyed single-file linter does natively and
+squarely alint's cross-file territory.
+
+| Gap | Detects | Scope | Expr | Fix |
+|---|---|---|---|---|
+| `key_parity` | every locale file (or `.env` vs `.env.example`) declares the same key set as a reference | IN | K | Suggestion (Safe for sort) |
+| `placeholder_parity` | interpolation tokens (`%s`, `{name}`, ICU plural, `{{var}}`) match the source string per key | IN | K | Never |
+
+**`key_parity` is a differentiator.** Missing-translation and drifted-`.env.example` are
+common, ship-blocking bugs; eslint-plugin-i18n-json, i18n-tasks, and compare-locales each do
+it for their ecosystem, and no general linter does it natively. `cross_file` set relations
+compare extracted value lists, not the key sets of a whole object with dynamic membership, so
+this is a clean new kind (reference file plus a glob of peers).
+
+### Family E: docs, accessibility, and i18n structural
+
+A markdown and docs-hygiene family. `markdown_paths_resolve` today handles only backticked
+paths with a required prefix list; it does not parse markdown link / image / anchor grammar,
+alt text, or heading structure. All of these are a light line-scanner (a fenced-code toggle
+plus front-matter skip), never a real AST.
+
+| Gap | Detects | Scope | Expr | Fix |
+|---|---|---|---|---|
+| `markdown_links_resolve` | relative `[text](./path)` and `![alt](./img)` targets that miss on disk; `#anchor` links matching no heading slug; undefined reference labels | IN (relative/anchor); external URLs OUT | K | Suggestion |
+| `markdown_images_have_alt` | an image with no alt text (WCAG / MD045) | IN | P+K | Suggestion |
+| `markdown_required_headings` | a document's heading sequence matches a required ordered template with wildcards (MD043) | IN | K | Suggestion |
+| `markdown_reference_integrity` | reference labels defined and used; no duplicate/unused definitions (MD052/MD053) | IN | K | Suggestion |
+| `markdown_no_duplicate_headings` | colliding heading slugs that break deep links (MD024) | IN | K | Never/Suggestion |
+| `frontmatter_schema` / `frontmatter_path_*` | a `---`-fenced front-matter block exists and has required keys / passes a schema | IN | K | Suggestion |
+
+`markdown_required_headings` is the most alint-native rule of the set: a structural manifest
+over an extracted heading list ("every ADR has `## Status` / `## Context` / `## Decision`"),
+which alint's own `docs/adr@v1` approximates crudely today with `file_content_matches`.
+`frontmatter_schema` has direct dogfood demand: alint.org is an Astro site whose content
+collections fail the build on missing front-matter, and the structured-query family cannot
+reach into a `---`-fenced block embedded in a `.md` file. A `docs/markdown@v1` bundled ruleset
+also covers the (P) single-line markdownlint rules (first-line heading, single H1, bare URLs,
+proper-name casing) with existing primitives; list-nesting rules (MD005/007/029/030/032) need
+an AST and stay OUT.
+
+### Family F: license, SPDX, and provenance (beyond the `compliance/*` bundles)
+
+| Gap | Detects | Scope | Expr | Fix |
+|---|---|---|---|---|
+| `license_detectable` | LICENSE has a conventional name and content matching a known license signature phrase (heuristic, not a legal classifier) | IN (heuristic); OUT for fuzzy best-match | K | Never |
+| `spdx_identifier_valid` | an `SPDX-License-Identifier` value is a real, non-deprecated id; an SPDX expression parses | BORDERLINE | K | Suggestion |
+| `reuse_license_completeness` | every used SPDX id has a `LICENSES/<id>.txt`, and none is unreferenced | IN | P+K | Suggestion |
+| `manifest_license_valid` | a manifest `license` field is a valid SPDX value (not a typo or bare `UNLICENSED`) | IN (presence) / BORDERLINE (validity) | P / K | Never |
+
+A single bundled, regenerable **SPDX id table** (roughly 600 ids plus exceptions and
+deprecated flags) plus a small self-contained SPDX-expression parser turns this whole
+BORDERLINE tier green with no network. `license_detectable` revives the deferred `detect:`
+fact as an offline heuristic (conventional name plus a bundled corpus of signature phrases),
+staying clear of licensee/askalono's statistical best-match, which is OUT. An SBOM-presence
+ruleset (`bom.json` / `*.cdx.json` exists and declares its format) is pure composition.
+
+### Family G: data-file integrity
+
+| Gap | Detects | Scope | Expr | Fix |
+|---|---|---|---|---|
+| `delimited_columns` | CSV/TSV rows all match the header column count; no duplicate/empty column names; no stray quotes | IN (structure); Table-Schema types BORDERLINE | K | Never/Suggestion |
+
+Data, ML, and analytics repos commit CSV fixtures where a ragged row is a silent downstream
+break, and no general repo linter checks tabular integrity. The structured-query family has no
+tabular reader, so this is a new kind.
+
+### Family H: container and CI structural (beyond `ci/github-actions@v1`)
+
+| Gap | Detects | Scope | Expr | Fix |
+|---|---|---|---|---|
+| `pinned_references` | one cross-system unpinned-ref rule: Actions `@tag`, CircleCI orbs/images, GitLab/Cloud-Build `image:`, pre-commit `rev`, Dockerfile `FROM tag` (want `@sha256:`), `ADD http(s)://` | IN (detect); fix network-gated | P+K | Suggestion / class 7 |
+| `dockerfile_structural` | hadolint's non-shell subset: base image tagged and digest-pinned, `COPY` not `ADD`, unique `FROM` aliases, JSON `CMD`/`ENTRYPOINT`, last `USER` not root, absolute `WORKDIR` | IN (structural); RUN-shell rules OUT | P (most) / K (cross-instruction state) | Unsafe / Suggestion |
+
+`pinned_references` generalizes the pinning discipline alint already ships for GitHub Actions
+to Dockerfile digests and pre-commit `rev:` (both clean gaps; hadolint has no base-image
+**digest**-pin rule), motivated by the March 2025 `tj-actions/changed-files` supply-chain
+incident. The tag-to-SHA fix is network-gated (auto-fix class 7).
+
+### Family I: portability (extend the portable-metadata family)
+
+| Gap | Detects | Scope | Expr | Fix |
+|---|---|---|---|---|
+| `max_path_length` | any tracked path longer than a limit (default 260, Windows MAX_PATH) | IN | K (small) | Never |
+| `lfs_pointer_valid` | a file tracked as LFS is a valid pointer, not a raw binary (or the inverse) | IN | P+K | Never |
+| `file_encoding` | a file is valid UTF-8 or a declared charset; flag UTF-16 / Latin-1 where unwanted | IN | P+K | Unsafe (transcode) |
+
+These sit alongside `no_illegal_windows_names` / `no_case_conflicts`, plus the already-tracked
+`case_collision_safe`, `not_executable`, and `destroyed_symlinks` emerging-gaps.
+
+### Family J: governance validity (beyond existence)
+
+| Gap | Detects | Scope | Expr | Fix |
+|---|---|---|---|---|
+| `codeowners_valid` | CODEOWNERS syntax, owner format, duplicate patterns, dead patterns, unowned files, shadowing order | IN (except owner existence, which is OUT) | P+K | Suggestion |
+| `governance/schemas@v1` | CITATION.cff / FUNDING.yml / dependabot / issue-forms / SECURITY-INSIGHTS validate against bundled schemas | IN | P | Never/Suggestion |
+| `field_date_valid` | `security.txt` `Expires:` is a valid future date; CHANGELOG dates are valid ISO | IN | K (small) | Never |
+
+`codeowners_valid` matters because GitHub silently skips invalid CODEOWNERS lines; alint today
+only checks the file exists and is non-empty. `field_date_valid` carries a determinism caveat:
+a "days since" verdict is time-dependent, which conflicts with constitution invariant 1, so it
+must take a fixed "now" (a `--as-of` input or a per-run pinned clock) rather than reading the
+wall clock. A Keep-a-Changelog structural ruleset and a `no_committed_binaries` discovery kind
+(magic-byte scan plus allowlist, fix = git-untrack) round out the (P) composition wins.
+
+## 4. Borderline: route to `command` or a WASM plugin
+
+These are real but better served by wrapping an existing tool via the `command` rule (or a
+future WASM plugin) than by growing the core binary:
+
+- **Dangerous-workflow taint** (Scorecard, zizmor, octoscan). The shallow regex patterns
+  (`pull_request_target` plus untrusted checkout; `${{ github.event.* }}` interpolated into
+  `run:`) are a reasonable bundled-content ruleset; the dataflow/taint core is CI-SAST and
+  belongs to actionlint/zizmor via `command`.
+- **codespell / common-misspellings** (a curated typo dictionary, not full spell-check): a
+  large data dependency; wrap codespell.
+- **Lockfile semantic in-sync-with-manifest**: only the resolver knows for real; route to
+  `command` (`npm ci`, `cargo update --locked`, `pnpm --frozen-lockfile`).
+- **Deep commit-history content grep** (Repolinter `git-grep-commits`): leans into
+  secret-scanning, a stated non-goal; the defensible slice (`git_no_denied_paths`,
+  `git_blame_age`) is already covered.
+
+## 5. Clearly out of scope
+
+Named honestly, these belong to the tools the README already points at:
+
+- **Scorecard checks needing a Git host API or release metadata:** Branch-Protection,
+  Webhooks, Code-Review, Contributors, Maintained, CI-Tests, Signed-Releases, Packaging,
+  CII-Best-Practices, Vulnerabilities (OSV), Fuzzing, SAST app-runs. (Scorecard's own
+  `--local` client returns "unsupported" for every one of these.)
+- **Dependency-graph resolution:** knip symbol usage, dependency-cruiser reachability/license,
+  true lockfile sync, cargo-deny advisories/licenses, cargo-udeps/machete.
+- **Code semantics / AST:** ESLint / Clippy / ruff; markdown list-nesting; yamllint value-type
+  rules; hadolint RUN-shell rules; Python-AST pre-commit hooks.
+- **SAST / taint:** Semgrep, CodeQL, CI expression-injection dataflow.
+- **Secret scanning:** gitleaks, trufflehog.
+- **Semantic IaC:** Checkov, tfsec, KICS.
+- **Fuzzy license classification, signature/attestation crypto, and numeric quality scores.**
+- **Whole-file reformatting:** alint is not a formatter.
+
+## 6. Auto-fix tie-in
+
+Most high-value gaps map onto the [`auto-fix.md`](auto-fix.md) four-state model, and the
+highest-value new fixes ride substrates that document already plans:
+
+| Gap | Tier | Note |
+|---|---|---|
+| `editorconfig_conforms` | Safe | reuses the existing hygiene fixers, driven by the file's declared policy |
+| `gitattributes_valid` (eol-pin) | Safe | a presence-guarded `ReplaceRange` insert |
+| `structured_key_sort` | Safe | format-preserving reorder (auto-fix Phase 4 sort) |
+| version SSOT | Safe/Unsafe | structured `set_value` to the SSOT (auto-fix Phase 2 flagship) |
+| toolchain / dependency drift | Unsafe | set the drifted pin to canonical |
+| `no_duplicate_keys` | Suggestion | which duplicate to keep is ambiguous |
+| `key_parity`, markdown gaps, `dependabot_ecosystem_drift` | Suggestion | insert stubs / stanzas; a human confirms |
+| `well_formed`, `git_tag`, `max_path_length`, `license_detectable` | Never | no unique correct output |
+
+The flagship structured-value write-back engine (auto-fix Phase 2) is the enabler for the
+highest-value new fixes here: version SSOT, structured key sort, and any `*_path_equals`-backed
+gap all ride the same path-to-span bridge.
+
+## 7. Prioritized shortlist
+
+1. `editorconfig_conforms` (A1): config-as-SSOT; every primitive exists, zero conformance
+   awareness; Safe auto-fix. (K)
+2. `no_duplicate_keys` (B1): a gap `docs/rules.md` documents; silent data loss; structural. (K)
+3. `key_parity` (D1): cross-file key-set equality for i18n and `.env.example`; alint's
+   territory, no general linter does it. (K)
+4. version-SSOT ruleset + config-ingest (C1): huge proven demand; mostly expressible, needs
+   packaging plus a tag kind. (P+K)
+5. toolchain-pins ruleset (C2): under-served, because Dependabot ignores pin files. (P)
+6. `semver_range` awareness (C4): the one class alint structurally cannot do. (K)
+7. `markdown_links_resolve` (E1): `markdown_paths_resolve` does only backticks. (K)
+8. `dependency_version_consistency` (C3): the syncpack/manypkg headline. (K)
+9. `license_detectable` (F1): the deferred `detect:` fact; Scorecard/Repolinter/GitHub gate on
+   it. (K)
+10. `gitattributes_valid` (A2): an un-owned niche; alint hit the bug itself. (P+K)
+11. `delimited_columns` (G1): data repos; no general linter covers tabular integrity. (K)
+12. `markdown_required_headings` (E3): the most alint-native doc rule. (K)
+13. `pinned_references` (H1): Dockerfile digest and pre-commit `rev` are clean gaps. (P+K)
+14. `markdown_images_have_alt` (E2): a fresh accessibility angle. (P+K)
+15. `dependabot_ecosystem_drift` (C5) and `codeowners_valid` (J1): governance validity beyond
+    existence. (P+K)
+
+Second tier: `well_formed`, `frontmatter_schema`, `spdx_identifier_valid`,
+`reuse_license_completeness`, `ignore_consistency`, `placeholder_parity`, `git_tag`,
+`max_path_length`, `lfs_pointer_valid`, the community-schema pack, `field_date_valid`,
+`structured_key_sort` (already on the radar).
+
+## 8. Strategic read and reusable substrates
+
+Two clusters dominate the high-value gaps, and both are almost entirely un-owned by any single
+language-agnostic tool:
+
+1. **Config-as-SSOT / meta-conformance (Family A):** read the config that already declares the
+   repo's policy (`.editorconfig`, `.gitattributes`, a bump-tool manifest) and assert it,
+   instead of re-declaring thresholds in `.alint.yml`. The same "manifest owns the truth" move
+   as `scope_filter`, applied to hygiene.
+2. **Cross-file value / key / version consistency (Families C and D):** the version-SSOT,
+   toolchain-pin, translation-parity, and dependency-consistency vein, which the prior
+   PROPOSAL gap analysis never mined (it covered ls-lint / Repolinter / Conftest, not
+   syncpack / manypkg / knip / the version-bump family).
+
+Four reusable substrates unlock disproportionate coverage, so they should be sequenced first:
+
+- **The format-preserving structured-value write-back engine** (auto-fix Phase 2) turns the
+  version-SSOT, structured-key-sort, and the whole `*_path_equals`-backed set of gaps fixable.
+- **A bundled SPDX id table plus a small expression parser** turns the entire BORDERLINE
+  license tier (F2, F3, F4) green with no network.
+- **A duplicate-aware / spanned structured parser** (shared with the auto-fix bridge) unlocks
+  `no_duplicate_keys` (B1).
+- **A markdown link / heading / front-matter scanner** (one light line-scanner with a
+  fenced-code toggle) unlocks all of Family E.
+
+Sequencing suggestion: ship `editorconfig_conforms` and `no_duplicate_keys` first (highest
+leverage, each a self-contained kind on an existing evaluator), package the version-SSOT and
+toolchain-pins bundled rulesets (mostly (P), immediate value), then build the markdown scanner
+(Family E) and the SPDX table (Family F) as shared substrates, with `semver_range` and the
+cross-file consistency kinds following as engine capabilities.
+
+## 9. References
+
+Repolinter rules; OpenSSF Scorecard checks, Allstar, Best Practices, OSPS Baseline;
+CNCF / Apache maturity models; GitHub community health files; syncpack, manypkg, knip, Nx and
+Turborepo boundaries, dependency-cruiser; the version-bump family (bump-my-version, commitizen,
+cargo-release, release-please, knope, version-sync); markdownlint, yamllint,
+editorconfig-checker, dotenv-linter, ls-lint, hadolint; REUSE and the SPDX license list;
+eslint-plugin-i18n-json, i18n-tasks, compare-locales, gettext `msgfmt`; csvlint and the
+Frictionless Table Schema; Keep a Changelog; SemVer 2.0.0; codeowners-validator;
+remark-lint-frontmatter-schema; the pre-commit-hooks battery. Full URLs are collected in the
+research artifact this doc is distilled from.


### PR DESCRIPTION
## What

Two canonical design docs for the next major piece of work (auto-fix expansion), plus the shared decision record. Docs only, no engine change.

- **`docs/design/auto-fix.md`**: research + phased proposal to expand auto-fix from 16/94 fixable rule kinds. Defines the universe of auto-fixable classes, a four-state applicability model (Safe/Unsafe/Suggestion/Never), a ranged edit primitive plus a batched conflict-resolving apply engine, a per-format JSONPath-to-byte-span write-back bridge, and a five-phase build.
- **`docs/design/rule-coverage-gaps.md`**: the detection-side companion. Ten ranked families of repository checks alint does not yet cover (config-as-SSOT meta-conformance, cross-file version/key consistency, structured-data integrity, docs/accessibility/i18n, license/SPDX, data and container/CI structural, portability, governance validity), each with a scope-fit verdict and an auto-fix tier, plus an honest out-of-scope list.
- **`docs/adr/0017-auto-fix-edit-model-and-applicability.md`**: records the ranged edit model plus the batched apply engine, the applicability model, and the fixer trust boundary.

## Process

Both docs were built from primary-source research (ESLint / Ruff / formatters / codemods / format-preserving structured editors for fixing; Repolinter / OpenSSF Scorecard / syncpack / manypkg / knip / markdownlint / REUSE for coverage), then put through an independent, adversarial audit covering both technical correctness (verified against the code and `cargo tree`) and design. Every audit finding is folded in: the rule-level `collect_edits` violation-to-edit binding, a total edit order, the fixpoint moved out of Phase 0, multi-file transactions, the structured bridge split into locate + serialize (Safe restricted to scalars), a fixer trust boundary distinct from the kind-level `SPAWNING_RULE_KINDS` gate, and the baseline / `--changed` / LSP / agent interaction surfaces. A revision note at the foot of `auto-fix.md` records the deltas from the first draft.

## Notes

- Passes the dogfood `alint check` (exit 0) and the bundled `docs/adr@v1` ruleset; em-dash / smart-quote / trailing-whitespace clean; every load-bearing dependency and feasibility claim was code-verified.
- `ROADMAP.md` / `roadmap.json` are intentionally untouched so the `gen-roadmap --check` gate stays green; wiring in the "Auto-fix expansion" cut is a deliberate follow-up.

https://claude.ai/code/session_01DY5e8zTE8XDCDsaPkJT8Ai
