### PR TITLE
docs: schedule the auto-fix arc as v0.17

### DIFF
--- a/docs/design/ROADMAP.md
+++ b/docs/design/ROADMAP.md
@@ -1480,6 +1480,31 @@ denial-of-service. See
   depth pre-scan matching hcl-rs at each content boundary, an XML attribute-count
   cap, a 32 MiB structured-input cap, and graceful worker-pool fallback.
 
+## v0.17: Auto-fix
+<!-- roadmap-public: blurb="alint learns to fix what it flags through a tiered fix engine that applies safe fixes by default and gates unsafe and suggestion tiers behind explicit flags, rewriting file content in place, setting or removing structured values across JSON, YAML, TOML, and XML with formatting preserved, repairing file permissions and shebangs, and canonicalizing ordering and headers, with every applied edit verified against the rule that requested it and a bounded fixpoint that either converges or reports exactly what it left unresolved." -->
+
+The release that makes `alint` a fixer, not just a checker. `alint --fix`
+applies the Safe tier; the Unsafe and Suggestion tiers stay opt-in
+(`--unsafe-fixes`, `--diff`, `--fix-only`). Every edit is re-checked against
+the rule that requested it, and a bounded fixpoint either converges or reports
+exactly what it could not resolve. The whole phased arc lands together in one
+minor. See [`auto-fix.md`](auto-fix.md),
+[ADR-0017](../adr/0017-auto-fix-edit-model-and-applicability.md), and the
+[implementation plan](auto-fix-implementation-plan.md).
+
+- A tiered fix engine and the `FixEdit` primitives, with a verify-after-apply
+  contract and an iterate-to-fixpoint driver that stays a genuine no-op for
+  configs that request no fixes.
+- Located content replacement for `file_content_forbidden` and
+  `file_content_matches`, driven by the host rule's `pattern:`.
+- Format-preserving `set_value` / `remove_value` for the `*_path_equals` and
+  `*_path_absent` kinds across JSON, YAML, TOML, and XML, plus templated
+  `*_path_matches` replacement: 24 of the 25 structured-query kinds become
+  fixable.
+- Permission and VCS repair: `chmod`, executable-bit, and shebang fixers, plus
+  the first repo-scale cross-file fixers.
+- Ordering, canonicalization, and header insertion.
+
 ## v1.0: Stability
 <!-- roadmap-public: blurb="A committed DSL and plugin ABI, a frozen alint-core public API, and a versioned documentation site." -->
 

--- a/docs/design/auto-fix-implementation-plan.md
+++ b/docs/design/auto-fix-implementation-plan.md
@@ -568,20 +568,36 @@ Not numbered phases; each needs an explicit opt-in and its own design record.
 
 ## 12. Sequencing, milestones, and versioning
 
-Aligns with `auto-fix.md` section 9 (v0.17 "introduces the tiers and a deprecation warning"):
+**v0.17 ships the entire arc (Phases 0 through 4) as one release**, cut only once every phase's
+Definition of Done (section 13) is green. This supersedes the earlier "one phase per minor" mapping
+and matches `auto-fix.md` section 9: the tiers, the primitives, and every fixer through
+ordering/headers ship together, so v0.17 is `alint`'s first *fixing* release rather than a dormant
+no-op.
 
-- **v0.17 = Phase 0.** The tiers, the primitives, the `CollectedEdit`/verify machinery (dormant), the
-  flags, report/exit plumbing, the two-op guard, the coverage gate, and the R-KANI fix. Ships the
-  `file_remove` deprecation warning. No new user-facing fixer, so a genuine no-op release.
-- **Next minor = Phase 1.** `replace` + the active fixpoint + `--changed` confinement + the
-  content-fixer trust gate. The first behavior-changing minor.
-- **Phase 2 (prelude, then 2a-lib -> 2a-handrolled -> 2b -> 2c -> 2d -> 2e)**, each sub-phase its own
-  increment. `file_remove` flips to Unsafe about two minors after v0.17 (its own migration PR).
+The work is still built and reviewed **phase by phase** - each phase is one PR (or a small series
+with a forward `Next: Phase N` pointer) that lands its downstream-artifact updates in the same PR and
+merges toward a long-lived v0.17 integration line, never released on its own:
+
+- **Phase 0 (foundation).** The tiers, the primitives, the `CollectedEdit`/verify machinery, the
+  fixpoint driver (dormant: no op collects located edits yet), the flags, report/exit plumbing, the
+  two-op guard, the coverage gate, and the R-KANI proof-count fix. Ships the `file_remove`
+  deprecation warning. A genuine no-op (byte-identical) for existing configs.
+- **Phase 1.** `replace` + the active fixpoint + `--changed` confinement + the content-fixer trust
+  gate (W2 demotes existing remote-`extends:` content ops to Suggestion, R-RETRO). First Unsafe op.
+- **Phase 2** (prelude, then 2a-lib -> 2a-handrolled -> 2b -> 2c -> 2d -> 2e): the flagship
+  structured-value edits, each sub-phase its own PR.
 - **Phase 3, then Phase 4.**
-- **Deferred** items stay demand-gated.
+- **Deferred** items (section 10) stay demand-gated and out of v0.17.
 
-Each phase is one PR (or a small series with a forward `Next: Phase N` pointer), keeps `ROADMAP.md`
-untouched until scheduled, and lands its downstream-artifact updates in the same PR.
+**The one thing v0.17 does NOT do is flip the `file_remove` default.** Reclassifying `file_remove`
+from Safe to Unsafe changes an existing default (R-FILEREMOVE, DoD item 3), and the safety contract
+(`auto-fix.md` 5.6, 7) requires the deprecation warning to ship at least one full minor before the
+flip. So v0.17 ships the warning and **v0.18** flips the default in its own migration PR. This is the
+deliberate exception to "the whole arc is v0.17," and it exists so users get one release of warning
+before a default changes under them.
+
+`ROADMAP.md` / `roadmap.json` carry the public `## v0.17: Auto-fix` entry; this section is the
+source of truth for the internal phase order behind it.
 
 ## 13. Definition of done
 

--- a/docs/design/auto-fix.md
+++ b/docs/design/auto-fix.md
@@ -1042,9 +1042,12 @@ Resolved after review (folded into the sections above):
   Suggestions, fix only new ones (5.7).
 - **Network-gated fixes:** the core stays network-free; SHA-pinning is a separate, top-level-only,
   explicitly-opted-in fix or a future WASM plugin, never a bare `alint fix` (6, Deferred).
-- **Versioning:** the arc slots as **v0.17**; it introduces the tiers and a deprecation warning,
-  then flips `file_remove` to Unsafe about two minors later (a warned, pre-1.0 MINOR change) (5.6,
-  6).
+- **Versioning:** the whole arc ships as **v0.17**, released only once every phase (0 through 4) is
+  complete: the tiers, the primitives, and every fixer through ordering and headers land together, so
+  v0.17 is `alint`'s first fixing release rather than a dormant no-op. The one thing held back is the
+  `file_remove` default flip: v0.17 introduces its deprecation warning, and the Safe-to-Unsafe flip
+  lands one minor later in **v0.18** (a warned, pre-1.0 MINOR change with a full minor of overlap)
+  (5.6, 6).
 - **Fixes in finding output:** `check --format sarif` emits SARIF `fixes[]` for all tiers, and
   `agent` / `json --include-fixes` carry a `proposed_edit`; the edit is computed during `check`
   **only** when such a format is selected, so the default check path is unchanged (5.7).

--- a/roadmap.json
+++ b/roadmap.json
@@ -98,6 +98,12 @@
       "blurb": "XML becomes a first-class target across every format-aware rule, and dotenv, Java .properties, INI, and HCL join as new config formats with their own path-query rule families, alongside a new *_path_absent kind family and a multi-round audit that bounds every config parser against crafted-file denial-of-service."
     },
     {
+      "version": "0.17",
+      "title": "Auto-fix",
+      "kind": "release",
+      "blurb": "alint learns to fix what it flags through a tiered fix engine that applies safe fixes by default and gates unsafe and suggestion tiers behind explicit flags, rewriting file content in place, setting or removing structured values across JSON, YAML, TOML, and XML with formatting preserved, repairing file permissions and shebangs, and canonicalizing ordering and headers, with every applied edit verified against the rule that requested it and a bounded fixpoint that either converges or reports exactly what it left unresolved."
+    },
+    {
       "version": "1.0",
       "title": "Stability",
       "kind": "release",


### PR DESCRIPTION
## Summary

Ratify the release strategy for the auto-fix arc: **the entire arc (Phases 0 through 4) ships as v0.17**, cut only once every phase's Definition of Done is green, rather than one phase per minor. The work is still built and reviewed phase by phase, but nothing releases on its own.

## Changes

- **`ROADMAP.md`**: adds the public `## v0.17: Auto-fix` entry (with its `roadmap-public` marker) between v0.16 and v1.0; `roadmap.json` regenerated.
- **`auto-fix.md` section 9**: the whole arc ships as v0.17; the `file_remove` Safe->Unsafe default flip trails one minor into **v0.18**, so the deprecation warning keeps a full minor of overlap.
- **implementation plan section 12**: rewrites sequencing/versioning to "v0.17 = all phases," keeping the `file_remove` flip as the one deliberate v0.18 exception. Internally the work is still built phase by phase toward a v0.17 integration line.

## Verification

- `cargo run -p xtask -- gen-roadmap --check` -> up to date
- doc-links gate (`coverage_audit_doc_links`) -> green
- dogfood (`alint check`) -> no new violations

https://claude.ai/code/session_01DY5e8zTE8XDCDsaPkJT8Ai