### PR TITLE
ci: run the Kani proof against alint-core, not alint-rules

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -1,7 +1,7 @@
 # Kani bounded-proof job (Phase 5 / WS4, docs/design/formal-methods.md).
 #
 # Runs the `#[kani::proof]` harnesses (today: the path-confinement policy
-# proof in alint-rules). Kept OFF the PR path and on a weekly schedule +
+# proof in alint-core: crates/alint-core/src/pathsafe.rs). Kept OFF the PR path and on a weekly schedule +
 # manual dispatch, because model-checking time should never block a merge
 # — the proptest properties on the PR path are the always-on behaviour
 # spec; this is the deeper, slower guarantee.
@@ -28,4 +28,8 @@ jobs:
       - name: Run Kani proofs
         uses: model-checking/kani-github-action@2534b7aeb3c6b4b0a5ecc3981bb3e63d47b5b126 # v1
         with:
-          args: "-p alint-rules"
+          # Target alint-core (where the sole #[kani::proof] lives; alint-rules
+          # has none, so "-p alint-rules" verified ZERO harnesses and passed
+          # vacuously). Pin the harness by name so a future mis-target fails
+          # loudly instead of silently going green with nothing checked.
+          args: "-p alint-core --harness confine_steps_is_sound"


### PR DESCRIPTION
The weekly Kani job has been passing **vacuously**. `kani.yml` ran `cargo kani -p alint-rules`, but `alint-rules` has no `#[kani::proof]`; the sole proof (`confine_steps_is_sound`) lives in `crates/alint-core/src/pathsafe.rs`. So the job discovered **zero** harnesses and reported green without verifying anything - the path-confinement proof has never actually run in CI.

This targets `alint-core` and pins the harness by name (`--harness confine_steps_is_sound`), so a future mis-target fails loudly ("no harnesses matched") instead of silently going green with nothing checked. The header comment (which also said "alint-rules") is corrected.

Surfaced by the auto-fix implementation-plan audit (R-KANI, companion to #243). Kani is off the PR path (weekly + `workflow_dispatch`); verified by a dispatch run on this branch.

https://claude.ai/code/session_01DY5e8zTE8XDCDsaPkJT8Ai
